### PR TITLE
chore: default line height, text size, and shaping for cosmic

### DIFF
--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -51,7 +51,7 @@ impl text::Renderer for Null {
     }
 
     fn default_size(&self) -> f32 {
-        16.0
+        14.0
     }
 
     fn load_font(&mut self, _font: Cow<'static, [u8]>) {}

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -82,7 +82,7 @@ impl LineHeight {
 
 impl Default for LineHeight {
     fn default() -> Self {
-        Self::Relative(1.2)
+        Self::Relative(1.4)
     }
 }
 

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -50,7 +50,7 @@ where
             height: Length::Shrink,
             horizontal_alignment: alignment::Horizontal::Left,
             vertical_alignment: alignment::Vertical::Top,
-            shaping: Shaping::Basic,
+            shaping: Shaping::Advanced,
             style: Default::default(),
         }
     }

--- a/graphics/src/geometry/text.rs
+++ b/graphics/src/geometry/text.rs
@@ -38,12 +38,12 @@ impl Default for Text {
             content: String::new(),
             position: Point::ORIGIN,
             color: Color::BLACK,
-            size: 16.0,
-            line_height: LineHeight::Relative(1.2),
+            size: 14.0,
+            line_height: LineHeight::default(),
             font: Font::default(),
             horizontal_alignment: alignment::Horizontal::Left,
             vertical_alignment: alignment::Vertical::Top,
-            shaping: Shaping::Basic,
+            shaping: Shaping::Advanced,
         }
     }
 }

--- a/renderer/src/compositor.rs
+++ b/renderer/src/compositor.rs
@@ -204,7 +204,9 @@ impl Candidate {
                     iced_tiny_skia::window::compositor::new(
                         iced_tiny_skia::Settings {
                             default_font: settings.default_font,
-                            default_text_size: settings.default_text_size,
+                            // TODO: find were this is getting set to a value other than 14.0
+                            // default_text_size: settings.default_text_size,
+                            default_text_size: 14.0
                         },
                     );
 

--- a/renderer/src/settings.rs
+++ b/renderer/src/settings.rs
@@ -11,7 +11,7 @@ pub struct Settings {
 
     /// The default size of text.
     ///
-    /// By default, it will be set to `16.0`.
+    /// By default, it will be set to `14.0`.
     pub default_text_size: f32,
 
     /// The antialiasing strategy that will be used for triangle primitives.
@@ -24,7 +24,7 @@ impl Default for Settings {
     fn default() -> Settings {
         Settings {
             default_font: Font::default(),
-            default_text_size: 16.0,
+            default_text_size: 14.0,
             antialiasing: None,
         }
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -88,7 +88,7 @@ where
             id: None,
             flags: Default::default(),
             default_font: Default::default(),
-            default_text_size: 16.0,
+            default_text_size: 14.0,
             antialiasing: false,
             exit_on_close_request: true,
         }
@@ -125,7 +125,7 @@ where
             window: Default::default(),
             flags: Default::default(),
             default_font: Default::default(),
-            default_text_size: 16.0,
+            default_text_size: 14.0,
             antialiasing: false,
             exit_on_close_request: true,
         }
@@ -175,7 +175,7 @@ where
             initial_surface: Default::default(),
             flags: Default::default(),
             default_font: Default::default(),
-            default_text_size: 16.0,
+            default_text_size: 14.0,
             antialiasing: false,
             exit_on_close_request: true,
         }

--- a/tiny_skia/src/settings.rs
+++ b/tiny_skia/src/settings.rs
@@ -10,7 +10,7 @@ pub struct Settings {
 
     /// The default size of text.
     ///
-    /// By default, it will be set to `16.0`.
+    /// By default, it will be set to `14.0`.
     pub default_text_size: f32,
 }
 
@@ -18,7 +18,7 @@ impl Default for Settings {
     fn default() -> Settings {
         Settings {
             default_font: Font::default(),
-            default_text_size: 16.0,
+            default_text_size: 14.0,
         }
     }
 }

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -66,7 +66,7 @@ impl<'a> Layer<'a> {
                 font: Font::MONOSPACE,
                 horizontal_alignment: alignment::Horizontal::Left,
                 vertical_alignment: alignment::Vertical::Top,
-                shaping: core::text::Shaping::Basic,
+                shaping: core::text::Shaping::Advanced,
             };
 
             overlay.text.push(text);

--- a/wgpu/src/settings.rs
+++ b/wgpu/src/settings.rs
@@ -20,7 +20,7 @@ pub struct Settings {
 
     /// The default size of text.
     ///
-    /// By default, it will be set to `16.0`.
+    /// By default, it will be set to `14.0`.
     pub default_text_size: f32,
 
     /// The antialiasing strategy that will be used for triangle primitives.
@@ -59,7 +59,7 @@ impl Default for Settings {
             present_mode: wgpu::PresentMode::AutoVsync,
             internal_backend: wgpu::Backends::all(),
             default_font: Font::default(),
-            default_text_size: 16.0,
+            default_text_size: 14.0,
             antialiasing: None,
         }
     }

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -100,14 +100,14 @@ where
             spacing: Self::DEFAULT_SPACING,
             text_size: None,
             text_line_height: text::LineHeight::default(),
-            text_shaping: text::Shaping::Basic,
+            text_shaping: text::Shaping::Advanced,
             font: None,
             icon: Icon {
                 font: Renderer::ICON_FONT,
                 code_point: Renderer::CHECKMARK_ICON,
                 size: None,
                 line_height: text::LineHeight::default(),
-                shaping: text::Shaping::Basic,
+                shaping: text::Shaping::Advanced,
             },
             style: Default::default(),
         }

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -61,7 +61,7 @@ where
             padding: Padding::ZERO,
             text_size: None,
             text_line_height: text::LineHeight::default(),
-            text_shaping: text::Shaping::Basic,
+            text_shaping: text::Shaping::Advanced,
             font: None,
             style: Default::default(),
         }

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -632,7 +632,7 @@ pub fn draw<'a, T, Renderer>(
             Renderer::ICON_FONT,
             Renderer::ARROW_DOWN_ICON,
             *size,
-            text::Shaping::Basic,
+            text::Shaping::Advanced,
         )),
         Handle::Static(Icon {
             font,

--- a/widget/src/radio.rs
+++ b/widget/src/radio.rs
@@ -126,7 +126,7 @@ where
             spacing: Self::DEFAULT_SPACING, //15
             text_size: None,
             text_line_height: text::LineHeight::default(),
-            text_shaping: text::Shaping::Basic,
+            text_shaping: text::Shaping::Advanced,
             font: None,
             style: Default::default(),
         }

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -104,7 +104,7 @@ where
             text_size: None,
             text_line_height: text::LineHeight::default(),
             text_alignment: alignment::Horizontal::Left,
-            text_shaping: text::Shaping::Basic,
+            text_shaping: text::Shaping::Advanced,
             spacing: 0.0,
             font: None,
             style: Default::default(),


### PR DESCRIPTION
- Set default font size to 14
- Default line height to a relative of 1.4
- Default to advanced shaping