### PR TITLE
swbuf: Make backend constructor visible

### DIFF
--- a/swbuf/src/backend.rs
+++ b/swbuf/src/backend.rs
@@ -89,7 +89,7 @@ pub struct Backend {
 }
 
 impl Backend {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             swash_cache: SwashCache::new(&FONT_SYSTEM),
             #[cfg(feature = "image")]


### PR DESCRIPTION
Makes the `swbuf` `Backend` type public to make it possible to construct it and iced's `Renderer` out-of-tree to integrate the swbuf backend directly without using one of the provided shells.