### PR TITLE
refactor: use iced clipboard for interacting with the selection

### DIFF
--- a/runtime/src/command/platform_specific/wayland/data_device.rs
+++ b/runtime/src/command/platform_specific/wayland/data_device.rs
@@ -34,21 +34,6 @@ pub trait DataFromMimeType {
 
 /// DataDevice Action
 pub enum ActionInner {
-    /// Indicate that you are setting the selection and will respond to events
-    /// with data of the advertised mime types.
-    SetSelection {
-        /// The mime types that the selection can be converted to.
-        mime_types: Vec<String>,
-        /// The data to send.
-        data: Box<dyn DataFromMimeType + Send + Sync>,
-    },
-    /// Unset the selection.
-    UnsetSelection,
-    /// Request the selection data from the clipboard.
-    RequestSelectionData {
-        /// The mime type that the selection should be converted to.
-        mime_type: String,
-    },
     /// Start a drag and drop operation. When a client asks for the selection, an event will be delivered
     /// This is used for internal drags, where the client is the source of the drag.
     /// The client will be resposible for data transfer.
@@ -115,13 +100,6 @@ impl fmt::Debug for ActionInner {
         match self {
             Self::Accept(mime_type) => {
                 f.debug_tuple("Accept").field(mime_type).finish()
-            }
-            Self::SetSelection { mime_types, .. } => {
-                f.debug_tuple("SetSelection").field(mime_types).finish()
-            }
-            Self::UnsetSelection => f.debug_tuple("UnsetSelection").finish(),
-            Self::RequestSelectionData { mime_type } => {
-                f.debug_tuple("RequestSelection").field(mime_type).finish()
             }
             Self::StartInternalDnd { origin_id, icon_id } => f
                 .debug_tuple("StartInternalDnd")

--- a/sctk/src/application.rs
+++ b/sctk/src/application.rs
@@ -368,6 +368,7 @@ where
 
     let mut states: HashMap<SurfaceId, State<A>> = HashMap::new();
     let mut interfaces = ManuallyDrop::new(HashMap::new());
+    let mut simple_clipboard = Clipboard::unconnected();
 
     {
         run_command(
@@ -382,6 +383,7 @@ where
             || compositor.fetch_information(),
             &mut auto_size_surfaces,
             &mut Vec::new(),
+            &mut simple_clipboard,
         );
     }
     runtime.track(
@@ -419,7 +421,6 @@ where
     let mut mods: Modifiers = Modifiers::default();
     let mut destroyed_surface_ids: HashMap<ObjectId, SurfaceIdWrapper> =
         Default::default();
-    let mut simple_clipboard = Clipboard::unconnected();
 
     'main: while let Some(event) = receiver.next().await {
         match event {
@@ -937,6 +938,7 @@ where
                         &mut Vec::new(),
                         || compositor.fetch_information(),
                         &mut auto_size_surfaces,
+                        &mut simple_clipboard,
                     );
 
                     interfaces = ManuallyDrop::new(build_user_interfaces(
@@ -1101,6 +1103,7 @@ where
                                 &mut actions,
                                 || compositor.fetch_information(),
                                 &mut auto_size_surfaces,
+                                &mut simple_clipboard,
                             );
 
                             pure_states.insert(surface_id.inner(), cache);
@@ -1789,6 +1792,7 @@ pub(crate) fn update<A, E, C>(
         SurfaceIdWrapper,
         (u32, u32, Limits, bool),
     >,
+    clipboard: &mut Clipboard,
 ) where
     A: Application + 'static,
     E: Executor + 'static,
@@ -1808,6 +1812,7 @@ pub(crate) fn update<A, E, C>(
             debug,
             graphics_info,
             auto_size_surfaces,
+            clipboard,
         ) {
             actions.push(a);
         }
@@ -1831,6 +1836,7 @@ pub(crate) fn update<A, E, C>(
             graphics_info,
             auto_size_surfaces,
             actions,
+            clipboard,
         )
     }
 
@@ -1860,6 +1866,7 @@ fn run_command<A, E>(
         (u32, u32, Limits, bool),
     >,
     actions: &mut Vec<command::Action<A::Message>>,
+    clipboard: &mut Clipboard,
 ) where
     A: Application,
     E: Executor,
@@ -1877,6 +1884,7 @@ fn run_command<A, E>(
             debug,
             graphics_info,
             auto_size_surfaces,
+            clipboard,
         ) {
             actions.push(a);
         }
@@ -1897,6 +1905,7 @@ fn handle_actions<A, E>(
         SurfaceIdWrapper,
         (u32, u32, Limits, bool),
     >,
+    clipboard: &mut Clipboard,
 ) -> Option<command::Action<A::Message>>
 where
     A: Application,
@@ -1911,11 +1920,17 @@ where
                     })));
             }
             command::Action::Clipboard(action) => match action {
-                clipboard::Action::Read(..) => {
-                    todo!();
+                clipboard::Action::Read(s_to_msg) => {
+                    if matches!(clipboard.state,  crate::clipboard::State::Connected(_)) {
+                        let contents = clipboard.read();
+                        let message = s_to_msg(contents);
+                        proxy.send_event(Event::Message(message));
+                    }
                 }
-                clipboard::Action::Write(..) => {
-                    todo!();
+                clipboard::Action::Write(contents) => {
+                    if matches!(clipboard.state,  crate::clipboard::State::Connected(_)) {
+                        clipboard.write(contents)
+                    }
                 }
             },
             command::Action::Window(..) => {
@@ -2142,7 +2157,6 @@ fn event_is_for_surface(
         | SctkEvent::RemovedOutput(_) => false,
         SctkEvent::ScaleFactorChanged { id, .. } => &id.id() == object_id,
         SctkEvent::DndOffer { surface, .. } => &surface.id() == object_id,
-        SctkEvent::SelectionOffer(_) => true,
         SctkEvent::DataSource(_) => true,
     }
 }

--- a/sctk/src/commands/data_device.rs
+++ b/sctk/src/commands/data_device.rs
@@ -15,45 +15,6 @@ use iced_runtime::{
 };
 use sctk::reexports::client::protocol::wl_data_device_manager::DndAction;
 
-/// Set the selection. When a client asks for the selection, an event will be delivered to the
-/// client with the fd to write the data to.
-pub fn set_selection<Message>(
-    mime_types: Vec<String>,
-    data: Box<dyn DataFromMimeType + Send + Sync>,
-) -> Command<Message> {
-    Command::single(command::Action::PlatformSpecific(
-        platform_specific::Action::Wayland(wayland::Action::DataDevice(
-            wayland::data_device::ActionInner::SetSelection {
-                mime_types,
-                data,
-            }
-            .into(),
-        )),
-    ))
-}
-
-/// unset the selection
-pub fn unset_selection<Message>() -> Command<Message> {
-    Command::single(command::Action::PlatformSpecific(
-        platform_specific::Action::Wayland(wayland::Action::DataDevice(
-            wayland::data_device::ActionInner::UnsetSelection.into(),
-        )),
-    ))
-}
-
-/// request the selection
-/// This will trigger an event with a read pipe to read the data from.
-pub fn request_selection<Message>(mime_type: String) -> Command<Message> {
-    Command::single(command::Action::PlatformSpecific(
-        platform_specific::Action::Wayland(wayland::Action::DataDevice(
-            wayland::data_device::ActionInner::RequestSelectionData {
-                mime_type,
-            }
-            .into(),
-        )),
-    ))
-}
-
 /// start an internal drag and drop operation. Events will only be delivered to the same client.
 /// The client is responsible for data transfer.
 pub fn start_internal_drag<Message>(

--- a/sctk/src/event_loop/state.rs
+++ b/sctk/src/event_loop/state.rs
@@ -33,10 +33,8 @@ use sctk::{
     activation::ActivationState,
     compositor::CompositorState,
     data_device_manager::{
-        data_device::DataDevice,
-        data_offer::{DragOffer, SelectionOffer},
-        data_source::{CopyPasteSource, DragSource},
-        DataDeviceManagerState, WritePipe,
+        data_device::DataDevice, data_offer::DragOffer,
+        data_source::DragSource, DataDeviceManagerState, WritePipe,
     },
     error::GlobalError,
     output::OutputState,
@@ -234,12 +232,6 @@ impl<T> Debug for Dnd<T> {
 }
 
 #[derive(Debug)]
-pub struct SctkSelectionOffer {
-    pub(crate) offer: SelectionOffer,
-    pub(crate) cur_read: Option<(String, Vec<u8>, RegistrationToken)>,
-}
-
-#[derive(Debug)]
 pub struct SctkDragOffer {
     pub(crate) dropped: bool,
     pub(crate) offer: DragOffer,
@@ -252,25 +244,6 @@ pub struct SctkPopupData {
     pub(crate) parent: SctkSurface,
     pub(crate) toplevel: WlSurface,
     pub(crate) positioner: XdgPositioner,
-}
-
-pub struct SctkCopyPasteSource {
-    pub accepted_mime_types: Vec<String>,
-    pub source: CopyPasteSource,
-    pub data: Box<dyn DataFromMimeType>,
-    pub(crate) pipe: Option<WritePipe>,
-    pub(crate) cur_write: Option<(Vec<u8>, usize, RegistrationToken)>,
-}
-
-impl Debug for SctkCopyPasteSource {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("SctkCopyPasteSource")
-            .field(&self.accepted_mime_types)
-            .field(&self.source)
-            .field(&self.pipe)
-            .field(&self.cur_write)
-            .finish()
-    }
 }
 
 /// Wrapper to carry sctk state.
@@ -302,9 +275,7 @@ pub struct SctkState<T> {
     pub compositor_updates: Vec<SctkEvent>,
 
     /// data data_device
-    pub(crate) selection_source: Option<SctkCopyPasteSource>,
     pub(crate) dnd_offer: Option<SctkDragOffer>,
-    pub(crate) selection_offer: Option<SctkSelectionOffer>,
     pub(crate) _accept_counter: u32,
     /// A sink for window and device events that is being filled during dispatching
     /// event loop and forwarded downstream afterwards.

--- a/sctk/src/handlers/data_device/data_device.rs
+++ b/sctk/src/handlers/data_device/data_device.rs
@@ -6,7 +6,7 @@ use sctk::{
 };
 
 use crate::{
-    event_loop::state::{SctkDragOffer, SctkSelectionOffer, SctkState},
+    event_loop::state::{SctkDragOffer, SctkState},
     sctk_event::{DndOfferEvent, SctkEvent},
 };
 
@@ -100,28 +100,9 @@ impl<T> DataDeviceHandler for SctkState<T> {
         &mut self,
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
-        wl_data_device: &wl_data_device::WlDataDevice,
+        _wl_data_device: &wl_data_device::WlDataDevice,
     ) {
-        let data_device = if let Some(seat) = self
-            .seats
-            .iter()
-            .find(|s| s.data_device.inner() == wl_data_device)
-        {
-            &seat.data_device
-        } else {
-            return;
-        };
-
-        if let Some(offer) = data_device.data().selection_offer() {
-            let mime_types = offer.with_mime_types(|types| types.to_vec());
-            self.sctk_events.push(SctkEvent::SelectionOffer(
-                crate::sctk_event::SelectionOfferEvent::Offer(mime_types),
-            ));
-            self.selection_offer = Some(SctkSelectionOffer {
-                offer: offer.clone(),
-                cur_read: None,
-            });
-        }
+        // not handled here
     }
 
     fn drop_performed(

--- a/sctk/src/sctk_event.rs
+++ b/sctk/src/sctk_event.rs
@@ -189,7 +189,6 @@ pub enum SctkEvent {
         event: DndOfferEvent,
         surface: WlSurface,
     },
-    SelectionOffer(SelectionOfferEvent),
 }
 
 #[derive(Debug, Clone)]
@@ -212,19 +211,6 @@ pub enum DataSourceEvent {
     /// Send the DnD data to the destination.
     SendDndData {
         /// The mime type of the data to be sent
-        mime_type: String,
-    },
-}
-
-#[derive(Debug, Clone)]
-pub enum SelectionOfferEvent {
-    /// A Selection offer has been introduced with the given mime types.
-    Offer(Vec<String>),
-    /// Read the selection data from the clipboard.
-    Data {
-        /// The raww data
-        data: Vec<u8>,
-        /// mime type of the data to read
         mime_type: String,
     },
 }
@@ -852,38 +838,6 @@ impl SctkEvent {
                         PlatformSpecific::Wayland(wayland::Event::DndOffer(
                             wayland::DndOfferEvent::SelectedAction(action),
                         )),
-                    ))
-                    .into_iter()
-                    .collect()
-                }
-            },
-            SctkEvent::SelectionOffer(so) => match so {
-                SelectionOfferEvent::Offer(mime_types) => {
-                    Some(iced_runtime::core::Event::PlatformSpecific(
-                        PlatformSpecific::Wayland(
-                            wayland::Event::SelectionOffer(
-                                wayland::SelectionOfferEvent::Offer(
-                                    mime_types
-                                        .iter()
-                                        .map(|m| m.to_string())
-                                        .collect(),
-                                ),
-                            ),
-                        ),
-                    ))
-                    .into_iter()
-                    .collect()
-                }
-                SelectionOfferEvent::Data { mime_type, data } => {
-                    Some(iced_runtime::core::Event::PlatformSpecific(
-                        PlatformSpecific::Wayland(
-                            wayland::Event::SelectionOffer(
-                                wayland::SelectionOfferEvent::Data {
-                                    data,
-                                    mime_type,
-                                },
-                            ),
-                        ),
                     ))
                     .into_iter()
                     .collect()


### PR DESCRIPTION
The clipboard actually probably should just be handled one way, so I guess not in the iced-sctk loop, or else it can block forever on reading. For example, it might block forever because a widget is using the "iced" method to read after setting the clipboard via the "iced-sctk" method.