### PR TITLE
features: Explicit backend/renderer combinations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,16 +21,16 @@ svg = ["iced_wgpu?/svg", "iced_glow?/svg", "iced_swbuf?/svg"]
 canvas = ["iced_graphics/canvas"]
 # Enables the `QRCode` widget
 qr_code = ["iced_graphics/qr_code"]
-# Enables the `iced_wgpu` renderer
+# Enables the `iced_wgpu` renderer. Conflicts with `iced_glow` and `iced_swbuf`
 wgpu = ["iced_wgpu"]
-# Enables the `iced_swbuf` renderer
+# Enables the `iced_swbuf` renderer. Conflicts with `iced_wgpu` and `iced_glow`
 swbuf = ["iced_swbuf"]
+# Enables the `iced_glow` renderer. Conflicts with `iced_wgpu` and `iced_swbuf`
+glow = ["iced_glow"]
 # Enables using system fonts
 default_system_font = ["iced_wgpu?/default_system_font", "iced_glow?/default_system_font"]
-# Enables the `iced_glow` renderer. Overrides `iced_wgpu`
-glow = ["iced_glow", "iced_glutin"]
 # Enables a debug view in native platforms (press F12)
-debug = ["iced_winit/debug"]
+debug = ["iced_winit?/debug"]
 # Enables `tokio` as the `executor::Default` on native platforms
 tokio = ["iced_futures/tokio"]
 # Enables `async-std` as the `executor::Default` on native platforms
@@ -40,9 +40,14 @@ smol = ["iced_futures/smol"]
 # Enables advanced color conversion via `palette`
 palette = ["iced_core/palette"]
 # Enables querying system information
-system = ["iced_winit/system"]
-# Enables wayland shell
-wayland = ["iced_sctk", "iced_glow"]
+system = ["iced_winit?/system"]
+# Enables the glutin shell. Conflicts with `sctk` and `winit`.
+# Forces the `glow` renderer, further conflicting with `wgpu` and `swbuf`.
+glutin = ["iced_glutin", "iced_glow"]
+# Enables the wayland shell. Conflicts with `winit` and `glutin`.
+# Incompatible with the `swbuf` and `wgpu` renderer.
+wayland = ["iced_sctk"]
+# Enables the winit shell. Conflicts with `wayland` and `glutin`.
 winit = ["iced_winit"]
 
 [badges]
@@ -102,3 +107,6 @@ opt-level = 3
 overflow-checks = false
 strip = "debuginfo"
 
+[patch."https://github.com/iced-rs/winit.git".winit]
+git = "https://github.com/pop-os/winit.git"
+branch = "iced"

--- a/native/src/event.rs
+++ b/native/src/event.rs
@@ -35,6 +35,7 @@ pub enum Event {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PlatformSpecific {
     /// A Wayland specific event
+    #[cfg(feature = "wayland")]
     Wayland(wayland::Event),
     /// A MacOS specific event
     MacOS(MacOS),

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,3 +1,4 @@
 //! Access the clipboard.
-#[cfg(all(not(target_arch = "wasm32"), not(feature = "wayland")))] // TODO support in wayland
+#[cfg(any(feature = "winit"))]
+// TODO support in wayland
 pub use crate::runtime::clipboard::{read, write};

--- a/src/element.rs
+++ b/src/element.rs
@@ -1,5 +1,6 @@
 /// A generic widget.
 ///
 /// This is an alias of an `iced_native` element with a default `Renderer`.
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub type Element<'a, Message, Renderer = crate::Renderer> =
     crate::runtime::Element<'a, Message, Renderer>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,18 +22,18 @@ impl From<iced_sctk::Error> for Error {
         match error {
             iced_sctk::Error::ExecutorCreationFailed(error) => {
                 Error::ExecutorCreationFailed(error)
-            },
+            }
             iced_sctk::Error::WindowCreationFailed(error) => {
                 Error::WindowCreationFailed(error)
-            },
+            }
             iced_sctk::Error::GraphicsCreationFailed(error) => {
                 Error::GraphicsCreationFailed(error)
-            },
+            }
         }
     }
 }
 
-#[cfg(not(feature = "wayland"))]
+#[cfg(feature = "winit")]
 impl From<iced_winit::Error> for Error {
     fn from(error: iced_winit::Error) -> Error {
         match error {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,4 +1,5 @@
 //! Choose your preferred executor to power your application.
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub use crate::runtime::Executor;
 
 /// A default cross-platform executor.

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1,2 +1,3 @@
 //! Listen and react to keyboard events.
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub use crate::runtime::keyboard::{Event, KeyCode, Modifiers};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,35 +164,26 @@
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(all(
-    not(feature = "glow"),
-    any(feature = "wgpu", feature = "swbuf"),
-    not(feature = "wayland")
-))]
+#[cfg(feature = "winit")]
 pub mod application;
 
 mod element;
 mod error;
 mod result;
 
-#[cfg(all(
-    not(feature = "wayland")
-))]
+#[cfg(feature = "winit")]
 mod sandbox;
 
-#[cfg(all(
-    not(feature = "wayland")
-))]
+#[cfg(feature = "winit")]
 pub use application::Application;
 
 /// wayland application
 #[cfg(feature = "wayland")]
 pub mod wayland;
 #[cfg(feature = "wayland")]
-pub use wayland::Application;
-#[cfg(feature = "wayland")]
 pub use wayland::sandbox;
-
+#[cfg(feature = "wayland")]
+pub use wayland::Application;
 
 pub mod clipboard;
 pub mod executor;
@@ -216,45 +207,45 @@ pub mod multi_window;
 #[cfg(feature = "wayland")]
 use iced_sctk as runtime;
 
-#[cfg(all(
-    not(feature = "glow"),
-    any(feature = "wgpu", feature = "swbuf"),
-    not(feature = "wayland")
-))]
+#[cfg(feature = "winit")]
 use iced_winit as runtime;
 
-#[cfg(all(feature = "glow", not(feature = "wayland")))]
+#[cfg(feature = "glutin")]
 use iced_glutin as runtime;
 
-#[cfg(all(not(feature = "iced_glow"), feature = "wgpu"))]
+#[cfg(feature = "wgpu")]
 use iced_wgpu as renderer;
 
-#[cfg(any(feature = "glow", feature = "wayland"))]
+#[cfg(any(feature = "glow", feature = "glutin"))]
 use iced_glow as renderer;
 
-#[cfg(all(not(feature = "iced_glow"), feature = "swbuf"))]
+#[cfg(feature = "swbuf")]
 use iced_swbuf as renderer;
 
 pub use iced_native::theme;
-pub use runtime::event;
-pub use runtime::subscription;
 
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub use element::Element;
 pub use error::Error;
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub use event::Event;
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub use executor::Executor;
+#[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
 pub use renderer::Renderer;
 pub use result::Result;
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub use sandbox::Sandbox;
 pub use settings::Settings;
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub use subscription::Subscription;
 pub use theme::Theme;
 
-pub use runtime::alignment;
-pub use runtime::futures;
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub use runtime::{
-    color, Alignment, Background, Color, Command, ContentFit, Font, Length,
-    Padding, Point, Rectangle, Size, Vector, settings as sctk_settings
+    alignment, color, event, futures, settings as sctk_settings, subscription,
+    Alignment, Background, Color, Command, ContentFit, Font, Length, Padding,
+    Point, Rectangle, Size, Vector,
 };
 
 #[cfg(feature = "system")]

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,2 +1,3 @@
 //! Listen and react to mouse events.
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub use crate::runtime::mouse::{Button, Event, Interaction, ScrollDelta};

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -5,14 +5,24 @@
 /// This is an alias of an `iced_native` element with a default `Renderer`.
 ///
 /// [`Overlay`]: iced_native::Overlay
+#[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
 pub type Element<'a, Message, Renderer = crate::Renderer> =
     iced_native::overlay::Element<'a, Message, Renderer>;
+#[cfg(not(any(feature = "swbuf", feature = "glow", feature = "wgpu")))]
+pub use iced_native::overlay::Element;
 
 pub mod menu {
     //! Build and show dropdown menus.
     pub use iced_native::overlay::menu::{Appearance, State, StyleSheet};
 
     /// A widget that produces a message when clicked.
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type Menu<'a, Message, Renderer = crate::Renderer> =
         iced_native::overlay::Menu<'a, Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::overlay::Menu;
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,7 +17,6 @@ pub struct Settings<Flags> {
     #[cfg(not(feature = "wayland"))]
     pub window: window::Settings,
 
-
     /// the initial surface to be created
     #[cfg(feature = "wayland")]
     pub initial_surface: iced_sctk::settings::InitialSurface,
@@ -119,7 +118,7 @@ where
     }
 }
 
-#[cfg(not(any(target_arch = "wasm32", feature = "wayland")))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "winit"))]
 impl<Flags> From<Settings<Flags>> for iced_winit::Settings<Flags> {
     fn from(settings: Settings<Flags>) -> iced_winit::Settings<Flags> {
         iced_winit::Settings {

--- a/src/touch.rs
+++ b/src/touch.rs
@@ -1,2 +1,3 @@
 //! Listen and react to touch events.
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub use crate::runtime::touch::{Event, Finger};

--- a/src/wayland/mod.rs
+++ b/src/wayland/mod.rs
@@ -4,7 +4,9 @@ use crate::{Command, Element, Executor, Settings, Subscription};
 pub mod sandbox;
 pub use iced_native::application::{Appearance, StyleSheet};
 pub use iced_native::command::platform_specific::wayland as actions;
-pub use iced_sctk::{application::SurfaceIdWrapper, commands::*, command::*, settings::*};
+pub use iced_sctk::{
+    application::SurfaceIdWrapper, command::*, commands::*, settings::*,
+};
 
 /// A pure version of [`Application`].
 ///

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -4,20 +4,33 @@ pub use iced_native::widget::helpers::*;
 pub use iced_native::{column, row};
 
 /// A container that distributes its contents vertically.
+#[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
 pub type Column<'a, Message, Renderer = crate::Renderer> =
     iced_native::widget::Column<'a, Message, Renderer>;
+#[cfg(not(any(feature = "swbuf", feature = "glow", feature = "wgpu")))]
+pub use iced_native::widget::Column;
 
 /// A container that distributes its contents horizontally.
+#[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
 pub type Row<'a, Message, Renderer = crate::Renderer> =
     iced_native::widget::Row<'a, Message, Renderer>;
+#[cfg(not(any(feature = "swbuf", feature = "glow", feature = "wgpu")))]
+pub use iced_native::widget::Row;
 
 pub mod text {
     //! Write some text for your users to read.
     pub use iced_native::widget::text::{Appearance, StyleSheet};
 
     /// A paragraph of text.
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type Text<'a, Renderer = crate::Renderer> =
         iced_native::widget::Text<'a, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::Text;
 }
 
 pub mod button {
@@ -25,8 +38,15 @@ pub mod button {
     pub use iced_native::widget::button::{Appearance, StyleSheet};
 
     /// A widget that produces a message when clicked.
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type Button<'a, Message, Renderer = crate::Renderer> =
         iced_native::widget::Button<'a, Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::Button;
 }
 
 pub mod checkbox {
@@ -34,8 +54,15 @@ pub mod checkbox {
     pub use iced_native::widget::checkbox::{Appearance, StyleSheet};
 
     /// A box that can be checked.
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type Checkbox<'a, Message, Renderer = crate::Renderer> =
         iced_native::widget::Checkbox<'a, Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::Checkbox;
 }
 
 pub mod container {
@@ -43,16 +70,30 @@ pub mod container {
     pub use iced_native::widget::container::{Appearance, StyleSheet};
 
     /// An element decorating some content.
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type Container<'a, Message, Renderer = crate::Renderer> =
         iced_native::widget::Container<'a, Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::Container;
 }
 
 pub mod mouse_listener {
     //! Intercept mouse events on a widget.
 
     /// A container intercepting mouse events.
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type MouseListener<'a, Message, Renderer = crate::Renderer> =
         iced_native::widget::MouseListener<'a, Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::MouseListener;
 }
 
 pub mod pane_grid {
@@ -74,16 +115,37 @@ pub mod pane_grid {
     /// to completely fill the space available.
     ///
     /// [![Pane grid - Iced](https://thumbs.gfycat.com/MixedFlatJellyfish-small.gif)](https://gfycat.com/mixedflatjellyfish)
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type PaneGrid<'a, Message, Renderer = crate::Renderer> =
         iced_native::widget::PaneGrid<'a, Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::PaneGrid;
 
     /// The content of a [`Pane`].
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type Content<'a, Message, Renderer = crate::Renderer> =
         iced_native::widget::pane_grid::Content<'a, Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::pane_grid::Content;
 
     /// The title bar of a [`Pane`].
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type TitleBar<'a, Message, Renderer = crate::Renderer> =
         iced_native::widget::pane_grid::TitleBar<'a, Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::pane_grid::TitleBar;
 }
 
 pub mod pick_list {
@@ -91,8 +153,15 @@ pub mod pick_list {
     pub use iced_native::widget::pick_list::{Appearance, StyleSheet};
 
     /// A widget allowing the selection of a single value from a list of options.
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type PickList<'a, T, Message, Renderer = crate::Renderer> =
         iced_native::widget::PickList<'a, T, Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::PickList;
 }
 
 pub mod radio {
@@ -100,8 +169,15 @@ pub mod radio {
     pub use iced_native::widget::radio::{Appearance, StyleSheet};
 
     /// A circular button representing a choice.
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type Radio<Message, Renderer = crate::Renderer> =
         iced_native::widget::Radio<Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::Radio;
 }
 
 pub mod scrollable {
@@ -112,8 +188,15 @@ pub mod scrollable {
 
     /// A widget that can vertically display an infinite amount of content
     /// with a scrollbar.
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type Scrollable<'a, Message, Renderer = crate::Renderer> =
         iced_native::widget::Scrollable<'a, Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::Scrollable;
 }
 
 pub mod toggler {
@@ -121,8 +204,15 @@ pub mod toggler {
     pub use iced_native::widget::toggler::{Appearance, StyleSheet};
 
     /// A toggler widget.
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type Toggler<'a, Message, Renderer = crate::Renderer> =
         iced_native::widget::Toggler<'a, Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::Toggler;
 }
 
 pub mod text_input {
@@ -133,8 +223,15 @@ pub mod text_input {
     };
 
     /// A field that can be filled with text.
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type TextInput<'a, Message, Renderer = crate::Renderer> =
         iced_native::widget::TextInput<'a, Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::TextInput;
 }
 
 pub mod tooltip {
@@ -142,8 +239,15 @@ pub mod tooltip {
     pub use iced_native::widget::tooltip::Position;
 
     /// A widget allowing the selection of a single value from a list of options.
+    #[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
     pub type Tooltip<'a, Message, Renderer = crate::Renderer> =
         iced_native::widget::Tooltip<'a, Message, Renderer>;
+    #[cfg(not(any(
+        feature = "swbuf",
+        feature = "glow",
+        feature = "wgpu"
+    )))]
+    pub use iced_native::widget::Tooltip;
 }
 
 pub use iced_native::widget::progress_bar;
@@ -223,10 +327,13 @@ pub use qr_code::QRCode;
 #[cfg_attr(docsrs, doc(cfg(feature = "svg")))]
 pub use svg::Svg;
 
+#[cfg(any(feature = "winit", feature = "wayland"))]
 use crate::Command;
+#[cfg(any(feature = "winit", feature = "wayland"))]
 use iced_native::widget::operation;
 
 /// Focuses the previous focusable widget.
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub fn focus_previous<Message>() -> Command<Message>
 where
     Message: 'static,
@@ -235,6 +342,7 @@ where
 }
 
 /// Focuses the next focusable widget.
+#[cfg(any(feature = "winit", feature = "wayland"))]
 pub fn focus_next<Message>() -> Command<Message>
 where
     Message: 'static,

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,17 +1,19 @@
 //! Configure the window of your application in native platforms.
+#[cfg(feature = "winit")]
+pub mod icon;
 mod position;
 mod settings;
-#[cfg(feature = "winit")]
-
-pub mod icon;
 #[cfg(feature = "winit")]
 pub use icon::Icon;
 pub use position::Position;
 pub use settings::Settings;
 
-#[cfg(not(target_arch = "wasm32"))]
-pub use crate::runtime::window::resize;
-#[cfg(not(any(target_arch = "wasm32", feature = "wayland")))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "winit"))]
 pub use crate::runtime::window::move_to;
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(feature = "wayland", feature = "winit")
+))]
+pub use crate::runtime::window::resize;
 
 pub use iced_native::window::Id;


### PR DESCRIPTION
Restructures the crate in a way, that doesn't cause features to disable other features and linkage between backends and renderers, etc.

Now the `iced` crate can be compiled without any features (though it is not super useful in this state and mostly re-exports iced_native).
Additionally  all renderers can be build free-standing (necessary to use `libcosmic` in `cosmic-comp` , which cannot use any of the existing shells/runtime).
Additionally allows combinations of runtimes and renderers to be selected freely, though many are not compatible with each other as noted in the Cargo.toml. (Though more can be made compatible, e.g. sctk could also work with wgpu or swbuf in the future.)

Required for https://github.com/pop-os/libcosmic/pull/64