### PR TITLE
sctk: Improvements for handling outputs

### DIFF
--- a/native/src/command/platform_specific/wayland/layer_surface.rs
+++ b/native/src/command/platform_specific/wayland/layer_surface.rs
@@ -3,7 +3,10 @@ use std::marker::PhantomData;
 use std::{collections::hash_map::DefaultHasher, fmt};
 
 use iced_futures::MaybeSend;
-use sctk::shell::layer::{Anchor, KeyboardInteractivity, Layer};
+use sctk::{
+    reexports::client::protocol::wl_output::WlOutput,
+    shell::layer::{Anchor, KeyboardInteractivity, Layer},
+};
 
 use crate::window;
 
@@ -15,12 +18,7 @@ pub enum IcedOutput {
     /// show on active output
     Active,
     /// show on a specific output
-    Output {
-        /// make
-        make: String,
-        /// model
-        model: String,
-    },
+    Output(WlOutput),
 }
 
 impl Default for IcedOutput {

--- a/sctk/src/application.rs
+++ b/sctk/src/application.rs
@@ -581,13 +581,10 @@ where
                     },
                     // TODO forward these events to an application which requests them?
                     SctkEvent::NewOutput { id, info } => {
-                        events.push(SctkEvent::NewOutput { id, info });
                     }
                     SctkEvent::UpdateOutput { id, info } => {
-                        events.push(SctkEvent::UpdateOutput { id, info });
                     }
                     SctkEvent::RemovedOutput(id) => {
-                        events.push(SctkEvent::RemovedOutput(id));
                     }
                     SctkEvent::Draw(_) => unimplemented!(), // probably should never be forwarded here...
                     SctkEvent::ScaleFactorChanged {


### PR DESCRIPTION
With this I'm able to spawn a fullscreen layer shell surface for each output.

For some reason my application doesn't seem to get output events until I move the mouse (with an initial layer surface that's 1x1 pixel). And if I destroy the initial surface in `Application::new`, it never does.

There should also be a way to run with no initial surface, but I guess it currently relies on an initial surface to initialize an EGL display/context.