### PR TITLE
runtime: Handle widget operations in `program::State` helper

### DIFF
--- a/runtime/src/program/state.rs
+++ b/runtime/src/program/state.rs
@@ -1,9 +1,12 @@
 use crate::core::event::{self, Event};
 use crate::core::mouse;
 use crate::core::renderer;
+use crate::core::widget::operation::{
+    Operation, OperationOutputWrapper, OperationWrapper, Outcome,
+};
 use crate::core::{Clipboard, Point, Size};
 use crate::user_interface::{self, UserInterface};
-use crate::{Command, Debug, Program};
+use crate::{command::Action, Command, Debug, Program};
 
 /// The execution state of a [`Program`]. It leverages caching, event
 /// processing, and rendering primitive storage.
@@ -97,7 +100,7 @@ where
         style: &renderer::Style,
         clipboard: &mut dyn Clipboard,
         debug: &mut Debug,
-    ) -> (Vec<Event>, Option<Command<P::Message>>) {
+    ) -> (Vec<Event>, Vec<Action<P::Message>>) {
         let mut user_interface = build_user_interface(
             id,
             &mut self.program,
@@ -132,7 +135,7 @@ where
         messages.append(&mut self.queued_messages);
         debug.event_processing_finished();
 
-        let command = if messages.is_empty() {
+        let actions = if messages.is_empty() {
             debug.draw_started();
             self.mouse_interaction =
                 user_interface.draw(renderer, theme, style, cursor_position);
@@ -140,13 +143,13 @@ where
 
             self.cache = Some(user_interface.into_cache());
 
-            None
+            Vec::new()
         } else {
             // When there are messages, we are forced to rebuild twice
             // for now :^)
             let temp_cache = user_interface.into_cache();
 
-            let commands =
+            let (actions, widget_actions) =
                 Command::batch(messages.into_iter().map(|message| {
                     debug.log_message(&message);
 
@@ -155,7 +158,12 @@ where
                     debug.update_finished();
 
                     command
-                }));
+                }))
+                .actions()
+                .into_iter()
+                .partition::<Vec<_>, _>(|action| {
+                    !matches!(action, Action::Widget(_))
+                });
 
             let mut user_interface = build_user_interface(
                 id,
@@ -166,6 +174,47 @@ where
                 debug,
             );
 
+            let had_operations = !widget_actions.is_empty();
+            for operation in widget_actions
+                .into_iter()
+                .map(|action| match action {
+                    Action::Widget(widget_action) => widget_action,
+                    _ => unreachable!(),
+                })
+                .map(OperationWrapper::Message)
+            {
+                let mut current_operation = Some(operation);
+                while let Some(mut operation) = current_operation.take() {
+                    user_interface.operate(renderer, &mut operation);
+                    match operation.finish() {
+                        Outcome::Some(OperationOutputWrapper::Message(
+                            message,
+                        )) => self.queued_messages.push(message),
+                        Outcome::Chain(op) => {
+                            current_operation =
+                                Some(OperationWrapper::Wrapper(op));
+                        }
+                        _ => {}
+                    };
+                }
+            }
+
+            let mut user_interface = if had_operations {
+                // When there were operations, we are forced to rebuild thrice ...
+                let temp_cache = user_interface.into_cache();
+
+                build_user_interface(
+                    id,
+                    &mut self.program,
+                    temp_cache,
+                    renderer,
+                    bounds,
+                    debug,
+                )
+            } else {
+                user_interface
+            };
+
             debug.draw_started();
             self.mouse_interaction =
                 user_interface.draw(renderer, theme, style, cursor_position);
@@ -173,10 +222,10 @@ where
 
             self.cache = Some(user_interface.into_cache());
 
-            Some(commands)
+            actions
         };
 
-        (uncaptured_events, command)
+        (uncaptured_events, actions)
     }
 }
 


### PR DESCRIPTION
This handles widget operations in the `State`-helper `cosmic-comp` makes use of. As far as I am aware the window integrations all use the `UserInterface`-type directly, while the `State`-helper was initially conceived for foreign integrations, like the previously existing `integration_opengl` and `integration_wgpu` examples.

`State` is mostly a convenience type around the `UserInterface` building block and hides that behind it's api, so there is no way to call `UserInterface::operate` from the outside. Additionally it returns `Command`-created by the Widget-Tree unprocessed.
Any `Actions::Widget`-variants derived from these `Command`s containing `Operation`s are thus never processed by the internal `UserInterface` and cannot be passed in from the outside.

This PR fixes this short-coming and thus makes the `State`-helper more useful. I opted to to handle this inside the helper, given that the only sensible thing to do with a `Command` is to convert it into `Action`s anyway. As such `State::update` now filters `Action`s for widget operations and sends those back into the `UserInterface`.

As far as I am aware this has no implications for any other integration of iced than in `cosmic-comp`.