### PR TITLE
Detect mouse side buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Detect mouse side buttons.
 
 Many thanks to...
+- @edfloreshz
 - @jackpot51
 - @wash2
 

--- a/core/src/mouse/button.rs
+++ b/core/src/mouse/button.rs
@@ -10,6 +10,12 @@ pub enum Button {
     /// The middle (wheel) button.
     Middle,
 
+    /// The side button often used as "back" in web browsers.
+    Back,
+
+    /// The side button often used as "forward" in web browsers.
+    Forward,
+
     /// Some other button.
     Other(u16),
 }

--- a/sctk/src/conversion.rs
+++ b/sctk/src/conversion.rs
@@ -9,7 +9,10 @@ use sctk::{
     reexports::client::protocol::wl_pointer::AxisSource,
     seat::{
         keyboard::Modifiers,
-        pointer::{AxisScroll, CursorIcon, BTN_LEFT, BTN_MIDDLE, BTN_RIGHT},
+        pointer::{
+            AxisScroll, CursorIcon, BTN_EXTRA, BTN_LEFT, BTN_MIDDLE, BTN_RIGHT,
+            BTN_SIDE,
+        },
     },
 };
 use xkeysym::{key, RawKeysym};
@@ -83,6 +86,10 @@ pub fn pointer_button_to_native(button: u32) -> Option<mouse::Button> {
         Some(mouse::Button::Right)
     } else if button == BTN_MIDDLE {
         Some(mouse::Button::Middle)
+    } else if button == BTN_SIDE {
+        Some(mouse::Button::Back)
+    } else if button == BTN_EXTRA {
+        Some(mouse::Button::Forward)
     } else {
         button.try_into().ok().map(mouse::Button::Other)
     }

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -278,6 +278,8 @@ pub fn mouse_button(mouse_button: winit::event::MouseButton) -> mouse::Button {
         winit::event::MouseButton::Left => mouse::Button::Left,
         winit::event::MouseButton::Right => mouse::Button::Right,
         winit::event::MouseButton::Middle => mouse::Button::Middle,
+        winit::event::MouseButton::Back => mouse::Button::Back,
+        winit::event::MouseButton::Forward => mouse::Button::Forward,
         winit::event::MouseButton::Other(other) => mouse::Button::Other(other),
     }
 }


### PR DESCRIPTION
This PR allows iced to detect back and forward side buttons for mouse devices that supports them, this includes:
- The fourth non-scroll button, which is often used as "back" in web browsers.
- The fifth non-scroll button, which is often used as "forward" in web browsers.