### PR TITLE
fix: broadcast surface events

### DIFF
--- a/sctk/src/application.rs
+++ b/sctk/src/application.rs
@@ -929,6 +929,9 @@ where
                             | SctkEvent::SessionLocked
                             | SctkEvent::SessionLockFinished
                             | SctkEvent::SessionUnlocked
+                            | SctkEvent::PopupEvent { .. }
+                            | SctkEvent::LayerSurfaceEvent { .. }
+                            | SctkEvent::WindowEvent { .. }
                     );
                     if remove {
                         let event = sctk_events.remove(i);


### PR DESCRIPTION
Subscriptions should receive surface events