### PR TITLE
fix: reset button state if the cursor leaves

### DIFF
--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -541,7 +541,8 @@ pub fn update<'a, Message: Clone>(
                 }
             }
         }
-        Event::Touch(touch::Event::FingerLost { .. }) => {
+        Event::Touch(touch::Event::FingerLost { .. })
+        | Event::Mouse(mouse::Event::CursorLeft) => {
             let state = state();
             state.is_hovered = false;
             state.is_pressed = false;


### PR DESCRIPTION
This should help fix an issue where panel buttons remain hovered after the pointer leaves