### PR TITLE
features: Use iced_native types without a runtime

### DIFF
--- a/src/element.rs
+++ b/src/element.rs
@@ -1,6 +1,6 @@
 /// A generic widget.
 ///
 /// This is an alias of an `iced_native` element with a default `Renderer`.
-#[cfg(any(feature = "winit", feature = "wayland"))]
+#[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
 pub type Element<'a, Message, Renderer = crate::Renderer> =
-    crate::runtime::Element<'a, Message, Renderer>;
+    iced_native::Element<'a, Message, Renderer>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,10 +224,9 @@ use iced_swbuf as renderer;
 
 pub use iced_native::theme;
 
-#[cfg(any(feature = "winit", feature = "wayland"))]
+#[cfg(any(feature = "swbuf", feature = "glow", feature = "wgpu"))]
 pub use element::Element;
 pub use error::Error;
-#[cfg(any(feature = "winit", feature = "wayland"))]
 pub use event::Event;
 #[cfg(any(feature = "winit", feature = "wayland"))]
 pub use executor::Executor;
@@ -237,15 +236,20 @@ pub use result::Result;
 #[cfg(any(feature = "winit", feature = "wayland"))]
 pub use sandbox::Sandbox;
 pub use settings::Settings;
-#[cfg(any(feature = "winit", feature = "wayland"))]
 pub use subscription::Subscription;
 pub use theme::Theme;
 
+#[cfg(not(any(feature = "winit", feature = "wayland")))]
+pub use iced_native::{
+    alignment, color, event, futures, subscription, Alignment, Background,
+    Color, Command, ContentFit, Font, Length, Padding, Point, Rectangle, Size,
+    Vector,
+};
 #[cfg(any(feature = "winit", feature = "wayland"))]
 pub use runtime::{
-    alignment, color, event, futures, settings as sctk_settings, subscription,
-    Alignment, Background, Color, Command, ContentFit, Font, Length, Padding,
-    Point, Rectangle, Size, Vector,
+    alignment, color, event, futures, subscription, Alignment, Background,
+    Color, Command, ContentFit, Font, Length, Padding, Point, Rectangle, Size,
+    Vector,
 };
 
 #[cfg(feature = "system")]

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,3 +1,2 @@
 //! Listen and react to mouse events.
-#[cfg(any(feature = "winit", feature = "wayland"))]
-pub use crate::runtime::mouse::{Button, Event, Interaction, ScrollDelta};
+pub use iced_native::mouse::{Button, Event, Interaction, ScrollDelta};

--- a/src/touch.rs
+++ b/src/touch.rs
@@ -1,3 +1,2 @@
 //! Listen and react to touch events.
-#[cfg(any(feature = "winit", feature = "wayland"))]
-pub use crate::runtime::touch::{Event, Finger};
+pub use iced_native::touch::{Event, Finger};


### PR DESCRIPTION
Turns out `iced_winit`/`iced_glutin`/`iced_sctk` only reexport most of their types from `iced_native`. This PR changes some imports in the main `iced`-crate, so that they use `iced_native` directly or as a fallback to enable building `libcosmic` without any `shell` or `runtime` feature being activated.