### PR TITLE
Expose draw_primitive for shell-less rendering

### DIFF
--- a/softbuffer/src/lib.rs
+++ b/softbuffer/src/lib.rs
@@ -15,6 +15,11 @@ pub use self::settings::Settings;
 
 pub(crate) mod surface;
 
+pub mod native {
+    pub use crate::surface::draw_primitive;
+    pub use raqote;
+}
+
 pub mod window;
 
 pub type Renderer<Theme = iced_native::Theme> =

--- a/softbuffer/src/surface.rs
+++ b/softbuffer/src/surface.rs
@@ -10,8 +10,8 @@ use raqote::{
     SolidSource, Source, StrokeStyle, Transform,
 };
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
-use std::cmp;
 use softbuffer::GraphicsContext;
+use std::cmp;
 
 // A software rendering surface
 pub struct Surface {
@@ -96,7 +96,7 @@ impl Surface {
     }
 }
 
-fn draw_primitive(
+pub fn draw_primitive(
     draw_target: &mut DrawTarget<&mut [u32]>,
     draw_options: &DrawOptions,
     backend: &mut Backend,


### PR DESCRIPTION
Allows the softbuffer renderer to be used without a surface.
Additionally re-exports the raqote-types for convenience, because they are needed for `draw_primitive`.