### PR TITLE
feat(renderer): definable default color for symbolic icons

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["gui", "ui", "graphics", "interface", "widgets"]
 categories = ["gui"]
 
 [features]
-default = ["winit", "a11y"]
 # Enable the `wgpu` GPU-accelerated renderer backend
 wgpu = ["iced_renderer/wgpu"]
 # Enables the `Image` widget

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -63,6 +63,8 @@ pub struct Quad {
 /// The styling attributes of a [`Renderer`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Style {
+    /// The color to apply to symbolic icons.
+    pub icon_color: Color,
     /// The text color
     pub text_color: Color,
     /// The scale factor
@@ -72,6 +74,7 @@ pub struct Style {
 impl Default for Style {
     fn default() -> Self {
         Style {
+            icon_color: Color::BLACK,
             text_color: Color::BLACK,
             scale_factor: 1.0,
         }

--- a/sctk/src/application.rs
+++ b/sctk/src/application.rs
@@ -631,7 +631,7 @@ where
                                         configure.new_size.1 as f64,
                                     );
                                 }
-                                
+
                             }
                         }
                         LayerSurfaceEventVariant::ScaleFactorChanged(sf, viewport) => {
@@ -854,6 +854,7 @@ where
                     &mut renderer,
                     state.theme(),
                     &Style {
+                        icon_color: state.icon_color(),
                         text_color: state.text_color(),
                         scale_factor: state.scale_factor(),
                     },
@@ -1012,10 +1013,11 @@ where
                             has_events || !native_events.is_empty();
 
                         let (interface_state, statuses) = {
-                            let Some(user_interface) = interfaces
-                                .get_mut(&surface_id.inner()) else {
-                                    continue;
-                                };
+                            let Some(user_interface) =
+                                interfaces.get_mut(&surface_id.inner())
+                            else {
+                                continue;
+                            };
                             user_interface.update(
                                 native_events.as_slice(),
                                 cursor_position,
@@ -1141,8 +1143,9 @@ where
                                 Instant::now(),
                             ),
                         );
-                        let Some(user_interface) = interfaces
-                        .get_mut(&surface_id.inner()) else {
+                        let Some(user_interface) =
+                            interfaces.get_mut(&surface_id.inner())
+                        else {
                             continue;
                         };
                         let (interface_state, _) = user_interface.update(
@@ -1306,6 +1309,7 @@ where
                         &mut renderer,
                         state.theme(),
                         &Style {
+                            icon_color: state.icon_color(),
                             text_color: state.text_color(),
                             scale_factor: state.scale_factor(),
                         },
@@ -1723,6 +1727,11 @@ where
     /// Returns the current background [`Color`] of the [`State`].
     pub fn background_color(&self) -> Color {
         self.appearance.background_color
+    }
+
+    /// Returns the current icon [`Color`] of the [`State`].
+    pub fn icon_color(&self) -> Color {
+        self.appearance.icon_color
     }
 
     /// Returns the current text [`Color`] of the [`State`].

--- a/sctk/src/event_loop/mod.rs
+++ b/sctk/src/event_loop/mod.rs
@@ -43,11 +43,7 @@ use sctk::{
     },
     registry::RegistryState,
     seat::SeatState,
-    shell::{
-        wlr_layer::LayerShell,
-        xdg::XdgShell,
-        WaylandSurface,
-    },
+    shell::{wlr_layer::LayerShell, xdg::XdgShell, WaylandSurface},
     shm::Shm,
 };
 #[cfg(feature = "a11y")]
@@ -680,7 +676,6 @@ where
                                     let wl_surface = layer_surface.surface.wl_surface();
 
                                 if let Some(mut prev_configure) = layer_surface.last_configure.clone() {
-                                    
                                     prev_configure.new_size = (width.unwrap_or(prev_configure.new_size.0), width.unwrap_or(prev_configure.new_size.1));
                                     sticky_exit_callback(
                                         IcedSctkEvent::SctkEvent(SctkEvent::LayerSurfaceEvent { variant: LayerSurfaceEventVariant::Configure(prev_configure, wl_surface.clone(), false), id: wl_surface.clone()}),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,13 @@
 #![allow(clippy::inherent_to_string, clippy::type_complexity)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+
+#[cfg(all(not(feature = "wayland"), not(feature = "winit")))]
+compile_error!("must define `wayland` or `winit` feature");
+
+#[cfg(all(feature = "wayland", feature = "winit"))]
+compile_error!("cannot use `wayland` feature with `winit");
+
 pub use iced_futures::futures;
 use iced_widget::graphics;
 use iced_widget::renderer;

--- a/style/src/application.rs
+++ b/style/src/application.rs
@@ -18,6 +18,9 @@ pub struct Appearance {
     /// The background [`Color`] of the application.
     pub background_color: Color,
 
+    /// The default icon [`Color`] of the application.
+    pub icon_color: Color,
+
     /// The default text [`Color`] of the application.
     pub text_color: Color,
 }

--- a/style/src/button.rs
+++ b/style/src/button.rs
@@ -14,6 +14,8 @@ pub struct Appearance {
     pub border_width: f32,
     /// The border [`Color`] of the button.
     pub border_color: Color,
+    /// The icon [`Color`] of the button.
+    pub icon_color: Color,
     /// The text [`Color`] of the button.
     pub text_color: Color,
 }
@@ -26,6 +28,7 @@ impl std::default::Default for Appearance {
             border_radius: 0.0.into(),
             border_width: 0.0,
             border_color: Color::TRANSPARENT,
+            icon_color: Color::BLACK,
             text_color: Color::BLACK,
         }
     }

--- a/style/src/button.rs
+++ b/style/src/button.rs
@@ -15,7 +15,7 @@ pub struct Appearance {
     /// The border [`Color`] of the button.
     pub border_color: Color,
     /// The icon [`Color`] of the button.
-    pub icon_color: Color,
+    pub icon_color: Option<Color>,
     /// The text [`Color`] of the button.
     pub text_color: Color,
 }
@@ -28,7 +28,7 @@ impl std::default::Default for Appearance {
             border_radius: 0.0.into(),
             border_width: 0.0,
             border_color: Color::TRANSPARENT,
-            icon_color: Color::BLACK,
+            icon_color: None,
             text_color: Color::BLACK,
         }
     }

--- a/style/src/container.rs
+++ b/style/src/container.rs
@@ -4,6 +4,8 @@ use iced_core::{Background, BorderRadius, Color};
 /// The appearance of a container.
 #[derive(Debug, Clone, Copy)]
 pub struct Appearance {
+    /// The icon [`Color`] of the container.
+    pub icon_color: Option<Color>,
     /// The text [`Color`] of the container.
     pub text_color: Option<Color>,
     /// The [`Background`] of the container.
@@ -19,6 +21,7 @@ pub struct Appearance {
 impl std::default::Default for Appearance {
     fn default() -> Self {
         Self {
+            icon_color: None,
             text_color: None,
             background: None,
             border_radius: 0.0.into(),

--- a/style/src/theme.rs
+++ b/style/src/theme.rs
@@ -98,6 +98,7 @@ impl application::StyleSheet for Theme {
         match style {
             Application::Default => application::Appearance {
                 background_color: palette.background.base.color,
+                icon_color: palette.background.base.icon,
                 text_color: palette.background.base.text,
             },
             Application::Custom(custom) => custom.appearance(self),
@@ -381,6 +382,7 @@ impl container::StyleSheet for Theme {
                 let palette = self.extended_palette();
 
                 container::Appearance {
+                    icon_color: None,
                     text_color: None,
                     background: Some(palette.background.weak.color.into()),
                     border_radius: 2.0.into(),

--- a/style/src/theme/palette.rs
+++ b/style/src/theme/palette.rs
@@ -117,11 +117,14 @@ impl Extended {
     }
 }
 
-/// A pair of background and text colors.
+/// Recommended background, icon, and text [`Color`].
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Pair {
     /// The background color.
     pub color: Color,
+
+    /// The icon color, which defaults to the text color.
+    pub icon: Color,
 
     /// The text color.
     ///
@@ -134,9 +137,12 @@ pub struct Pair {
 impl Pair {
     /// Creates a new [`Pair`] from a background [`Color`] and some text [`Color`].
     pub fn new(color: Color, text: Color) -> Self {
+        let text = readable(color, text);
+
         Self {
             color,
-            text: readable(color, text),
+            icon: text,
+            text,
         }
     }
 }

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -316,7 +316,9 @@ where
             renderer,
             theme,
             &renderer::Style {
-                icon_color: styling.icon_color,
+                icon_color: styling
+                    .icon_color
+                    .unwrap_or(renderer_style.icon_color),
                 text_color: styling.text_color,
                 scale_factor: renderer_style.scale_factor,
             },

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -316,6 +316,7 @@ where
             renderer,
             theme,
             &renderer::Style {
+                icon_color: styling.icon_color,
                 text_color: styling.text_color,
                 scale_factor: renderer_style.scale_factor,
             },

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -253,6 +253,9 @@ where
             renderer,
             theme,
             &renderer::Style {
+                icon_color: style
+                    .icon_color
+                    .unwrap_or(renderer_style.text_color),
                 text_color: style
                     .text_color
                     .unwrap_or(renderer_style.text_color),

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -255,7 +255,7 @@ where
             &renderer::Style {
                 icon_color: style
                     .icon_color
-                    .unwrap_or(renderer_style.text_color),
+                    .unwrap_or(renderer_style.icon_color),
                 text_color: style
                     .text_color
                     .unwrap_or(renderer_style.text_color),

--- a/widget/src/pane_grid/title_bar.rs
+++ b/widget/src/pane_grid/title_bar.rs
@@ -133,6 +133,7 @@ where
         let bounds = layout.bounds();
         let style = theme.appearance(&self.style);
         let inherited_style = renderer::Style {
+            icon_color: style.icon_color.unwrap_or(inherited_style.icon_color),
             text_color: style.text_color.unwrap_or(inherited_style.text_color),
             scale_factor: inherited_style.scale_factor,
         };

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -748,7 +748,7 @@ pub fn update<Message>(
             match event {
                 touch::Event::FingerPressed { .. } => {
                     let Some(cursor_position) = cursor.position() else {
-                        return event::Status::Ignored
+                        return event::Status::Ignored;
                     };
 
                     state.scroll_area_touched_at = Some(cursor_position);
@@ -758,7 +758,7 @@ pub fn update<Message>(
                         state.scroll_area_touched_at
                     {
                         let Some(cursor_position) = cursor.position() else {
-                            return event::Status::Ignored
+                            return event::Status::Ignored;
                         };
 
                         let delta = Vector::new(
@@ -803,7 +803,7 @@ pub fn update<Message>(
             | Event::Touch(touch::Event::FingerMoved { .. }) => {
                 if let Some(scrollbar) = scrollbars.y {
                     let Some(cursor_position) = cursor.position() else {
-                        return event::Status::Ignored
+                        return event::Status::Ignored;
                     };
 
                     state.scroll_y_to(
@@ -833,7 +833,7 @@ pub fn update<Message>(
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
             | Event::Touch(touch::Event::FingerPressed { .. }) => {
                 let Some(cursor_position) = cursor.position() else {
-                    return event::Status::Ignored
+                    return event::Status::Ignored;
                 };
 
                 if let (Some(scroller_grabbed_at), Some(scrollbar)) =
@@ -877,7 +877,7 @@ pub fn update<Message>(
             Event::Mouse(mouse::Event::CursorMoved { .. })
             | Event::Touch(touch::Event::FingerMoved { .. }) => {
                 let Some(cursor_position) = cursor.position() else {
-                    return event::Status::Ignored
+                    return event::Status::Ignored;
                 };
 
                 if let Some(scrollbar) = scrollbars.x {
@@ -908,7 +908,7 @@ pub fn update<Message>(
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
             | Event::Touch(touch::Event::FingerPressed { .. }) => {
                 let Some(cursor_position) = cursor.position() else {
-                    return event::Status::Ignored
+                    return event::Status::Ignored;
                 };
 
                 if let (Some(scroller_grabbed_at), Some(scrollbar)) =

--- a/widget/src/svg.rs
+++ b/widget/src/svg.rs
@@ -39,6 +39,7 @@ where
     width: Length,
     height: Length,
     content_fit: ContentFit,
+    symbolic: bool,
     style: <Renderer::Theme as StyleSheet>::Style,
     _phantom_data: std::marker::PhantomData<&'a ()>,
 }
@@ -62,6 +63,7 @@ where
             width: Length::Fill,
             height: Length::Shrink,
             content_fit: ContentFit::Contain,
+            symbolic: false,
             style: Default::default(),
             _phantom_data: std::marker::PhantomData,
         }
@@ -97,6 +99,13 @@ where
             content_fit,
             ..self
         }
+    }
+
+    /// Symbolic icons inherit their color from the renderer if a color is not defined.
+    #[must_use]
+    pub fn symbolic(mut self, symbolic: bool) -> Self {
+        self.symbolic = symbolic;
+        self
     }
 
     /// Sets the style variant of this [`Svg`].
@@ -196,7 +205,7 @@ where
         _state: &Tree,
         renderer: &mut Renderer,
         theme: &Renderer::Theme,
-        _style: &renderer::Style,
+        style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
         _viewport: &Rectangle,
@@ -219,7 +228,10 @@ where
                 ..bounds
             };
 
-            let appearance = theme.appearance(&self.style);
+            let mut appearance = theme.appearance(&self.style);
+            if self.symbolic && appearance.color.is_none() {
+                appearance.color = Some(style.icon_color);
+            }
 
             renderer.draw(
                 self.handle.clone(),

--- a/widget/src/text_input/text_input.rs
+++ b/widget/src/text_input/text_input.rs
@@ -668,7 +668,9 @@ where
             let state = state();
 
             if let Some(focus) = &mut state.is_focused {
-                let Some(on_input) = on_input else { return event::Status::Ignored };
+                let Some(on_input) = on_input else {
+                    return event::Status::Ignored;
+                };
 
                 if state.is_pasting.is_none()
                     && !state.keyboard_modifiers.command()
@@ -691,7 +693,9 @@ where
             let state = state();
 
             if let Some(focus) = &mut state.is_focused {
-                let Some(on_input) = on_input else { return event::Status::Ignored };
+                let Some(on_input) = on_input else {
+                    return event::Status::Ignored;
+                };
 
                 let modifiers = state.keyboard_modifiers;
                 focus.updated_at = Instant::now();

--- a/widget/src/text_input/text_input_wayland.rs
+++ b/widget/src/text_input/text_input_wayland.rs
@@ -890,7 +890,9 @@ where
             let state = state();
 
             if let Some(focus) = &mut state.is_focused {
-                let Some(on_input) = on_input else { return event::Status::Ignored };
+                let Some(on_input) = on_input else {
+                    return event::Status::Ignored;
+                };
 
                 if state.is_pasting.is_none()
                     && !state.keyboard_modifiers.command()
@@ -913,7 +915,9 @@ where
             let state = state();
 
             if let Some(focus) = &mut state.is_focused {
-                let Some(on_input) = on_input else { return event::Status::Ignored };
+                let Some(on_input) = on_input else {
+                    return event::Status::Ignored;
+                };
 
                 let modifiers = state.keyboard_modifiers;
                 focus.updated_at = Instant::now();

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -420,6 +420,7 @@ where
         container::draw_background(renderer, &style, layout.bounds());
 
         let defaults = renderer::Style {
+            icon_color: inherited_style.icon_color,
             text_color: style.text_color.unwrap_or(inherited_style.text_color),
             scale_factor: inherited_style.scale_factor,
         };

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -517,6 +517,7 @@ async fn run_instance<A, E, C>(
                     &mut renderer,
                     state.theme(),
                     &renderer::Style {
+                        icon_color: state.icon_color(),
                         text_color: state.text_color(),
                         scale_factor: state.scale_factor(),
                     },
@@ -682,6 +683,7 @@ async fn run_instance<A, E, C>(
                         &mut renderer,
                         state.theme(),
                         &renderer::Style {
+                            icon_color: state.icon_color(),
                             text_color: state.text_color(),
                             scale_factor: state.scale_factor(),
                         },

--- a/winit/src/application/state.rs
+++ b/winit/src/application/state.rs
@@ -121,6 +121,11 @@ where
         self.appearance.background_color
     }
 
+    /// Returns the current icon [`Color`] of the [`State`].
+    pub fn icon_color(&self) -> Color {
+        self.appearance.icon_color
+    }
+
     /// Returns the current text [`Color`] of the [`State`].
     pub fn text_color(&self) -> Color {
         self.appearance.text_color


### PR DESCRIPTION
Adds a new field to the renderer style to support defining a default icon color for symbolic icons. By default, this color will be set to the same value as the text color for maximum visibility. The color may be overridden by the button or container that it is placed in. Icons marked as symbolic will opt into this color if no color was defined.

Merge with https://github.com/pop-os/libcosmic/pull/150