### PR TITLE
fix: iced-sctk

### DIFF
--- a/examples/autosize_layer/Cargo.toml
+++ b/examples/autosize_layer/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "autosize_layer"
+version = "0.1.0"
+authors = ["Héctor Ramón Jiménez <hector0193@gmail.com>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+iced = { path = "../..", default-features=false, features = ["async-std", "wayland", "debug", "dyrend"] }
+sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay/client-toolkit", rev = "a257bf7" }
+iced_native = { path = "../../native" }
+iced_style = { path = "../../style" }
+

--- a/examples/autosize_layer/src/main.rs
+++ b/examples/autosize_layer/src/main.rs
@@ -1,0 +1,168 @@
+use iced::alignment::{self, Alignment};
+use iced::event::{self, Event};
+use iced::keyboard;
+use iced::subscription;
+use iced::theme::{self, Theme};
+use iced::wayland::actions::layer_surface::SctkLayerSurfaceSettings;
+use iced::wayland::actions::popup::SctkPopupSettings;
+use iced::wayland::actions::popup::SctkPositioner;
+use iced::wayland::actions::window::SctkWindowSettings;
+use iced::wayland::layer_surface::{get_layer_surface, Anchor};
+use iced::wayland::popup::destroy_popup;
+use iced::wayland::popup::get_popup;
+use iced::wayland::window::get_window;
+use iced::wayland::InitialSurface;
+use iced::wayland::SurfaceIdWrapper;
+use iced::widget::{
+    self, button, checkbox, column, container, row, scrollable, text,
+    text_input, Column, Row, Text,
+};
+use iced::Rectangle;
+use iced::{window, Application, Element};
+use iced::{Color, Command, Font, Length, Settings, Subscription};
+use iced_style::application;
+
+pub fn main() -> iced::Result {
+    Todos::run(Settings {
+        initial_surface: InitialSurface::LayerSurface(Default::default()),
+        ..Default::default()
+    })
+}
+
+#[derive(Debug, Default)]
+struct Todos {
+    size: u32,
+    id_ctr: u32,
+    popup: Option<window::Id>,
+}
+
+#[derive(Debug, Clone)]
+enum Message {
+    Tick,
+    Popup,
+    Ignore,
+}
+
+impl Application for Todos {
+    type Message = Message;
+    type Theme = Theme;
+    type Executor = iced::executor::Default;
+    type Flags = ();
+
+    fn new(_flags: ()) -> (Todos, Command<Message>) {
+        (
+            Todos {
+                size: 5,
+                id_ctr: 2,
+                ..Default::default()
+            },
+            get_layer_surface(SctkLayerSurfaceSettings {
+                id: window::Id::new(1),
+                anchor: Anchor::RIGHT,
+                ..Default::default()
+            }),
+        )
+    }
+
+    fn update(&mut self, message: Message) -> Command<Message> {
+        match message {
+            Message::Tick => {
+                self.size = (self.size - 1) % 10;
+                if self.size == 0 {
+                    self.size = 10;
+                }
+            }
+            Message::Popup => {
+                if let Some(p) = self.popup.take() {
+                    return destroy_popup(p);
+                } else {
+                    self.id_ctr += 1;
+                    let new_id = window::Id::new(self.id_ctr);
+                    self.popup.replace(new_id);
+                    return get_popup(SctkPopupSettings {
+                        parent: window::Id::new(0),
+                        id: new_id,
+                        positioner: SctkPositioner {
+                            anchor_rect: Rectangle {
+                                x: 10,
+                                y: 10,
+                                width: 1,
+                                height: 1,
+                            },
+                            ..Default::default()
+                        },
+                        parent_size: None,
+                        grab: true,
+                    });
+                }
+            }
+            Message::Ignore => {}
+        }
+        Command::none()
+    }
+
+    fn view(&self, id: SurfaceIdWrapper) -> Element<Message> {
+        match id {
+            SurfaceIdWrapper::LayerSurface(_) | SurfaceIdWrapper::Popup(_) => {
+                Column::with_children(
+                    (0..self.size)
+                        .map(|_| {
+                            Row::with_children(
+                                (0..self.size)
+                                    .map(|i| {
+                                        button(Text::new(format!(
+                                            "{}: {}",
+                                            i, i
+                                        )))
+                                        .on_press(Message::Popup)
+                                        .into()
+                                    })
+                                    .collect(),
+                            )
+                            .spacing(12)
+                            .width(Length::Shrink)
+                            .height(Length::Shrink)
+                            .into()
+                        })
+                        .collect(),
+                )
+                .spacing(12)
+                .width(Length::Shrink)
+                .height(Length::Shrink)
+                .into()
+            }
+            SurfaceIdWrapper::Window(_) => unimplemented!(),
+        }
+    }
+
+    fn close_requested(&self, id: SurfaceIdWrapper) -> Self::Message {
+        Message::Ignore
+    }
+
+    fn style(&self) -> <iced_style::Theme as application::StyleSheet>::Style {
+        <iced_style::Theme as application::StyleSheet>::Style::Custom(Box::new(
+            CustomTheme,
+        ))
+    }
+    fn title(&self) -> String {
+        String::from("autosize")
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        iced::time::every(std::time::Duration::from_millis(1000))
+            .map(|_| Message::Tick)
+    }
+}
+
+pub struct CustomTheme;
+
+impl application::StyleSheet for CustomTheme {
+    type Style = iced::Theme;
+
+    fn appearance(&self, style: &Self::Style) -> application::Appearance {
+        application::Appearance {
+            background_color: Color::from_rgba(1.0, 1.0, 1.0, 0.8),
+            text_color: Color::BLACK,
+        }
+    }
+}

--- a/native/src/command/platform_specific/wayland/popup.rs
+++ b/native/src/command/platform_specific/wayland/popup.rs
@@ -77,7 +77,11 @@ impl Default for SctkPositioner {
     fn default() -> Self {
         Self {
             size: None,
-            size_limits: Limits::NONE.min_height(1).min_width(1).max_width(300).max_height(1080),
+            size_limits: Limits::NONE
+                .min_height(1)
+                .min_width(1)
+                .max_width(300)
+                .max_height(1080),
             anchor_rect: Rectangle {
                 x: 0,
                 y: 0,
@@ -121,7 +125,7 @@ pub enum Action<T> {
         width: u32,
         /// height
         height: u32,
-    }
+    },
 }
 
 impl<T> Action<T> {
@@ -140,7 +144,9 @@ impl<T> Action<T> {
             },
             Action::Destroy { id } => Action::Destroy { id },
             Action::Grab { id } => Action::Grab { id },
-            Action::Size { id, width, height } => Action::Size { id, width, height },
+            Action::Size { id, width, height } => {
+                Action::Size { id, width, height }
+            }
         }
     }
 }

--- a/sctk/src/event_loop/state.rs
+++ b/sctk/src/event_loop/state.rs
@@ -174,15 +174,6 @@ pub struct SctkState<T> {
     /// A sink for window and device events that is being filled during dispatching
     /// event loop and forwarded downstream afterwards.
     pub(crate) sctk_events: Vec<SctkEvent>,
-    /// Window updates comming from the user requests. Those are separatelly dispatched right after
-    /// `MainEventsCleared`.
-    pub window_user_requests: HashMap<ObjectId, SurfaceUserRequest>,
-    /// Layer Surface updates comming from the user requests. Those are separatelly dispatched right after
-    /// `MainEventsCleared`.
-    pub layer_surface_user_requests: HashMap<ObjectId, SurfaceUserRequest>,
-    /// Window updates comming from the user requests. Those are separatelly dispatched right after
-    /// `MainEventsCleared`.
-    pub popup_user_requests: HashMap<ObjectId, SurfaceUserRequest>,
 
     /// pending user events
     pub pending_user_events: Vec<Event<T>>,

--- a/sctk/src/handlers/compositor.rs
+++ b/sctk/src/handlers/compositor.rs
@@ -58,7 +58,7 @@ impl<T: Debug> CompositorHandler for SctkState<T> {
         surface: &wl_surface::WlSurface,
         _time: u32,
     ) {
-        self.sctk_events.push(SctkEvent::Draw(surface.clone()));
+        self.sctk_events.push(SctkEvent::Frame(surface.clone()));
     }
 }
 

--- a/sctk/src/handlers/shell/layer.rs
+++ b/sctk/src/handlers/shell/layer.rs
@@ -46,15 +46,15 @@ impl<T: Debug> LayerShellHandler for SctkState<T> {
                 Some(l) => l,
                 None => return,
             };
-        
-        configure.new_size.0 = if let Some(w)  = layer.requested_size.0 {
+
+        configure.new_size.0 = if let Some(w) = layer.requested_size.0 {
             w
-        } else  {
+        } else {
             configure.new_size.0.max(1)
         };
-        configure.new_size.1 = if let Some(h)  = layer.requested_size.1 {
+        configure.new_size.1 = if let Some(h) = layer.requested_size.1 {
             h
-        } else  {
+        } else {
             configure.new_size.1.max(1)
         };
 
@@ -74,7 +74,7 @@ impl<T: Debug> LayerShellHandler for SctkState<T> {
             id: layer.surface.wl_surface().clone(),
         });
         self.sctk_events
-            .push(SctkEvent::Draw(layer.surface.wl_surface().clone()));
+            .push(SctkEvent::Frame(layer.surface.wl_surface().clone()));
     }
 }
 

--- a/sctk/src/handlers/shell/xdg_popup.rs
+++ b/sctk/src/handlers/shell/xdg_popup.rs
@@ -41,7 +41,7 @@ impl<T: Debug> PopupHandler for SctkState<T> {
             },
         });
         self.sctk_events
-            .push(SctkEvent::Draw(popup.wl_surface().clone()));
+            .push(SctkEvent::Frame(popup.wl_surface().clone()));
     }
 
     fn done(

--- a/sctk/src/handlers/shell/xdg_window.rs
+++ b/sctk/src/handlers/shell/xdg_window.rs
@@ -64,7 +64,7 @@ impl<T: Debug> WindowHandler for SctkState<T> {
             ),
             id,
         });
-        self.sctk_events.push(SctkEvent::Draw(wl_surface.clone()));
+        self.sctk_events.push(SctkEvent::Frame(wl_surface.clone()));
     }
 }
 

--- a/sctk/src/sctk_event.rs
+++ b/sctk/src/sctk_event.rs
@@ -160,7 +160,7 @@ pub enum SctkEvent {
     //
     // compositor events
     //
-    Draw(WlSurface),
+    Frame(WlSurface),
     ScaleFactorChanged {
         factor: f64,
         id: WlOutput,
@@ -213,11 +213,9 @@ pub enum PopupEventVariant {
     /// <https://wayland.app/protocols/xdg-shell#xdg_popup:event:configure>
     Configure(PopupConfigure, WlSurface, bool),
     /// <https://wayland.app/protocols/xdg-shell#xdg_popup:event:repositioned>
-    RepositionionedPopup {
-        token: u32,
-    },
+    RepositionionedPopup { token: u32 },
     /// size
-    Size(u32, u32)
+    Size(u32, u32),
 }
 
 #[derive(Debug, Clone)]
@@ -618,14 +616,14 @@ impl SctkEvent {
                 .into_iter()
                 .collect()
             }
-            SctkEvent::UpdateOutput { id, info } => vec![
-                iced_native::Event::PlatformSpecific(
+            SctkEvent::UpdateOutput { id, info } => {
+                vec![iced_native::Event::PlatformSpecific(
                     PlatformSpecific::Wayland(wayland::Event::Output(
                         wayland::OutputEvent::InfoUpdate(info),
                         id.clone(),
                     )),
-                ),
-            ],
+                )]
+            }
             SctkEvent::RemovedOutput(id) => {
                 Some(iced_native::Event::PlatformSpecific(
                     PlatformSpecific::Wayland(wayland::Event::Output(
@@ -636,7 +634,7 @@ impl SctkEvent {
                 .into_iter()
                 .collect()
             }
-            SctkEvent::Draw(_) => Default::default(),
+            SctkEvent::Frame(_) => Default::default(),
             SctkEvent::ScaleFactorChanged {
                 factor,
                 id,

--- a/sctk/src/settings.rs
+++ b/sctk/src/settings.rs
@@ -22,6 +22,7 @@ pub struct Settings<Flags> {
 pub enum InitialSurface {
     LayerSurface(SctkLayerSurfaceSettings),
     XdgWindow(SctkWindowSettings),
+    None,
 }
 
 impl Default for InitialSurface {


### PR DESCRIPTION
cleanup: fixes visual corruption sometimes present in auto-sized surfaces, and also adds the option for starting without an  initial surface