### PR TITLE
sctk: Add support for `ext-session-lock` protocol

### DIFF
--- a/core/src/event/wayland/mod.rs
+++ b/core/src/event/wayland/mod.rs
@@ -3,6 +3,7 @@ mod layer;
 mod output;
 mod popup;
 mod seat;
+mod session_lock;
 mod window;
 
 use crate::{time::Instant, window::Id};
@@ -15,6 +16,7 @@ pub use layer::*;
 pub use output::*;
 pub use popup::*;
 pub use seat::*;
+pub use session_lock::*;
 pub use window::*;
 
 /// wayland events
@@ -36,6 +38,8 @@ pub enum Event {
     DndOffer(DndOfferEvent),
     /// Selection Offer events
     SelectionOffer(SelectionOfferEvent),
+    /// Session lock events
+    SessionLock(SessionLockEvent),
     /// Frame events
     Frame(Instant, WlSurface, Id),
 }

--- a/core/src/event/wayland/session_lock.rs
+++ b/core/src/event/wayland/session_lock.rs
@@ -1,0 +1,19 @@
+use crate::window::Id;
+use sctk::reexports::client::protocol::wl_surface::WlSurface;
+
+/// session lock events
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionLockEvent {
+    /// Compositor has activated lock
+    Locked,
+    /// Lock rejected / canceled by compositor
+    Finished,
+    /// Session lock protocol not supported
+    NotSupported,
+    /// Session lock surface focused
+    Focused(WlSurface, Id),
+    /// Session lock surface unfocused
+    Unfocused(WlSurface, Id),
+    /// Session unlock has been processed by server
+    Unlocked,
+}

--- a/examples/sctk_session_lock/Cargo.toml
+++ b/examples/sctk_session_lock/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sctk_session_lock"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sctk = { package = "smithay-client-toolkit", git = "https://github.com/smithay/client-toolkit", rev = "828b1eb" }
+iced = { path = "../..", default-features = false,  features = ["async-std", "wayland", "debug", "a11y"] }
+iced_runtime = { path = "../../runtime" }
+env_logger = "0.10"
+async-std = "1.0"

--- a/examples/sctk_session_lock/src/main.rs
+++ b/examples/sctk_session_lock/src/main.rs
@@ -1,0 +1,117 @@
+use iced::wayland::session_lock;
+use iced::{
+    event::wayland::{Event as WaylandEvent, OutputEvent, SessionLockEvent},
+    wayland::InitialSurface,
+    widget::text,
+    window, Application, Command, Element, Subscription, Theme,
+};
+use iced_runtime::window::Id as SurfaceId;
+
+fn main() {
+    let mut settings = iced::Settings::default();
+    settings.initial_surface = InitialSurface::None;
+    Locker::run(settings).unwrap();
+}
+
+#[derive(Debug, Clone, Default)]
+struct Locker {
+    max_surface_id: u128,
+    exit: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    WaylandEvent(WaylandEvent),
+    TimeUp,
+    Ignore,
+}
+
+impl Locker {
+    fn next_surface_id(&mut self) -> SurfaceId {
+        self.max_surface_id += 1;
+        SurfaceId(self.max_surface_id)
+    }
+}
+
+impl Application for Locker {
+    type Executor = iced::executor::Default;
+    type Message = Message;
+    type Flags = ();
+    type Theme = Theme;
+
+    fn new(_flags: ()) -> (Locker, Command<Self::Message>) {
+        (
+            Locker {
+                ..Locker::default()
+            },
+            session_lock::lock(),
+        )
+    }
+
+    fn title(&self) -> String {
+        String::from("Locker")
+    }
+
+    fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
+        match message {
+            Message::WaylandEvent(evt) => match evt {
+                WaylandEvent::Output(evt, output) => match evt {
+                    OutputEvent::Created(_) => {
+                        return session_lock::get_lock_surface(
+                            self.next_surface_id(),
+                            output,
+                        );
+                    }
+                    OutputEvent::Removed => {}
+                    _ => {}
+                },
+                WaylandEvent::SessionLock(evt) => match evt {
+                    SessionLockEvent::Locked => {
+                        return iced::Command::perform(
+                            async_std::task::sleep(
+                                std::time::Duration::from_secs(5),
+                            ),
+                            |_| Message::TimeUp,
+                        );
+                    }
+                    SessionLockEvent::Unlocked => {
+                        // Server has processed unlock, so it's safe to exit
+                        self.exit = true;
+                    }
+                    _ => {}
+                },
+                _ => {}
+            },
+            Message::TimeUp => {
+                return session_lock::unlock();
+            }
+            Message::Ignore => {}
+        }
+        Command::none()
+    }
+
+    fn should_exit(&self) -> bool {
+        self.exit
+    }
+
+    fn view(&self, id: window::Id) -> Element<Self::Message> {
+        text(format!("Lock Surface {:?}", id)).into()
+    }
+
+    fn subscription(&self) -> Subscription<Self::Message> {
+        iced::subscription::events_with(|evt, _| {
+            if let iced::Event::PlatformSpecific(
+                iced::event::PlatformSpecific::Wayland(evt),
+            ) = evt
+            {
+                Some(Message::WaylandEvent(evt))
+            } else {
+                None
+            }
+        })
+    }
+
+    fn close_requested(&self, _id: window::Id) -> Self::Message {
+        Message::Ignore
+    }
+}

--- a/runtime/src/command/platform_specific/wayland/mod.rs
+++ b/runtime/src/command/platform_specific/wayland/mod.rs
@@ -10,6 +10,8 @@ pub mod data_device;
 pub mod layer_surface;
 /// popup actions
 pub mod popup;
+/// session locks
+pub mod session_lock;
 /// window actions
 pub mod window;
 
@@ -25,6 +27,8 @@ pub enum Action<T> {
     DataDevice(data_device::Action<T>),
     /// activation
     Activation(activation::Action<T>),
+    /// session lock
+    SessionLock(session_lock::Action<T>),
 }
 
 impl<T> Action<T> {
@@ -43,6 +47,7 @@ impl<T> Action<T> {
             Action::Popup(a) => Action::Popup(a.map(f)),
             Action::DataDevice(a) => Action::DataDevice(a.map(f)),
             Action::Activation(a) => Action::Activation(a.map(f)),
+            Action::SessionLock(a) => Action::SessionLock(a.map(f)),
         }
     }
 }
@@ -60,6 +65,9 @@ impl<T> Debug for Action<T> {
             }
             Self::Activation(arg0) => {
                 f.debug_tuple("Activation").field(arg0).finish()
+            }
+            Self::SessionLock(arg0) => {
+                f.debug_tuple("SessionLock").field(arg0).finish()
             }
         }
     }

--- a/runtime/src/command/platform_specific/wayland/session_lock.rs
+++ b/runtime/src/command/platform_specific/wayland/session_lock.rs
@@ -1,0 +1,80 @@
+use std::{fmt, marker::PhantomData};
+
+use iced_core::window::Id;
+use iced_futures::MaybeSend;
+
+use sctk::reexports::client::protocol::wl_output::WlOutput;
+
+/// Session lock action
+#[derive(Clone)]
+pub enum Action<T> {
+    /// Request a session lock
+    Lock,
+    /// Destroy lock
+    Unlock,
+    /// Create lock surface for output
+    LockSurface {
+        /// unique id for surface
+        id: Id,
+        /// output
+        output: WlOutput,
+        /// phantom
+        _phantom: PhantomData<T>,
+    },
+    /// Destroy lock surface
+    DestroyLockSurface {
+        /// unique id for surface
+        id: Id,
+    },
+}
+
+impl<T> Action<T> {
+    /// Maps the output of a window [`Action`] using the provided closure.
+    pub fn map<A>(
+        self,
+        _: impl Fn(T) -> A + 'static + MaybeSend + Sync,
+    ) -> Action<A>
+    where
+        T: 'static,
+    {
+        match self {
+            Action::Lock => Action::Lock,
+            Action::Unlock => Action::Unlock,
+            Action::LockSurface {
+                id,
+                output,
+                _phantom,
+            } => Action::LockSurface {
+                id,
+                output,
+                _phantom: PhantomData,
+            },
+            Action::DestroyLockSurface { id } => {
+                Action::DestroyLockSurface { id }
+            }
+        }
+    }
+}
+
+impl<T> fmt::Debug for Action<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Action::Lock => write!(f, "Action::SessionLock::Lock"),
+            Action::Unlock => write!(f, "Action::SessionLock::Unlock"),
+            Action::LockSurface {
+                id,
+                output,
+                _phantom,
+            } => write!(
+                f,
+                "Action::SessionLock::LockSurface {{ id: {:?}, output: {:?} }}",
+                id, output
+            ),
+            Action::DestroyLockSurface { id } => write!(
+                f,
+                "Action::SessionLock::DestroyLockSurface {{ id: {:?} }}",
+                id
+            ),
+        }
+    }
+}

--- a/sctk/src/commands/mod.rs
+++ b/sctk/src/commands/mod.rs
@@ -4,4 +4,5 @@ pub mod activation;
 pub mod data_device;
 pub mod layer_surface;
 pub mod popup;
+pub mod session_lock;
 pub mod window;

--- a/sctk/src/commands/session_lock.rs
+++ b/sctk/src/commands/session_lock.rs
@@ -1,0 +1,48 @@
+use iced_runtime::command::Command;
+use iced_runtime::command::{
+    self,
+    platform_specific::{self, wayland},
+};
+use iced_runtime::window::Id as SurfaceId;
+use sctk::reexports::client::protocol::wl_output::WlOutput;
+
+use std::marker::PhantomData;
+
+pub fn lock<Message>() -> Command<Message> {
+    Command::single(command::Action::PlatformSpecific(
+        platform_specific::Action::Wayland(wayland::Action::SessionLock(
+            wayland::session_lock::Action::Lock,
+        )),
+    ))
+}
+
+pub fn unlock<Message>() -> Command<Message> {
+    Command::single(command::Action::PlatformSpecific(
+        platform_specific::Action::Wayland(wayland::Action::SessionLock(
+            wayland::session_lock::Action::Unlock,
+        )),
+    ))
+}
+
+pub fn get_lock_surface<Message>(
+    id: SurfaceId,
+    output: WlOutput,
+) -> Command<Message> {
+    Command::single(command::Action::PlatformSpecific(
+        platform_specific::Action::Wayland(wayland::Action::SessionLock(
+            wayland::session_lock::Action::LockSurface {
+                id,
+                output,
+                _phantom: PhantomData,
+            },
+        )),
+    ))
+}
+
+pub fn destroy_lock_surface<Message>(id: SurfaceId) -> Command<Message> {
+    Command::single(command::Action::PlatformSpecific(
+        platform_specific::Action::Wayland(wayland::Action::SessionLock(
+            wayland::session_lock::Action::DestroyLockSurface { id },
+        )),
+    ))
+}

--- a/sctk/src/event_loop/mod.rs
+++ b/sctk/src/event_loop/mod.rs
@@ -43,6 +43,7 @@ use sctk::{
     },
     registry::RegistryState,
     seat::SeatState,
+    session_lock::SessionLockState,
     shell::{wlr_layer::LayerShell, xdg::XdgShell, WaylandSurface},
     shm::Shm,
 };
@@ -125,7 +126,8 @@ where
                 calloop::channel::Event::Closed => {}
             })
             .unwrap();
-        let wayland_source = WaylandSource::new(connection, event_queue);
+        let wayland_source =
+            WaylandSource::new(connection.clone(), event_queue);
 
         let wayland_dispatcher = calloop::Dispatcher::new(
             wayland_source,
@@ -166,6 +168,7 @@ where
             event_loop,
             wayland_dispatcher,
             state: SctkState {
+                connection,
                 registry_state,
                 seat_state: SeatState::new(&globals, &qh),
                 output_state: OutputState::new(&globals, &qh),
@@ -181,6 +184,8 @@ where
                 )
                 .expect("data device manager is not available"),
                 activation_state: ActivationState::bind(&globals, &qh).ok(),
+                session_lock_state: SessionLockState::new(&globals, &qh),
+                session_lock: None,
 
                 queue_handle: qh,
                 loop_handle,
@@ -192,6 +197,7 @@ where
                 windows: Vec::new(),
                 layer_surfaces: Vec::new(),
                 popups: Vec::new(),
+                lock_surfaces: Vec::new(),
                 dnd_source: None,
                 _kbd_focus: None,
                 sctk_events: Vec::new(),
@@ -1262,6 +1268,45 @@ where
                             }
                         },
                     },
+                    Event::SessionLock(action) => match action {
+                        platform_specific::wayland::session_lock::Action::Lock => {
+                            if self.state.session_lock.is_none() {
+                                // TODO send message on error? When protocol doesn't exist.
+                                self.state.session_lock = self.state.session_lock_state.lock(&self.state.queue_handle).ok();
+                            }
+                        }
+                        platform_specific::wayland::session_lock::Action::Unlock => {
+                            self.state.session_lock.take();
+                            // Make sure server processes unlock before client exits
+                            let _ = self.state.connection.roundtrip();
+                            sticky_exit_callback(
+                                IcedSctkEvent::SctkEvent(SctkEvent::SessionUnlocked),
+                                &self.state,
+                                &mut control_flow,
+                                &mut callback,
+                            );
+                        }
+                        platform_specific::wayland::session_lock::Action::LockSurface { id, output, _phantom } => {
+                            // TODO how to handle this when there's no lock?
+                            if let Some(surface) = self.state.get_lock_surface(id, &output) {
+                                sticky_exit_callback(
+                                    IcedSctkEvent::SctkEvent(SctkEvent::SessionLockSurfaceCreated {surface, native_id: id}),
+                                    &self.state,
+                                    &mut control_flow,
+                                    &mut callback,
+                                );
+                            }
+                        }
+                        platform_specific::wayland::session_lock::Action::DestroyLockSurface { id } => {
+                            if let Some(i) =
+                                self.state.lock_surfaces.iter().position(|s| {
+                                    s.id == id
+                                })
+                            {
+                                self.state.lock_surfaces.remove(i);
+                            }
+                        }
+                    }
                 }
             }
 

--- a/sctk/src/handlers/mod.rs
+++ b/sctk/src/handlers/mod.rs
@@ -4,6 +4,7 @@ pub mod compositor;
 pub mod data_device;
 pub mod output;
 pub mod seat;
+pub mod session_lock;
 pub mod shell;
 pub mod wp_fractional_scaling;
 pub mod wp_viewporter;

--- a/sctk/src/handlers/session_lock.rs
+++ b/sctk/src/handlers/session_lock.rs
@@ -1,0 +1,57 @@
+use crate::{handlers::SctkState, sctk_event::SctkEvent};
+use sctk::{
+    delegate_session_lock,
+    reexports::client::{Connection, QueueHandle},
+    session_lock::{
+        SessionLock, SessionLockHandler, SessionLockSurface,
+        SessionLockSurfaceConfigure,
+    },
+};
+use std::fmt::Debug;
+
+impl<T: 'static + Debug> SessionLockHandler for SctkState<T> {
+    fn locked(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _session_lock: SessionLock,
+    ) {
+        self.sctk_events.push(SctkEvent::SessionLocked);
+    }
+
+    fn finished(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _session_lock: SessionLock,
+    ) {
+        self.sctk_events.push(SctkEvent::SessionLockFinished);
+    }
+
+    fn configure(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        session_lock_surface: SessionLockSurface,
+        configure: SessionLockSurfaceConfigure,
+        _serial: u32,
+    ) {
+        let lock_surface = match self.lock_surfaces.iter_mut().find(|s| {
+            s.session_lock_surface.wl_surface()
+                == session_lock_surface.wl_surface()
+        }) {
+            Some(l) => l,
+            None => return,
+        };
+        let first = lock_surface.last_configure.is_none();
+        lock_surface.last_configure.replace(configure.clone());
+        self.sctk_events
+            .push(SctkEvent::SessionLockSurfaceConfigure {
+                surface: session_lock_surface.wl_surface().clone(),
+                configure,
+                first,
+            });
+    }
+}
+
+delegate_session_lock!(@<T: 'static + Debug> SctkState<T>);


### PR DESCRIPTION
The example creates a session lock surface, but doesn't currently show the contents of the surface correctly. Still figuring that part out. Then some of the smaller details will need some care (making sure to not exit without a round trip, handling the compositor refusing to create lock, etc.)