### PR TITLE
feat(sctk): configurable natural_scroll property

### DIFF
--- a/sctk/src/application.rs
+++ b/sctk/src/application.rs
@@ -170,6 +170,11 @@ where
         1.0
     }
 
+    /// Defines whether or not to use natural scrolling
+    fn natural_scroll(&self) -> bool {
+        false
+    }
+
     /// Returns whether the [`Application`] should be terminated.
     ///
     /// By default, it returns `false`.
@@ -379,6 +384,8 @@ where
             .map(subscription_map::<A, E, C>)
             .into_recipes(),
     );
+
+    let natural_scroll = application.natural_scroll();
 
     let mut mouse_interaction = Interaction::default();
     let mut sctk_events: Vec<SctkEvent> = Vec::new();
@@ -862,6 +869,7 @@ where
                             &mut mods,
                             &surface_ids,
                             &destroyed_surface_ids,
+                            natural_scroll,
                         ) {
                             runtime.broadcast(native_event, Status::Ignored);
                         }
@@ -907,6 +915,7 @@ where
                     }
                 } else {
                     let mut needs_update = false;
+
                     for (object_id, surface_id) in &surface_ids {
                         if matches!(surface_id, SurfaceIdWrapper::Dnd(_)) {
                             continue;
@@ -943,6 +952,7 @@ where
                                     &mut mods,
                                     &surface_ids,
                                     &destroyed_surface_ids,
+                                    state.natural_scroll,
                                 )
                             })
                             .collect();
@@ -1514,6 +1524,7 @@ where
     appearance: application::Appearance,
     application: PhantomData<A>,
     frame: Option<WlSurface>,
+    natural_scroll: bool,
     needs_redraw: bool,
     first: bool,
     wp_viewport: Option<WpViewport>,
@@ -1545,6 +1556,7 @@ where
             appearance,
             application: PhantomData,
             frame: None,
+            natural_scroll: application.natural_scroll(),
             needs_redraw: false,
             first: true,
             wp_viewport: None,

--- a/sctk/src/conversion.rs
+++ b/sctk/src/conversion.rs
@@ -31,16 +31,35 @@ pub fn pointer_axis_to_native(
     source: Option<AxisSource>,
     horizontal: AxisScroll,
     vertical: AxisScroll,
+    natural_scroll: bool,
 ) -> Option<ScrollDelta> {
     source.map(|source| match source {
-        AxisSource::Wheel | AxisSource::WheelTilt => ScrollDelta::Lines {
-            x: horizontal.discrete as f32,
-            y: vertical.discrete as f32,
-        },
-        _ => ScrollDelta::Pixels {
-            x: horizontal.absolute as f32,
-            y: vertical.absolute as f32,
-        },
+        AxisSource::Wheel | AxisSource::WheelTilt => {
+            if natural_scroll {
+                ScrollDelta::Lines {
+                    x: horizontal.discrete as f32,
+                    y: vertical.discrete as f32,
+                }
+            } else {
+                ScrollDelta::Lines {
+                    x: (-1 * horizontal.discrete) as f32,
+                    y: (-1 * vertical.discrete) as f32,
+                }
+            }
+        }
+        _ => {
+            if natural_scroll {
+                ScrollDelta::Pixels {
+                    x: horizontal.absolute as f32,
+                    y: vertical.absolute as f32,
+                }
+            } else {
+                ScrollDelta::Pixels {
+                    x: (-1.0 * horizontal.absolute) as f32,
+                    y: (-1.0 * vertical.absolute) as f32,
+                }
+            }
+        }
     })
 }
 

--- a/sctk/src/sctk_event.rs
+++ b/sctk/src/sctk_event.rs
@@ -387,6 +387,7 @@ impl SctkEvent {
         modifiers: &mut Modifiers,
         surface_ids: &HashMap<ObjectId, SurfaceIdWrapper>,
         destroyed_surface_ids: &HashMap<ObjectId, SurfaceIdWrapper>,
+        natural_scroll: bool,
     ) -> Vec<iced_runtime::core::Event> {
         match self {
             // TODO Ashley: Platform specific multi-seat events?
@@ -441,14 +442,19 @@ impl SctkEvent {
                     horizontal,
                     vertical,
                     source,
-                } => pointer_axis_to_native(source, horizontal, vertical)
-                    .map(|a| {
-                        iced_runtime::core::Event::Mouse(
-                            mouse::Event::WheelScrolled { delta: a },
-                        )
-                    })
-                    .into_iter()
-                    .collect(), // TODO Ashley: conversion
+                } => pointer_axis_to_native(
+                    source,
+                    horizontal,
+                    vertical,
+                    natural_scroll,
+                )
+                .map(|a| {
+                    iced_runtime::core::Event::Mouse(
+                        mouse::Event::WheelScrolled { delta: a },
+                    )
+                })
+                .into_iter()
+                .collect(), // TODO Ashley: conversion
             },
             SctkEvent::KeyboardEvent {
                 variant,


### PR DESCRIPTION
The next step will be getting this setting from the environment. I'm not sure if there's a protocol for this that sctk can use to get the value from the compositor, or if we'll need to get this from cosmic-comp's config file in libcosmic.

The winit backend defaults to reverse scrolling, but sctk is defaulting to natural.