### PR TITLE
fix: default to ControlFlow::Wait for applications with no surface

### DIFF
--- a/sctk/src/application.rs
+++ b/sctk/src/application.rs
@@ -946,6 +946,7 @@ where
                     if application.should_exit() {
                         break 'main;
                     }
+                    let _ = control_sender.start_send(ControlFlow::Wait);
                 } else {
                     let mut needs_update = false;
 


### PR DESCRIPTION
this seems to help CPU usage for app library and launcher