### PR TITLE
features: Don't always build sctk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ palette = ["iced_core/palette"]
 # Enables querying system information
 system = ["iced_winit/system"]
 # Enables wayland shell
-wayland = ["iced_sctk", "iced_glow", "iced_native/sctk"]
+wayland = ["iced_sctk", "iced_glow"]
 winit = ["iced_winit"]
 
 [badges]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/iced-rs/iced"
 
 [features]
-default = ["wayland"]
+default = []
 wayland = ["sctk"]
 debug = []
 


### PR DESCRIPTION
This should be handled by `iced_sctk` (and already is, `iced_sctk` enables `iced_native/wayland`, which in turn enables the `sctk` dependency). Allows building libcosmic without an unconditional `sctk` dependency.