### PR TITLE
Input method and virtual keyboard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,12 @@ advanced = []
 a11y = ["iced_accessibility", "iced_core/a11y", "iced_widget/a11y", "iced_winit?/a11y", "iced_sctk?/a11y"]
 # Enables the winit shell. Conflicts with `wayland` and `glutin`.
 winit = ["iced_winit", "iced_accessibility?/accesskit_winit"]
-# Enables the sctk shell. COnflicts with `winit` and `glutin`.
+# Enables the sctk shell. Conflicts with `winit` and `glutin`.
 wayland = ["iced_sctk", "iced_widget/wayland", "iced_accessibility?/accesskit_unix", "iced_core/wayland"]
+# Enables the sctk with input method support.
+wayland_input_method = ["iced_sctk/input_method"]
+# Enables the sctk with virtual keyboard.
+wayland_virtual_keyboard = ["iced_sctk/virtual_keyboard"]
 
 [dependencies]
 iced_core.workspace = true
@@ -175,6 +179,7 @@ web-time = "0.2"
 # wgpu = "0.19"
 # Newer wgpu commit that fixes Vulkan backend on Nvidia
 wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "20fda69" }
+wayland-protocols-misc = { version = "0.2.0"}
 winapi = "0.3"
 window_clipboard = "0.4"
 winit = { git = "https://github.com/pop-os/winit.git", branch = "winit-0.29" }

--- a/core/src/event/wayland/input_method.rs
+++ b/core/src/event/wayland/input_method.rs
@@ -1,0 +1,132 @@
+use sctk::{
+    reexports::{
+        client::WEnum,
+        protocols::wp::text_input::zv3::client::zwp_text_input_v3::{
+            ChangeCause, ContentHint, ContentPurpose,
+        },
+    },
+    seat::keyboard::Keysym,
+};
+
+use crate::keyboard::KeyCode;
+
+/// input method events
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InputMethodEvent {
+    /// A new text input is interacting with the application
+    Activate,
+    /// A text input is not interacting with the application anymore
+    Deactivate,
+    /// The surrounding plain text around the cursor, excluding the preedit text
+    SurroundingText {
+        /// plain text
+        text: String,
+        /// Cursor position
+        cursor: u32,
+        /// Anchor position
+        anchor: u32,
+    },
+    /// indicates the cause of surrounding text change
+    TextChangeCause(WEnum<ChangeCause>),
+    /// content purpose and hint
+    ContentType(WEnum<ContentHint>, WEnum<ContentPurpose>),
+    /// apply state
+    Done,
+}
+
+/// Input method keyboard events
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InputMethodKeyboardEvent {
+    /// A key is pressed
+    Press(KeyEvent, KeyCode, Modifiers),
+    /// A key is released
+    Release(KeyEvent, KeyCode, Modifiers),
+    /// A key is repeated
+    Repeat(KeyEvent, KeyCode, Modifiers),
+    /// Modifiers are updated
+    Modifiers(Modifiers, RawModifiers),
+}
+
+/// Data associated with a key press or release event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeyEvent {
+    /// Time at which the keypress occurred.
+    pub time: u32,
+
+    /// The raw value of the key.
+    pub raw_code: u32,
+
+    /// The interpreted symbol of the key.
+    ///
+    /// This corresponds to one of the associated values on the [`Keysym`] type.
+    pub keysym: Keysym,
+
+    /// UTF-8 interpretation of the entered text.
+    ///
+    /// This will always be [`None`] on release events.
+    pub utf8: Option<String>,
+}
+
+/// The state of keyboard modifiers
+/// Each field of this indicates whether a specified modifier is active.
+/// Depending on the modifier, the modifier key may currently be pressed or toggled.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Modifiers {
+    /// The "control" key
+    pub ctrl: bool,
+
+    /// The "alt" key
+    pub alt: bool,
+
+    /// The "shift" key
+    pub shift: bool,
+
+    /// The "Caps lock" key
+    pub caps_lock: bool,
+
+    /// The "logo" key
+    /// Also known as the "windows" or "super" key on a keyboard.
+    #[doc(alias = "windows")]
+    #[doc(alias = "super")]
+    pub logo: bool,
+
+    /// The "Num lock" key
+    pub num_lock: bool,
+}
+
+/// Raw modifiers
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RawModifiers {
+    /// Modifiers depressed
+    pub mods_depressed: u32,
+    /// Modifiers latched
+    pub mods_latched: u32,
+    /// Modifiers locked
+    pub mods_locked: u32,
+    /// Modifiers group
+    pub group: u32,
+}
+
+impl From<sctk::seat::keyboard::KeyEvent> for KeyEvent {
+    fn from(value: sctk::seat::keyboard::KeyEvent) -> Self {
+        KeyEvent {
+            time: value.time,
+            raw_code: value.raw_code,
+            keysym: value.keysym,
+            utf8: value.utf8,
+        }
+    }
+}
+
+impl From<sctk::seat::keyboard::Modifiers> for Modifiers {
+    fn from(value: sctk::seat::keyboard::Modifiers) -> Self {
+        Modifiers {
+            ctrl: value.ctrl,
+            alt: value.alt,
+            shift: value.shift,
+            caps_lock: value.caps_lock,
+            logo: value.logo,
+            num_lock: value.num_lock,
+        }
+    }
+}

--- a/core/src/event/wayland/mod.rs
+++ b/core/src/event/wayland/mod.rs
@@ -1,4 +1,5 @@
 mod data_device;
+mod input_method;
 mod layer;
 mod output;
 mod popup;
@@ -12,6 +13,7 @@ use sctk::reexports::client::protocol::{
 };
 
 pub use data_device::*;
+pub use input_method::*;
 pub use layer::*;
 pub use output::*;
 pub use popup::*;
@@ -42,6 +44,10 @@ pub enum Event {
     SessionLock(SessionLockEvent),
     /// Frame events
     Frame(Instant, WlSurface, Id),
+    /// Input Method
+    InputMethod(InputMethodEvent),
+    /// Input Method Keyboard Event
+    InputMethodKeyboard(InputMethodKeyboardEvent),
 }
 
 impl Event {

--- a/examples/sctk_input_method/Cargo.toml
+++ b/examples/sctk_input_method/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sctk_input_method"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sctk = { package = "smithay-client-toolkit", git = "https://github.com/smithay/client-toolkit", rev = "dc8c4a0" }
+iced = { path = "../..", default-features = false,  features = ["wayland", "debug", "wayland_input_method", "wayland_virtual_keyboard"] }
+iced_core = { path = "../../core" }
+iced_style = { path = "../../style" }
+iced_runtime = { path = "../../runtime" }
+env_logger = "0.10"
+lazy_static = "1.4.0"

--- a/examples/sctk_input_method/src/main.rs
+++ b/examples/sctk_input_method/src/main.rs
@@ -1,0 +1,327 @@
+#[macro_use]
+extern crate lazy_static;
+
+use iced::{
+    event::{self, listen_raw, wayland::InputMethodEvent},
+    wayland::{
+        actions::{
+            input_method::ActionInner,
+            input_method_popup::InputMethodPopupSettings,
+            virtual_keyboard::ActionInner as VKActionInner,
+        },
+        input_method::{
+            hide_input_method_popup, input_method_action,
+            show_input_method_popup,
+        },
+        virtual_keyboard::virtual_keyboard_action,
+        InitialSurface,
+    },
+    widget::{column, container, row, text},
+    window, Alignment, Application, Color, Command, Element, Event, Settings,
+    Subscription, Theme,
+};
+use iced_core::{
+    event::wayland::{
+        InputMethodKeyboardEvent, KeyEvent, Modifiers, RawModifiers,
+    },
+    keyboard::KeyCode,
+    window::Id,
+};
+use iced_style::application;
+use selection_field::widget::selection_field;
+use std::{collections::HashMap, fmt::Debug};
+mod selection_field;
+
+lazy_static! {
+    static ref ACCENTKEYS: HashMap<char, Vec<char>> = [
+        ('A', vec!['À', 'Á', 'Â', 'Ã', 'Ä', 'Å', 'Ā', 'Ă', 'Ą', 'Æ']),
+        ('E', vec!['É', 'È', 'Ê', 'Ë']),
+        ('I', vec!['Í', 'Ì', 'Î', 'Ï']),
+        ('O', vec!['Ó', 'Ò', 'Ô', 'Õ', 'Ö']),
+        ('U', vec!['Ú', 'Ù', 'Û', 'Ü']),
+        ('a', vec!['à', 'á', 'â', 'ã', 'ä', 'å', 'ā', 'ă', 'ą', 'æ']),
+        ('e', vec!['é', 'è', 'ê', 'ë']),
+        ('i', vec!['í', 'ì', 'î', 'ï']),
+        ('o', vec!['ó', 'ò', 'ô', 'õ', 'ö']),
+        ('u', vec!['ú', 'ù', 'û', 'ü']),
+    ]
+    .into();
+}
+
+fn main() -> iced::Result {
+    let initial_surface = InputMethodPopupSettings::default();
+    let settings = Settings {
+        initial_surface: InitialSurface::InputMethodPopup(initial_surface),
+        ..Settings::default()
+    };
+    InputMethod::run(settings)
+}
+
+struct InputMethod {
+    index: usize,
+    popup: bool,
+    list: Vec<char>,
+}
+
+impl InputMethod {
+    fn commit_string(&mut self, character: char) -> Command<Message> {
+        Command::batch(vec![
+            hide_input_method_popup(),
+            input_method_action(ActionInner::CommitString(
+                character.to_string(),
+            )),
+            input_method_action(ActionInner::Commit),
+        ])
+    }
+
+    fn open_popup(
+        &mut self,
+        character: char,
+        list: &Vec<char>,
+    ) -> Command<Message> {
+        self.popup = true;
+        self.index = 0;
+        self.list = list.clone();
+        Command::batch(vec![
+            input_method_action(ActionInner::SetPreeditString {
+                string: character.to_string(),
+                cursor_begin: 0,
+                cursor_end: 0,
+            }),
+            input_method_action(ActionInner::Commit),
+            show_input_method_popup(),
+        ])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Message {
+    Activate,
+    Deactivate,
+    KeyPressed(KeyEvent, KeyCode, Modifiers),
+    KeyRepeat(KeyEvent, KeyCode, Modifiers),
+    KeyReleased(KeyEvent, KeyCode, Modifiers),
+    Modifiers(Modifiers, RawModifiers),
+    UpdatePopup { index: usize },
+    Done,
+}
+
+impl Application for InputMethod {
+    type Executor = iced::executor::Default;
+    type Message = Message;
+    type Flags = ();
+    type Theme = Theme;
+
+    fn new(_flags: ()) -> (InputMethod, Command<Message>) {
+        (
+            InputMethod {
+                index: 0,
+                popup: false,
+                list: Vec::new(),
+            },
+            Command::none(),
+        )
+    }
+
+    fn title(&self, _: Id) -> String {
+        String::from("InputMethod")
+    }
+
+    fn update(&mut self, message: Message) -> Command<Message> {
+        match message {
+            Message::Activate => Command::none(),
+            Message::Deactivate => Command::none(),
+            Message::KeyPressed(_key, key_code, _modifiers) => {
+                if self.popup {
+                    match key_code {
+                        KeyCode::Left => {
+                            if self.index > 0 {
+                                self.index -= 1;
+                            }
+                            Command::none()
+                        }
+                        KeyCode::Right => {
+                            if self.index < self.list.len() - 1 {
+                                self.index += 1;
+                            }
+                            Command::none()
+                        }
+                        KeyCode::Enter => {
+                            self.commit_string(self.list[self.index])
+                        }
+                        _ => Command::none(),
+                    }
+                } else {
+                    Command::none()
+                }
+            }
+            Message::KeyRepeat(key, key_code, _modifiers) => {
+                if !self.popup {
+                    if let Some(utf8) = key
+                        .utf8
+                        .as_ref()
+                        .map(|str| str.chars().last().unwrap_or_default())
+                    {
+                        if let Some(list) = ACCENTKEYS.get(&utf8) {
+                            self.open_popup(utf8, list)
+                        } else {
+                            virtual_keyboard_action(VKActionInner::KeyPressed(
+                                key,
+                            ))
+                        }
+                    } else {
+                        virtual_keyboard_action(VKActionInner::KeyPressed(key))
+                    }
+                } else {
+                    match key_code {
+                        KeyCode::Left => {
+                            if self.index > 0 {
+                                self.index -= 1;
+                            }
+                            Command::none()
+                        }
+                        KeyCode::Right => {
+                            if self.index < self.list.len() - 1 {
+                                self.index += 1;
+                            }
+                            Command::none()
+                        }
+                        _ => Command::none(),
+                    }
+                }
+            }
+            Message::KeyReleased(key, key_code, _modifiers) => {
+                if !self.popup {
+                    Command::batch(vec![
+                        virtual_keyboard_action(VKActionInner::KeyPressed(
+                            key.clone(),
+                        )),
+                        virtual_keyboard_action(VKActionInner::KeyReleased(
+                            key,
+                        )),
+                    ])
+                } else {
+                    match key_code {
+                        KeyCode::Enter => self.popup = false,
+                        _ => {}
+                    }
+                    Command::none()
+                }
+            }
+            Message::Modifiers(_modifiers, raw_modifiers) => {
+                virtual_keyboard_action(VKActionInner::Modifiers(raw_modifiers))
+            }
+            Message::Done => Command::none(),
+            Message::UpdatePopup { index } => {
+                self.index = index;
+                Command::none()
+            }
+        }
+    }
+
+    fn view(&self, _id: window::Id) -> Element<Message> {
+        container(
+            row(self
+                .list
+                .iter()
+                .enumerate()
+                .map(|(index, char)| {
+                    selection_field(
+                        column(vec![
+                            text((index + 1) % 10)
+                                .size(50)
+                                .style(Color::WHITE)
+                                .into(),
+                            text(char).style(Color::WHITE).size(50).into(),
+                        ])
+                        .align_items(Alignment::Center)
+                        .padding(5.0)
+                        .spacing(4.0)
+                    )
+                    .set_indexes(index)
+                    .selected(self.index)
+                    .on_press(Message::Deactivate)
+                    .on_select(Message::UpdatePopup { index })
+                    .into()
+                })
+                .collect())
+            .padding(2.0),
+        )
+        .padding(5.0)
+        .style(<iced_style::Theme as container::StyleSheet>::Style::Custom(
+            Box::new(CustomTheme),
+        ))
+        .into()
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        listen_raw(|event, status| match (event.clone(), status) {
+            (
+                Event::PlatformSpecific(event::PlatformSpecific::Wayland(
+                    event::wayland::Event::InputMethod(event),
+                )),
+                event::Status::Ignored,
+            ) => match event {
+                InputMethodEvent::Activate => Some(Message::Activate),
+                InputMethodEvent::Deactivate => Some(Message::Deactivate),
+                InputMethodEvent::Done => Some(Message::Done),
+                _ => None,
+            },
+            (
+                Event::PlatformSpecific(event::PlatformSpecific::Wayland(
+                    event::wayland::Event::InputMethodKeyboard(event),
+                )),
+                event::Status::Ignored,
+            ) => match event {
+                InputMethodKeyboardEvent::Press(key, key_code, modifiers) => {
+                    Some(Message::KeyPressed(key, key_code, modifiers))
+                }
+                InputMethodKeyboardEvent::Release(key, key_code, modifiers) => {
+                    Some(Message::KeyReleased(key, key_code, modifiers))
+                }
+                InputMethodKeyboardEvent::Repeat(key, key_code, modifiers) => {
+                    Some(Message::KeyRepeat(key, key_code, modifiers))
+                }
+                InputMethodKeyboardEvent::Modifiers(
+                    modifiers,
+                    raw_modifiers,
+                ) => Some(Message::Modifiers(modifiers, raw_modifiers)),
+            },
+            _ => None,
+        })
+    }
+
+    fn style(&self) -> <Self::Theme as application::StyleSheet>::Style {
+        <Self::Theme as application::StyleSheet>::Style::Custom(Box::new(
+            CustomTheme,
+        ))
+    }
+}
+
+pub struct CustomTheme;
+
+impl container::StyleSheet for CustomTheme {
+    type Style = iced::Theme;
+
+    fn appearance(&self, _style: &Self::Style) -> container::Appearance {
+        container::Appearance {
+            border_color: Color::from_rgb(1.0, 1.0, 1.0),
+            border_radius: 10.0.into(),
+            border_width: 3.0,
+            background: Some(Color::from_rgb(0.0, 0.0, 0.0).into()),
+            ..container::Appearance::default()
+        }
+    }
+}
+
+impl iced_style::application::StyleSheet for CustomTheme {
+    type Style = iced::Theme;
+
+    fn appearance(&self, _style: &Self::Style) -> application::Appearance {
+        iced_style::application::Appearance {
+            background_color: Color::from_rgba(0.0, 0.0, 0.0, 0.0),
+            icon_color: Color::BLACK,
+            text_color: Color::BLACK,
+        }
+    }
+}

--- a/examples/sctk_input_method/src/selection_field/mod.rs
+++ b/examples/sctk_input_method/src/selection_field/mod.rs
@@ -1,0 +1,2 @@
+pub mod style;
+pub mod widget;

--- a/examples/sctk_input_method/src/selection_field/style.rs
+++ b/examples/sctk_input_method/src/selection_field/style.rs
@@ -1,0 +1,81 @@
+//! Change the apperance of a button.
+use iced_core::{Background, BorderRadius, Color};
+use iced_style::Theme;
+
+/// The appearance of a button.
+#[derive(Debug, Clone, Copy)]
+pub struct Appearance {
+    /// The [`Background`] of the button.
+    pub background: Option<Background>,
+    /// The border radius of the button.
+    pub border_radius: BorderRadius,
+    /// The border width of the button.
+    pub border_width: f32,
+    /// The border [`Color`] of the button.
+    pub border_color: Color,
+    /// The icon [`Color`] of the button.
+    pub icon_color: Option<Color>,
+    /// The text [`Color`] of the button.
+    pub text_color: Color,
+}
+
+impl std::default::Default for Appearance {
+    fn default() -> Self {
+        Self {
+            background: None,
+            border_radius: 0.0.into(),
+            border_width: 0.0,
+            border_color: Color::TRANSPARENT,
+            icon_color: None,
+            text_color: Color::WHITE,
+        }
+    }
+}
+
+/// A set of rules that dictate the style of a button.
+pub trait StyleSheet {
+    /// The supported style of the [`StyleSheet`].
+    type Style: Default;
+
+    /// Produces the active [`Appearance`] of a button.
+    fn default(&self, style: &Self::Style) -> Appearance;
+
+    /// Produces the selected [`Appearance`] of a button.
+    fn selected(&self, style: &Self::Style) -> Appearance;
+}
+
+/// The style of a button.
+#[derive(Default)]
+pub enum SelectionField {
+    /// The primary style.
+    #[default]
+    Default,
+    /// A custom style.
+    Custom(Box<dyn StyleSheet<Style = Theme>>),
+}
+
+impl SelectionField {
+    /// Creates a custom [`Button`] style variant.
+    pub fn custom(style_sheet: impl StyleSheet<Style = Theme> + 'static) -> Self {
+        Self::Custom(Box::new(style_sheet))
+    }
+}
+
+impl StyleSheet for Theme {
+    type Style = SelectionField;
+
+    fn default(&self, _style: &Self::Style) -> Appearance {
+        Appearance::default()
+    }
+
+    fn selected(&self, _style: &Self::Style) -> Appearance {
+        Appearance {
+            background: Some(Background::Color(Color::from_rgba(0.0, 0.07, 0.42, 1.0))),
+            border_radius: 5.5.into(),
+            border_width: 1.0,
+            border_color: Color::WHITE,
+            icon_color: None,
+            text_color: Color::WHITE,
+        }
+    }
+}

--- a/examples/sctk_input_method/src/selection_field/widget.rs
+++ b/examples/sctk_input_method/src/selection_field/widget.rs
@@ -1,0 +1,356 @@
+//! Allow your users to perform actions by selecting a field.
+
+use super::style::StyleSheet;
+use iced_runtime::core::{
+    event::{self, Event},
+    layout,
+    mouse,
+    overlay,
+    renderer,
+    touch,
+    widget::{Id, tree::{self, Tree}},
+    Background, Clipboard, Color, Element, Layout, Length, Padding, Point,
+    Rectangle, Shell, Widget,
+};
+
+/// A generic widget that produces a message when pressed.
+#[allow(missing_debug_implementations)]
+pub struct SelectionField<'a, Message, Renderer = iced::Renderer>
+where
+    Renderer: iced_core::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    id: Id,
+    content: Element<'a, Message, Renderer>,
+    on_press: Option<Message>,
+    on_select: Option<Message>,
+    index: usize,
+    is_selected: bool,
+    width: Length,
+    height: Length,
+    padding: Padding,
+    style: <Renderer::Theme as StyleSheet>::Style,
+}
+
+impl<'a, Message, Renderer> SelectionField<'a, Message, Renderer>
+where
+    Renderer: iced_core::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    /// Creates a new [`Button`] with the given content.
+    pub fn new(content: impl Into<Element<'a, Message, Renderer>>) -> Self {
+        SelectionField {
+            id: Id::unique(),
+            content: content.into(),
+            on_press: None,
+            on_select: None,
+            index: 0,
+            is_selected: false,
+            width: Length::Shrink,
+            height: Length::Shrink,
+            padding: Padding::new(2.0),
+            style: <Renderer::Theme as StyleSheet>::Style::default(),
+        }
+    }
+
+    /// Sets the width of the [`Button`].
+    pub fn width(mut self, width: impl Into<Length>) -> Self {
+        self.width = width.into();
+        self
+    }
+
+    /// Sets the height of the [`Button`].
+    pub fn height(mut self, height: impl Into<Length>) -> Self {
+        self.height = height.into();
+        self
+    }
+
+    /// Sets the [`Padding`] of the [`Button`].
+    pub fn padding<P: Into<Padding>>(mut self, padding: P) -> Self {
+        self.padding = padding.into();
+        self
+    }
+
+    /// Sets the message that will be produced when the [`Button`] is pressed.
+    ///
+    /// Unless `on_press` is called, the [`Button`] will be disabled.
+    pub fn on_press(mut self, on_press: Message) -> Self {
+        self.on_press = Some(on_press);
+        self
+    }
+
+    /// Sets the message that will be produced when the [`SelectionField`] is selected
+    pub fn on_select(mut self, on_select: Message) -> Self {
+        self.on_select = Some(on_select);
+        self
+    }
+
+    /// Sets the index values
+    pub fn set_indexes(mut self, index: usize) -> Self {
+        self.index = index;
+        self
+    }
+
+    /// Selects the [`SelectionField`] at current page and index
+    pub fn selected(mut self, index: usize) -> Self {
+        self.is_selected = index == self.index;
+        self
+    }
+
+    /// Sets the style variant of this [`Button`].
+    pub fn style(
+        mut self,
+        style: <Renderer::Theme as StyleSheet>::Style,
+    ) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Sets the [`Id`] of the [`Button`].
+    pub fn id(mut self, id: Id) -> Self {
+        self.id = id;
+        self
+    }
+}
+
+impl<'a, Message, Renderer> Widget<Message, Renderer>
+    for SelectionField<'a, Message, Renderer>
+where
+    Message: 'a + Clone,
+    Renderer: 'a + iced_core::Renderer,
+    Renderer::Theme: StyleSheet,
+{
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State::new())
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        vec![Tree::new(&self.content)]
+    }
+
+    fn diff(&mut self, tree: &mut Tree) {
+        tree.diff_children(std::slice::from_mut(&mut self.content))
+    }
+
+    fn width(&self) -> Length {
+        self.width
+    }
+
+    fn height(&self) -> Length {
+        self.height
+    }
+
+    fn layout(
+        &self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        let limits = limits.width(self.width).height(self.height);
+
+        let mut content = self.content.as_widget().layout(
+            &mut tree.children[0],
+            renderer,
+            &limits,
+        );
+        let padding = self.padding.fit(content.size(), limits.max());
+        let size = limits.pad(self.padding).resolve(content.size()).pad(self.padding);
+
+        content.move_to(Point::new(padding.left, padding.top));
+
+        layout::Node::with_children(size, vec![content])
+    }
+
+    fn on_event(
+        &mut self,
+        tree: &mut Tree,
+        event: Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) -> event::Status {
+        if let event::Status::Captured = self.content.as_widget_mut().on_event(
+            &mut tree.children[0],
+            event.clone(),
+            layout.children().next().unwrap(),
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        ) {
+            return event::Status::Captured;
+        }
+        let state = tree.state.downcast_mut::<State>();
+        match event {
+            Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                if let Some(_cursor_position) =
+                    cursor.position_in(layout.bounds())
+                {
+                    state.is_hovered = true;
+                    if let Some(on_select) = self.on_select.clone() {
+                        shell.publish(on_select);
+                    }
+                    return event::Status::Captured;
+                }
+            }
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerPressed { .. }) => {
+                if self.on_press.is_some() && cursor.is_over(layout.bounds()) {
+                    state.is_pressed = true;
+                    return event::Status::Captured;
+                }
+            }
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+            | Event::Touch(touch::Event::FingerLifted { .. }) => {
+                if let Some(on_press) = self.on_press.clone() {
+                    if state.is_pressed {
+                        state.is_pressed = false;
+                        if cursor.is_over(layout.bounds()) {
+                            shell.publish(on_press);
+                        }
+                        return event::Status::Captured;
+                    }
+                }
+            }
+            Event::Touch(touch::Event::FingerLost { .. })
+            | Event::Mouse(mouse::Event::CursorLeft) => {
+                state.is_hovered = false;
+                state.is_pressed = false;
+            }
+            _ => {}
+        }
+
+        event::Status::Ignored
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Renderer::Theme,
+        renderer_style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+    ) {
+        let content_layout = layout.children().next().unwrap();
+
+        let styling = if self.is_selected {
+            theme.selected(&self.style)
+        } else {
+            theme.default(&self.style)
+        };
+
+        if styling.background.is_some() || styling.border_width > 0.0 {
+            renderer.fill_quad(
+                renderer::Quad {
+                    bounds: layout.bounds(),
+                    border_radius: styling.border_radius,
+                    border_width: styling.border_width,
+                    border_color: styling.border_color,
+                },
+                styling
+                    .background
+                    .unwrap_or(Background::Color(Color::TRANSPARENT)),
+            );
+        }
+
+        self.content.as_widget().draw(
+            &tree.children[0],
+            renderer,
+            theme,
+            &renderer::Style {
+                icon_color: styling
+                    .icon_color
+                    .unwrap_or(renderer_style.icon_color),
+                text_color: styling.text_color,
+                scale_factor: renderer_style.scale_factor,
+            },
+            content_layout,
+            cursor,
+            &layout.bounds(),
+        );
+    }
+
+    fn mouse_interaction(
+        &self,
+        _tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        _viewport: &Rectangle,
+        _renderer: &Renderer,
+    ) -> mouse::Interaction {
+        let is_mouse_over = cursor.is_over(layout.bounds());
+        if is_mouse_over {
+            mouse::Interaction::Pointer
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+    ) -> Option<overlay::Element<'b, Message, Renderer>> {
+        self.content.as_widget_mut().overlay(
+            &mut tree.children[0],
+            layout.children().next().unwrap(),
+            renderer,
+        )
+    }
+
+    fn id(&self) -> Option<Id> {
+        Some(self.id.clone())
+    }
+
+    fn set_id(&mut self, id: Id) {
+        self.id = id;
+    }
+}
+
+impl<'a, Message, Renderer> From<SelectionField<'a, Message, Renderer>>
+    for Element<'a, Message, Renderer>
+where
+    Message: Clone + 'a,
+    Renderer: iced_core::Renderer + 'a,
+    Renderer::Theme: StyleSheet,
+{
+    fn from(selection_field: SelectionField<'a, Message, Renderer>) -> Self {
+        Self::new(selection_field)
+    }
+}
+
+/// The local state of a [`Button`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct State {
+    is_hovered: bool,
+    is_pressed: bool,
+}
+
+impl State {
+    /// Creates a new [`State`].
+    pub fn new() -> State {
+        State::default()
+    }
+}
+
+pub fn selection_field<'a, Message, Renderer>(
+    content: impl Into<Element<'a, Message, Renderer>>,
+) -> SelectionField<'a, Message, Renderer>
+where
+    Renderer: iced_core::Renderer,
+    Renderer::Theme: StyleSheet,
+    <Renderer::Theme as StyleSheet>::Style: Default,
+{
+    SelectionField::new(content)
+}

--- a/runtime/src/command/platform_specific/wayland/input_method.rs
+++ b/runtime/src/command/platform_specific/wayland/input_method.rs
@@ -1,0 +1,92 @@
+use iced_futures::MaybeSend;
+use std::fmt;
+use std::marker::PhantomData;
+
+/// Input Method Action
+pub struct Action<T> {
+    /// The inner action
+    pub inner: ActionInner,
+    /// The phantom data
+    _phantom: PhantomData<T>,
+}
+
+impl<T> From<ActionInner> for Action<T> {
+    fn from(inner: ActionInner) -> Self {
+        Self {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> fmt::Debug for Action<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+/// Input Method Actions
+pub enum ActionInner {
+    /// Apply state
+    Commit,
+    /// Send string to client
+    CommitString(String),
+    /// Set preedit string
+    SetPreeditString {
+        /// String to be set
+        string: String,
+        /// Start of preedit cursor
+        cursor_begin: i32,
+        /// Preedit cursor end
+        cursor_end: i32,
+    },
+    /// Delete surrounding text
+    DeleteSurroundingText {
+        /// Number of bytes before current cursor index (excluding the preedit text) to delete
+        before_length: u32,
+        /// Number of bytes after current cursor index (excluding the preedit text) to delete
+        after_length: u32,
+    },
+}
+
+impl<T> Action<T> {
+    /// Maps the output of a window [`Action`] using the provided closure.
+    pub fn map<A>(
+        self,
+        _: impl Fn(T) -> A + 'static + MaybeSend + Sync,
+    ) -> Action<A>
+    where
+        T: 'static,
+    {
+        Action::from(self.inner)
+    }
+}
+
+impl fmt::Debug for ActionInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Commit => f.debug_tuple("Commit").finish(),
+            Self::CommitString(string) => {
+                f.debug_tuple("Commit String").field(string).finish()
+            }
+            Self::SetPreeditString {
+                string,
+                cursor_begin,
+                cursor_end,
+            } => f
+                .debug_tuple("Set Preedit String")
+                .field(string)
+                .field(cursor_begin)
+                .field(cursor_end)
+                .finish(),
+            Self::DeleteSurroundingText {
+                before_length,
+                after_length,
+            } => f
+                .debug_tuple("Delete Sorrunding Text")
+                .field(before_length)
+                .field(after_length)
+                .finish(),
+        }
+    }
+}

--- a/runtime/src/command/platform_specific/wayland/input_method_popup.rs
+++ b/runtime/src/command/platform_specific/wayland/input_method_popup.rs
@@ -1,0 +1,106 @@
+use iced_core::layout::Limits;
+use iced_core::window::Id;
+use iced_futures::MaybeSend;
+use std::hash::{Hash, Hasher};
+use std::{fmt, marker::PhantomData};
+
+/// Popup creation details
+#[derive(Debug, Clone)]
+pub struct InputMethodPopupSettings {
+    /// Id of the popup
+    pub id: Id,
+    /// Limits of the window size
+    pub size_limits: Limits,
+    /// The initial size of the window.
+    pub size: (u32, u32),
+}
+
+impl Default for InputMethodPopupSettings {
+    fn default() -> Self {
+        Self {
+            id: Id::MAIN,
+            size_limits: Limits::NONE
+                .min_height(1.0)
+                .min_width(1.0)
+                .max_width(1920.0)
+                .max_height(1080.0),
+            size: (256, 256),
+        }
+    }
+}
+
+impl Hash for InputMethodPopupSettings {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+/// Input Method Actions
+pub enum Action<T> {
+    /// Create input method popup
+    Popup {
+        /// settings
+        settings: InputMethodPopupSettings,
+        /// phantom
+        _phantom: PhantomData<T>,
+    },
+    /// show input method popup
+    ShowPopup,
+    /// hide input method popup
+    HidePopup,
+    /// Set size of the input method popup
+    Size {
+        /// id of the popup
+        id: Id,
+        /// width
+        width: u32,
+        /// height
+        height: u32,
+    },
+}
+
+impl<T> Action<T> {
+    /// Maps the output of a window [`Action`] using the provided closure.
+    pub fn map<A>(
+        self,
+        _: impl Fn(T) -> A + 'static + MaybeSend + Sync,
+    ) -> Action<A>
+    where
+        T: 'static,
+    {
+        match self {
+            Action::Popup { settings, _phantom } => Action::Popup {
+                settings,
+                _phantom: PhantomData,
+            },
+            Action::ShowPopup => Action::ShowPopup,
+            Action::HidePopup => Action::HidePopup,
+            Action::Size { id, width, height } => {
+                Action::Size { id, width, height }
+            }
+        }
+    }
+}
+
+impl<T> fmt::Debug for Action<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Popup { settings, _phantom } => f
+                .debug_tuple("Show Input Method Popup")
+                .field(settings)
+                .finish(),
+            Self::ShowPopup => {
+                f.debug_tuple("Show Input Method Popup").finish()
+            }
+            Self::HidePopup => {
+                f.debug_tuple("Hide Input Method Popup").finish()
+            }
+            Self::Size { id, width, height } => f
+                .debug_tuple("Input method popup size changed")
+                .field(id)
+                .field(width)
+                .field(height)
+                .finish(),
+        }
+    }
+}

--- a/runtime/src/command/platform_specific/wayland/mod.rs
+++ b/runtime/src/command/platform_specific/wayland/mod.rs
@@ -8,12 +8,18 @@ use iced_futures::MaybeSend;
 pub mod activation;
 /// data device Actions
 pub mod data_device;
+/// input method actions
+pub mod input_method;
+/// input method popup actions
+pub mod input_method_popup;
 /// layer surface actions
 pub mod layer_surface;
 /// popup actions
 pub mod popup;
 /// session locks
 pub mod session_lock;
+/// virtual keyboard actions
+pub mod virtual_keyboard;
 /// window actions
 pub mod window;
 
@@ -31,6 +37,12 @@ pub enum Action<T> {
     Activation(activation::Action<T>),
     /// session lock
     SessionLock(session_lock::Action<T>),
+    /// virtual keyboard
+    VirtualKeyboard(virtual_keyboard::Action<T>),
+    /// input method
+    InputMethod(input_method::Action<T>),
+    /// input method popup
+    InputMethodPopup(input_method_popup::Action<T>),
 }
 
 impl<T> Action<T> {
@@ -50,6 +62,9 @@ impl<T> Action<T> {
             Action::DataDevice(a) => Action::DataDevice(a.map(f)),
             Action::Activation(a) => Action::Activation(a.map(f)),
             Action::SessionLock(a) => Action::SessionLock(a.map(f)),
+            Action::VirtualKeyboard(a) => Action::VirtualKeyboard(a.map(f)),
+            Action::InputMethod(a) => Action::InputMethod(a.map(f)),
+            Action::InputMethodPopup(a) => Action::InputMethodPopup(a.map(f)),
         }
     }
 }
@@ -70,6 +85,15 @@ impl<T> Debug for Action<T> {
             }
             Self::SessionLock(arg0) => {
                 f.debug_tuple("SessionLock").field(arg0).finish()
+            }
+            Self::VirtualKeyboard(arg0) => {
+                f.debug_tuple("VirtualKeyboard").field(arg0).finish()
+            }
+            Self::InputMethod(arg0) => {
+                f.debug_tuple("InputMethod").field(arg0).finish()
+            }
+            Self::InputMethodPopup(arg0) => {
+                f.debug_tuple("InputMethodPopup").field(arg0).finish()
             }
         }
     }

--- a/runtime/src/command/platform_specific/wayland/virtual_keyboard.rs
+++ b/runtime/src/command/platform_specific/wayland/virtual_keyboard.rs
@@ -1,0 +1,66 @@
+use std::{fmt, marker::PhantomData};
+
+use iced_core::event::wayland::{KeyEvent, RawModifiers};
+use iced_futures::MaybeSend;
+
+/// Virtual keyboard action
+pub struct Action<T> {
+    /// The inner action
+    pub inner: ActionInner,
+    /// The phantom data
+    _phantom: PhantomData<T>,
+}
+
+impl<T> From<ActionInner> for Action<T> {
+    fn from(inner: ActionInner) -> Self {
+        Self {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> fmt::Debug for Action<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+/// Virtual keyboard Actions
+pub enum ActionInner {
+    /// Forward a keypress to client
+    KeyPressed(KeyEvent),
+    /// Forward a keyrelease to client
+    KeyReleased(KeyEvent),
+    /// Forward modifiers to client
+    Modifiers(RawModifiers),
+}
+
+impl<T> Action<T> {
+    /// Maps the output of a virtual keyboard [`Action`] using the provided closure.
+    pub fn map<A>(
+        self,
+        _: impl Fn(T) -> A + 'static + MaybeSend + Sync,
+    ) -> Action<A>
+    where
+        T: 'static,
+    {
+        Action::from(self.inner)
+    }
+}
+
+impl fmt::Debug for ActionInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::KeyPressed(key) => {
+                f.debug_tuple("Key event").field(key).finish()
+            }
+            Self::KeyReleased(key) => {
+                f.debug_tuple("Key event").field(key).finish()
+            }
+            Self::Modifiers(modifiers) => {
+                f.debug_tuple("Modifier event").field(modifiers).finish()
+            }
+        }
+    }
+}

--- a/sctk/Cargo.toml
+++ b/sctk/Cargo.toml
@@ -10,12 +10,16 @@ debug = ["iced_runtime/debug"]
 system = ["sysinfo"]
 application = []
 a11y = ["iced_accessibility", "iced_runtime/a11y"]
+input_method = ["calloop", "xkbcommon/wayland", "bytemuck", "pkg-config", 
+  "xkeysym/bytemuck", "wayland-protocols-misc/client", "log", "tempfile"]
+virtual_keyboard = ["wayland-protocols-misc/client"]
 
 [dependencies]
 tracing = "0.1"
 thiserror = "1.0"
 sctk.workspace = true
 wayland-protocols.workspace = true
+wayland-protocols-misc.workspace = true
 # sctk = { package = "smithay-client-toolkit", path = "../../fork/client-toolkit/" }
 raw-window-handle = "0.6"
 enum-repr = "0.2"
@@ -28,6 +32,14 @@ xkbcommon = { version = "0.7", features = ["wayland"] }
 itertools = "0.12"
 xkeysym = "0.2.0"
 lazy_static = "1.4.0"
+bytemuck = { version = "1.14.0", optional = true }
+xkbcommon = { version = "0.6", optional = true }
+calloop = { version = "0.12.3", optional = true }
+tempfile = { version = "3.8.1", optional = true }
+log = { version = "0.4", optional = true }
+
+[build-dependencies]
+pkg-config = { version = "0.3", optional = true }
 
 [dependencies.iced_runtime]
 path = "../runtime"
@@ -38,7 +50,6 @@ path = "../style"
 
 [dependencies.iced_graphics]
 path = "../graphics"
-
 
 [dependencies.iced_futures]
 path = "../futures"

--- a/sctk/src/application.rs
+++ b/sctk/src/application.rs
@@ -585,18 +585,17 @@ where
                     SctkEvent::InputMethodKeyboardEvent { variant } =>
                     match variant {
                         InputMethodKeyboardEventVariant::Press(ke) => {
-                            if let Some(key_code) = keysym_to_vkey(ke.keysym.raw()){
-                                runtime.broadcast(
-                                    iced_runtime::core::Event::PlatformSpecific(
-                                        PlatformSpecific::Wayland(
-                                            wayland::Event::InputMethodKeyboard(
-                                                wayland::InputMethodKeyboardEvent::Press(ke.into(), key_code, mods.into())
-                                            )
+                            let key_code = keysym_to_vkey(ke.keysym.raw()).unwrap_or(iced_runtime::keyboard::KeyCode::Unlabeled);
+                            runtime.broadcast(
+                                iced_runtime::core::Event::PlatformSpecific(
+                                    PlatformSpecific::Wayland(
+                                        wayland::Event::InputMethodKeyboard(
+                                            wayland::InputMethodKeyboardEvent::Press(ke.into(), key_code, mods.into())
                                         )
-                                    ),
-                                    Status::Ignored
-                                )
-                            }
+                                    )
+                                ),
+                                Status::Ignored
+                            )
                         }
                         InputMethodKeyboardEventVariant::Release(ke) => {
                             if let Some(key_code) = keysym_to_vkey(ke.keysym.raw()){

--- a/sctk/src/commands/input_method.rs
+++ b/sctk/src/commands/input_method.rs
@@ -1,0 +1,49 @@
+//! Interact with the virtual keyboard from your application.
+use std::marker::PhantomData;
+
+use iced_runtime::command::platform_specific::wayland::input_method::ActionInner;
+use iced_runtime::command::platform_specific::wayland::input_method_popup::InputMethodPopupSettings;
+use iced_runtime::command::Command;
+use iced_runtime::command::{
+    self,
+    platform_specific::{self, wayland},
+};
+
+pub fn input_method_action<Message>(
+    action_inner: ActionInner,
+) -> Command<Message> {
+    Command::single(command::Action::PlatformSpecific(
+        platform_specific::Action::Wayland(wayland::Action::InputMethod(
+            action_inner.into(),
+        )),
+    ))
+}
+
+pub fn get_input_method_popup<Message>(
+    builder: InputMethodPopupSettings,
+) -> Command<Message> {
+    Command::single(command::Action::PlatformSpecific(
+        platform_specific::Action::Wayland(wayland::Action::InputMethodPopup(
+            wayland::input_method_popup::Action::Popup {
+                settings: builder,
+                _phantom: PhantomData,
+            },
+        )),
+    ))
+}
+
+pub fn show_input_method_popup<Message>() -> Command<Message> {
+    Command::single(command::Action::PlatformSpecific(
+        platform_specific::Action::Wayland(wayland::Action::InputMethodPopup(
+            wayland::input_method_popup::Action::ShowPopup,
+        )),
+    ))
+}
+
+pub fn hide_input_method_popup<Message>() -> Command<Message> {
+    Command::single(command::Action::PlatformSpecific(
+        platform_specific::Action::Wayland(wayland::Action::InputMethodPopup(
+            wayland::input_method_popup::Action::HidePopup,
+        )),
+    ))
+}

--- a/sctk/src/commands/mod.rs
+++ b/sctk/src/commands/mod.rs
@@ -2,7 +2,11 @@
 
 pub mod activation;
 pub mod data_device;
+#[cfg(feature = "input_method")]
+pub mod input_method;
 pub mod layer_surface;
 pub mod popup;
 pub mod session_lock;
+#[cfg(feature = "virtual_keyboard")]
+pub mod virtual_keyboard;
 pub mod window;

--- a/sctk/src/commands/virtual_keyboard.rs
+++ b/sctk/src/commands/virtual_keyboard.rs
@@ -1,0 +1,17 @@
+//! Interact with the virtual keyboard from your application.
+use iced_runtime::command::platform_specific::wayland::virtual_keyboard::ActionInner;
+use iced_runtime::command::Command;
+use iced_runtime::command::{
+    self,
+    platform_specific::{self, wayland},
+};
+
+pub fn virtual_keyboard_action<Message>(
+    action_inner: ActionInner,
+) -> Command<Message> {
+    Command::single(command::Action::PlatformSpecific(
+        platform_specific::Action::Wayland(wayland::Action::VirtualKeyboard(
+            action_inner.into(),
+        )),
+    ))
+}

--- a/sctk/src/handlers/input_method/keyboard.rs
+++ b/sctk/src/handlers/input_method/keyboard.rs
@@ -1,0 +1,856 @@
+use std::{
+    env, fmt::Debug, marker::PhantomData, num::NonZeroU32,
+    os::unix::io::AsRawFd, sync::Mutex,
+};
+#[cfg(feature = "calloop")]
+use std::{sync::Arc, time::Duration};
+#[doc(inline)]
+pub use xkeysym::Keysym;
+
+#[cfg(feature = "calloop")]
+use sctk::reexports::calloop::{
+    timer::{TimeoutAction, Timer},
+    LoopHandle, RegistrationToken,
+};
+use sctk::{
+    reexports::client::{
+        protocol::wl_keyboard, Connection, Dispatch, Proxy, QueueHandle, WEnum,
+    },
+    seat::keyboard::{KeyEvent, KeyboardError, Modifiers, RepeatInfo, RMLVO},
+};
+
+use xkbcommon::xkb;
+
+use wayland_protocols_misc::zwp_input_method_v2::client::{
+    zwp_input_method_keyboard_grab_v2::{self, ZwpInputMethodKeyboardGrabV2},
+    zwp_input_method_v2::ZwpInputMethodV2,
+};
+
+use crate::handlers::input_method::InputMethod;
+
+#[cfg(feature = "calloop")]
+pub(crate) struct RepeatedKey {
+    pub(crate) key: KeyEvent,
+    /// Whether this is the first event of the repeat sequence.
+    pub(crate) is_first: bool,
+}
+
+#[cfg(feature = "calloop")]
+pub type RepeatCallback<T> =
+    Box<dyn FnMut(&mut T, &ZwpInputMethodKeyboardGrabV2, KeyEvent) + 'static>;
+
+#[cfg(feature = "calloop")]
+pub(crate) struct RepeatData<T> {
+    pub(crate) current_repeat: Option<RepeatedKey>,
+    pub(crate) repeat_info: RepeatInfo,
+    pub(crate) loop_handle: LoopHandle<'static, T>,
+    pub(crate) callback: RepeatCallback<T>,
+    pub(crate) repeat_token: Option<RegistrationToken>,
+}
+
+#[cfg(feature = "calloop")]
+impl<T> Drop for RepeatData<T> {
+    fn drop(&mut self) {
+        if let Some(token) = self.repeat_token.take() {
+            self.loop_handle.remove(token);
+        }
+    }
+}
+
+impl InputMethod {
+    /// Creates a keyboard from a seat.
+    ///
+    /// This function returns an [`EventSource`] that indicates when a key press is going to repeat.
+    ///
+    /// This keyboard implementation uses libxkbcommon for the keymap.
+    ///
+    /// Typically the compositor will provide a keymap, but you may specify your own keymap using the `rmlvo`
+    /// field.
+    ///
+    /// ## Errors
+    ///
+    /// This will return [`SeatError::UnsupportedCapability`] if the seat does not support a keyboard.
+    ///
+    /// [`EventSource`]: calloop::EventSource
+    #[cfg(feature = "calloop")]
+    pub fn grab_keyboard_with_repeat<D, T>(
+        &mut self,
+        qh: &QueueHandle<D>,
+        input_method: &ZwpInputMethodV2,
+        rmlvo: Option<RMLVO>,
+        loop_handle: LoopHandle<'static, T>,
+        callback: RepeatCallback<T>,
+    ) -> Result<ZwpInputMethodKeyboardGrabV2, KeyboardError>
+    where
+        D: Dispatch<ZwpInputMethodKeyboardGrabV2, InputMethodKeyboardData<T>>
+            + InputMethodKeyboardHandler
+            + 'static,
+        T: 'static,
+    {
+        let udata = match rmlvo {
+            Some(rmlvo) => InputMethodKeyboardData::from_rmlvo(rmlvo)?,
+            None => InputMethodKeyboardData::new(),
+        };
+
+        Ok(self.grab_keyboard_with_repeat_with_data(
+            qh,
+            input_method,
+            udata,
+            loop_handle,
+            callback,
+        ))
+    }
+
+    /// Creates a keyboard from a seat.
+    ///
+    /// This function returns an [`EventSource`] that indicates when a key press is going to repeat.
+    ///
+    /// This keyboard implementation uses libxkbcommon for the keymap.
+    ///
+    /// Typically the compositor will provide a keymap, but you may specify your own keymap using the `rmlvo`
+    /// field.
+    ///
+    /// ## Errors
+    ///
+    /// This will return [`SeatError::UnsupportedCapability`] if the seat does not support a keyboard.
+    ///
+    /// [`EventSource`]: calloop::EventSource
+    #[cfg(feature = "calloop")]
+    pub fn grab_keyboard_with_repeat_with_data<D, U>(
+        &mut self,
+        qh: &QueueHandle<D>,
+        input_method: &ZwpInputMethodV2,
+        mut udata: U,
+        loop_handle: LoopHandle<
+            'static,
+            <U as InputMethodKeyboardDataExt>::State,
+        >,
+        callback: RepeatCallback<<U as InputMethodKeyboardDataExt>::State>,
+    ) -> ZwpInputMethodKeyboardGrabV2
+    where
+        D: Dispatch<ZwpInputMethodKeyboardGrabV2, U>
+            + InputMethodKeyboardHandler
+            + 'static,
+        U: InputMethodKeyboardDataExt + 'static,
+    {
+        let kbd_data = udata.keyboard_data_mut();
+        kbd_data.repeat_data.lock().unwrap().replace(RepeatData {
+            current_repeat: None,
+            repeat_info: RepeatInfo::Disable,
+            loop_handle: loop_handle.clone(),
+            callback,
+            repeat_token: None,
+        });
+        kbd_data.init_compose();
+
+        input_method.grab_keyboard(qh, udata)
+    }
+
+    /// Creates a keyboard from a seat.
+    ///
+    /// This keyboard implementation uses libxkbcommon for the keymap.
+    ///
+    /// Typically the compositor will provide a keymap, but you may specify your own keymap using the `rmlvo`
+    /// field.
+    pub fn grab_keyboard<D, T: 'static>(
+        &mut self,
+        qh: &QueueHandle<D>,
+        input_method: &ZwpInputMethodV2,
+        rmlvo: Option<RMLVO>,
+    ) -> Result<ZwpInputMethodKeyboardGrabV2, KeyboardError>
+    where
+        D: Dispatch<ZwpInputMethodKeyboardGrabV2, InputMethodKeyboardData<T>>
+            + InputMethodKeyboardHandler
+            + 'static,
+    {
+        let udata = match rmlvo {
+            Some(rmlvo) => InputMethodKeyboardData::from_rmlvo(rmlvo)?,
+            None => InputMethodKeyboardData::new(),
+        };
+
+        Ok(self.grab_keyboard_with_data(qh, input_method, udata))
+    }
+
+    /// Creates a keyboard from a seat.
+    ///
+    /// This keyboard implementation uses libxkbcommon for the keymap.
+    ///
+    /// Typically the compositor will provide a keymap, but you may specify your own keymap using the `rmlvo`
+    /// field.
+    pub fn grab_keyboard_with_data<D, U>(
+        &mut self,
+        qh: &QueueHandle<D>,
+        input_method: &ZwpInputMethodV2,
+        udata: U,
+    ) -> ZwpInputMethodKeyboardGrabV2
+    where
+        D: Dispatch<ZwpInputMethodKeyboardGrabV2, U>
+            + InputMethodKeyboardHandler
+            + 'static,
+        U: InputMethodKeyboardDataExt + 'static,
+    {
+        input_method.grab_keyboard(qh, udata)
+    }
+}
+
+/// Wrapper around a libxkbcommon keymap
+#[allow(missing_debug_implementations)]
+pub struct Keymap<'a>(&'a xkb::Keymap);
+
+impl<'a> Keymap<'a> {
+    /// Get keymap as string in text format. The keymap should always be valid.
+    pub fn as_string(&self) -> String {
+        self.0.get_as_string(xkb::KEYMAP_FORMAT_TEXT_V1)
+    }
+}
+
+/// Handler trait for keyboard input.
+///
+/// The functions defined in this trait are called as keyboard events are received from the compositor.
+pub trait InputMethodKeyboardHandler: Sized {
+    /// A key has been pressed on the keyboard.
+    ///
+    /// The key will repeat if there is no other press event afterwards or the key is released.
+    fn press_key(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        keyboard: &ZwpInputMethodKeyboardGrabV2,
+        serial: u32,
+        event: KeyEvent,
+    );
+
+    /// A key has been released.
+    ///
+    /// This stops the key from being repeated if the key is the last key which was pressed.
+    fn release_key(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        keyboard: &ZwpInputMethodKeyboardGrabV2,
+        serial: u32,
+        event: KeyEvent,
+    );
+
+    /// Keyboard modifiers have been updated.
+    ///
+    /// This happens when one of the modifier keys, such as "Shift", "Control" or "Alt" is pressed or
+    /// released.
+    fn update_modifiers(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        keyboard: &ZwpInputMethodKeyboardGrabV2,
+        serial: u32,
+        modifiers: Modifiers,
+        raw_modifiers: RawModifiers,
+    );
+
+    /// The keyboard has updated the rate and delay between repeating key inputs.
+    ///
+    /// This function does nothing by default but is provided if a repeat mechanism outside of calloop is\
+    /// used.
+    fn update_repeat_info(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &ZwpInputMethodKeyboardGrabV2,
+        _info: RepeatInfo,
+    ) {
+    }
+
+    /// Keyboard keymap has been updated.
+    ///
+    /// `keymap.as_string()` can be used get the keymap as a string. It cannot be exposed directly
+    /// as an `xkbcommon::xkb::Keymap` due to the fact xkbcommon uses non-thread-safe reference
+    /// counting. But can be used to create an independent `Keymap`.
+    ///
+    /// This is called after the default handler for keymap changes and does nothing by default.
+    fn update_keymap(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        keyboard: &ZwpInputMethodKeyboardGrabV2,
+        keymap: Keymap<'_>,
+    );
+}
+
+pub struct InputMethodKeyboardData<T> {
+    xkb_context: Mutex<xkb::Context>,
+    /// If the user manually specified the RMLVO to use.
+    user_specified_rmlvo: bool,
+    xkb_state: Mutex<Option<xkb::State>>,
+    xkb_compose: Mutex<Option<xkb::compose::State>>,
+    #[cfg(feature = "calloop")]
+    repeat_data: Arc<Mutex<Option<RepeatData<T>>>>,
+    _phantom_data: PhantomData<T>,
+}
+
+impl<T> Debug for InputMethodKeyboardData<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KeyboardData").finish_non_exhaustive()
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_input_method_keyboard {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        sctk::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                wayland_protocols_misc::zwp_input_method_v2::client::zwp_input_method_keyboard_grab_v2::ZwpInputMethodKeyboardGrabV2:
+                    $crate::handlers::input_method::keyboard::InputMethodKeyboardData<$ty>
+            ] => $crate::handlers::input_method::InputMethod
+        );
+    };
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty, keyboard: [$($udata:ty),* $(,)?]) => {
+        sctk::reexports::client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty:
+            [
+                $(
+                    wayland_protocols_misc::zwp_input_method_v2::client::zwp_input_method_keyboard_grab_v2::ZwpInputMethodKeyboardGrabV2: $udata,
+                )*
+            ] => $crate::handlers::input_method::InputMethod
+        );
+    };
+}
+
+// SAFETY: The state does not share state with any other rust types.
+unsafe impl<T> Send for InputMethodKeyboardData<T> {}
+// SAFETY: The state is guarded by a mutex since libxkbcommon has no internal synchronization.
+unsafe impl<T> Sync for InputMethodKeyboardData<T> {}
+
+impl<T> InputMethodKeyboardData<T> {
+    pub fn new() -> Self {
+        let xkb_context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let udata = InputMethodKeyboardData {
+            xkb_context: Mutex::new(xkb_context),
+            xkb_state: Mutex::new(None),
+            user_specified_rmlvo: false,
+            xkb_compose: Mutex::new(None),
+            #[cfg(feature = "calloop")]
+            repeat_data: Arc::new(Mutex::new(None)),
+            _phantom_data: PhantomData,
+        };
+
+        udata.init_compose();
+
+        udata
+    }
+
+    pub fn from_rmlvo(rmlvo: RMLVO) -> Result<Self, KeyboardError> {
+        let xkb_context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let keymap = xkb::Keymap::new_from_names(
+            &xkb_context,
+            &rmlvo.rules.unwrap_or_default(),
+            &rmlvo.model.unwrap_or_default(),
+            &rmlvo.layout.unwrap_or_default(),
+            &rmlvo.variant.unwrap_or_default(),
+            rmlvo.options,
+            xkb::COMPILE_NO_FLAGS,
+        );
+
+        if keymap.is_none() {
+            return Err(KeyboardError::InvalidKeymap);
+        }
+
+        let xkb_state = Some(xkb::State::new(&keymap.unwrap()));
+
+        let udata = InputMethodKeyboardData {
+            xkb_context: Mutex::new(xkb_context),
+            xkb_state: Mutex::new(xkb_state),
+            user_specified_rmlvo: true,
+            xkb_compose: Mutex::new(None),
+            #[cfg(feature = "calloop")]
+            repeat_data: Arc::new(Mutex::new(None)),
+            _phantom_data: PhantomData,
+        };
+
+        udata.init_compose();
+
+        Ok(udata)
+    }
+
+    fn init_compose(&self) {
+        let xkb_context = self.xkb_context.lock().unwrap();
+
+        if let Some(locale) = env::var_os("LC_ALL")
+            .and_then(|v| if v.is_empty() { None } else { Some(v) })
+            .or_else(|| env::var_os("LC_CTYPE"))
+            .and_then(|v| if v.is_empty() { None } else { Some(v) })
+            .or_else(|| env::var_os("LANG"))
+            .and_then(|v| if v.is_empty() { None } else { Some(v) })
+            .unwrap_or_else(|| "C".into())
+            .to_str()
+        {
+            // TODO: Pending new release of xkbcommon to use new_from_locale with OsStr
+            if let Ok(table) = xkb::compose::Table::new_from_locale(
+                &xkb_context,
+                locale.as_ref(),
+                xkb::compose::COMPILE_NO_FLAGS,
+            ) {
+                let compose_state = xkb::compose::State::new(
+                    &table,
+                    xkb::compose::COMPILE_NO_FLAGS,
+                );
+                *self.xkb_compose.lock().unwrap() = Some(compose_state);
+            }
+        }
+    }
+
+    fn update_modifiers(&self) -> Modifiers {
+        let guard = self.xkb_state.lock().unwrap();
+        let state = guard.as_ref().unwrap();
+
+        Modifiers {
+            ctrl: state.mod_name_is_active(
+                xkb::MOD_NAME_CTRL,
+                xkb::STATE_MODS_EFFECTIVE,
+            ),
+            alt: state.mod_name_is_active(
+                xkb::MOD_NAME_ALT,
+                xkb::STATE_MODS_EFFECTIVE,
+            ),
+            shift: state.mod_name_is_active(
+                xkb::MOD_NAME_SHIFT,
+                xkb::STATE_MODS_EFFECTIVE,
+            ),
+            caps_lock: state.mod_name_is_active(
+                xkb::MOD_NAME_CAPS,
+                xkb::STATE_MODS_EFFECTIVE,
+            ),
+            logo: state.mod_name_is_active(
+                xkb::MOD_NAME_LOGO,
+                xkb::STATE_MODS_EFFECTIVE,
+            ),
+            num_lock: state.mod_name_is_active(
+                xkb::MOD_NAME_NUM,
+                xkb::STATE_MODS_EFFECTIVE,
+            ),
+        }
+    }
+}
+
+pub trait InputMethodKeyboardDataExt: Send + Sync {
+    type State: 'static;
+    fn keyboard_data(&self) -> &InputMethodKeyboardData<Self::State>;
+    fn keyboard_data_mut(
+        &mut self,
+    ) -> &mut InputMethodKeyboardData<Self::State>;
+}
+
+impl<T: 'static> InputMethodKeyboardDataExt for InputMethodKeyboardData<T> {
+    /// The type of the user defined state
+    type State = T;
+    fn keyboard_data(&self) -> &InputMethodKeyboardData<T> {
+        self
+    }
+
+    fn keyboard_data_mut(&mut self) -> &mut InputMethodKeyboardData<T> {
+        self
+    }
+}
+
+impl<D, U> Dispatch<ZwpInputMethodKeyboardGrabV2, U, D> for InputMethod
+where
+    D: Dispatch<ZwpInputMethodKeyboardGrabV2, U> + InputMethodKeyboardHandler,
+    U: InputMethodKeyboardDataExt,
+{
+    fn event(
+        data: &mut D,
+        keyboard: &ZwpInputMethodKeyboardGrabV2,
+        event: <ZwpInputMethodKeyboardGrabV2 as Proxy>::Event,
+        udata: &U,
+        conn: &Connection,
+        qh: &QueueHandle<D>,
+    ) {
+        let udata = udata.keyboard_data();
+        match event {
+            zwp_input_method_keyboard_grab_v2::Event::Keymap {
+                format,
+                fd,
+                size,
+            } => {
+                match format {
+                    WEnum::Value(format) => match format {
+                        wl_keyboard::KeymapFormat::NoKeymap => {
+                            log::warn!(target: "sctk", "non-xkb compatible keymap");
+                        }
+
+                        wl_keyboard::KeymapFormat::XkbV1 => {
+                            if udata.user_specified_rmlvo {
+                                // state is locked, ignore keymap updates
+                                return;
+                            }
+
+                            let context = udata.xkb_context.lock().unwrap();
+
+                            // SAFETY:
+                            // - wayland-client guarantees we have received a valid file descriptor.
+                            #[allow(unused_unsafe)]
+                            // Upstream release will change this
+                            match unsafe {
+                                xkb::Keymap::new_from_fd(
+                                    &context,
+                                    fd.as_raw_fd(),
+                                    size as usize,
+                                    xkb::KEYMAP_FORMAT_TEXT_V1,
+                                    xkb::COMPILE_NO_FLAGS,
+                                )
+                            } {
+                                Ok(Some(keymap)) => {
+                                    let state = xkb::State::new(&keymap);
+                                    {
+                                        let mut state_guard =
+                                            udata.xkb_state.lock().unwrap();
+                                        *state_guard = Some(state);
+                                    }
+                                    data.update_keymap(
+                                        conn,
+                                        qh,
+                                        keyboard,
+                                        Keymap(&keymap),
+                                    );
+                                }
+
+                                Ok(None) => {
+                                    log::error!(target: "sctk", "invalid keymap");
+                                }
+
+                                Err(err) => {
+                                    log::error!(target: "sctk", "{}", err);
+                                }
+                            }
+                        }
+
+                        _ => unreachable!(),
+                    },
+
+                    WEnum::Unknown(value) => {
+                        log::warn!(target: "sctk", "unknown keymap format 0x{:x}", value)
+                    }
+                }
+            }
+
+            zwp_input_method_keyboard_grab_v2::Event::Key {
+                serial,
+                time,
+                key,
+                state,
+            } => match state {
+                WEnum::Value(state) => {
+                    let state_guard = udata.xkb_state.lock().unwrap();
+
+                    if let Some(guard) = state_guard.as_ref() {
+                        // We must add 8 to the keycode for any functions we pass the raw keycode into per
+                        // wl_keyboard protocol.
+                        let keysym = guard.key_get_one_sym((key + 8).into());
+                        let utf8 = if state == wl_keyboard::KeyState::Pressed {
+                            let mut compose = udata.xkb_compose.lock().unwrap();
+
+                            match compose.as_mut() {
+                                Some(compose) => match compose.feed(keysym) {
+                                    xkb::FeedResult::Ignored => None,
+                                    xkb::FeedResult::Accepted => match compose
+                                        .status()
+                                    {
+                                        xkb::Status::Composed => compose.utf8(),
+                                        xkb::Status::Nothing => Some(
+                                            guard
+                                                .key_get_utf8((key + 8).into()),
+                                        ),
+                                        _ => None,
+                                    },
+                                },
+
+                                // No compose
+                                None => {
+                                    Some(guard.key_get_utf8((key + 8).into()))
+                                }
+                            }
+                        } else {
+                            None
+                        };
+
+                        // Drop guard before calling user code.
+                        drop(state_guard);
+
+                        let event = KeyEvent {
+                            time,
+                            raw_code: key,
+                            keysym: keysym.into(),
+                            utf8,
+                        };
+
+                        match state {
+                            wl_keyboard::KeyState::Released => {
+                                #[cfg(feature = "calloop")]
+                                {
+                                    if let Some(repeat_data) = udata
+                                        .repeat_data
+                                        .lock()
+                                        .unwrap()
+                                        .as_mut()
+                                    {
+                                        if Some(event.raw_code)
+                                            == repeat_data
+                                                .current_repeat
+                                                .as_ref()
+                                                .map(|r| r.key.raw_code)
+                                        {
+                                            repeat_data.current_repeat = None;
+                                        }
+                                    }
+                                }
+                                data.release_key(
+                                    conn, qh, keyboard, serial, event,
+                                );
+                            }
+
+                            wl_keyboard::KeyState::Pressed => {
+                                #[cfg(feature = "calloop")]
+                                {
+                                    if let Some(repeat_data) = udata
+                                        .repeat_data
+                                        .lock()
+                                        .unwrap()
+                                        .as_mut()
+                                    {
+                                        let loop_handle =
+                                            &mut repeat_data.loop_handle;
+                                        let state_guard =
+                                            udata.xkb_state.lock().unwrap();
+                                        let key_repeats = state_guard
+                                            .as_ref()
+                                            .map(|guard| {
+                                                guard.get_keymap().key_repeats(
+                                                    (event.raw_code + 8).into(),
+                                                )
+                                            })
+                                            .unwrap_or_default();
+                                        if key_repeats {
+                                            // Cancel the previous timer / repeat.
+                                            if let Some(token) =
+                                                repeat_data.repeat_token.take()
+                                            {
+                                                loop_handle.remove(token);
+                                            }
+
+                                            // Update the current repeat key.
+                                            repeat_data.current_repeat.replace(
+                                                RepeatedKey {
+                                                    key: event.clone(),
+                                                    is_first: true,
+                                                },
+                                            );
+
+                                            let (delay, rate) =
+                                                match repeat_data.repeat_info {
+                                                    RepeatInfo::Disable => {
+                                                        return
+                                                    }
+                                                    RepeatInfo::Repeat {
+                                                        delay,
+                                                        rate,
+                                                    } => (delay, rate),
+                                                };
+                                            let gap = Duration::from_micros(
+                                                1_000_000 / rate.get() as u64,
+                                            );
+                                            let timer = Timer::from_duration(
+                                                Duration::from_millis(
+                                                    delay as u64,
+                                                ),
+                                            );
+                                            let repeat_data2 =
+                                                udata.repeat_data.clone();
+
+                                            // Start the timer.
+                                            let kbd = keyboard.clone();
+                                            if let Ok(token) = loop_handle.insert_source(
+                                                timer,
+                                                move |_, _, state| {
+                                                    let mut repeat_data =
+                                                        repeat_data2.lock().unwrap();
+                                                    let repeat_data = match repeat_data.as_mut() {
+                                                        Some(repeat_data) => repeat_data,
+                                                        None => return TimeoutAction::Drop,
+                                                    };
+
+                                                    let callback = &mut repeat_data.callback;
+                                                    let key = &mut repeat_data.current_repeat;
+                                                    if key.is_none() {
+                                                        return TimeoutAction::Drop;
+                                                    }
+                                                    let key = key.as_mut().unwrap();
+                                                    key.key.time += if key.is_first {
+                                                        key.is_first = false;
+                                                        delay
+                                                    } else {
+                                                        gap.as_millis() as u32
+                                                    };
+                                                    callback(state, &kbd, key.key.clone());
+                                                    TimeoutAction::ToDuration(gap)
+                                                },
+                                            ) {
+                                                repeat_data.repeat_token = Some(token);
+                                            }
+                                        }
+                                    }
+                                }
+                                data.press_key(
+                                    conn, qh, keyboard, serial, event,
+                                );
+                            }
+
+                            _ => unreachable!(),
+                        }
+                    };
+                }
+
+                WEnum::Unknown(unknown) => {
+                    log::warn!(target: "sctk", "{}: compositor sends invalid key state: {:x}", keyboard.id(), unknown);
+                }
+            },
+
+            zwp_input_method_keyboard_grab_v2::Event::Modifiers {
+                serial,
+                mods_depressed,
+                mods_latched,
+                mods_locked,
+                group,
+            } => {
+                let raw_modifiers = RawModifiers {
+                    mods_depressed,
+                    mods_latched,
+                    mods_locked,
+                    group,
+                };
+                let mut guard = udata.xkb_state.lock().unwrap();
+
+                let state = match guard.as_mut() {
+                    Some(state) => state,
+                    None => return,
+                };
+
+                // Apply the new xkb state with the new modifiers.
+                let _ = state.update_mask(
+                    mods_depressed,
+                    mods_latched,
+                    mods_locked,
+                    0,
+                    0,
+                    group,
+                );
+
+                // Update the currently repeating key if any.
+                #[cfg(feature = "calloop")]
+                if let Some(repeat_data) =
+                    udata.repeat_data.lock().unwrap().as_mut()
+                {
+                    if let Some(mut event) = repeat_data.current_repeat.take() {
+                        // Apply new modifiers to get new utf8.
+                        event.key.utf8 = {
+                            let mut compose = udata.xkb_compose.lock().unwrap();
+
+                            match compose.as_mut() {
+                                Some(compose) => match compose
+                                    .feed(event.key.keysym.into())
+                                {
+                                    xkb::FeedResult::Ignored => None,
+                                    xkb::FeedResult::Accepted => match compose
+                                        .status()
+                                    {
+                                        xkb::Status::Composed => compose.utf8(),
+                                        xkb::Status::Nothing => {
+                                            Some(state.key_get_utf8(
+                                                (event.key.raw_code + 8).into(),
+                                            ))
+                                        }
+                                        _ => None,
+                                    },
+                                },
+
+                                // No compose.
+                                None => Some(state.key_get_utf8(
+                                    (event.key.raw_code + 8).into(),
+                                )),
+                            }
+                        };
+
+                        // Update the stored event.
+                        repeat_data.current_repeat = Some(event);
+                    }
+                }
+
+                // Drop guard before calling user code.
+                drop(guard);
+
+                // Always issue the modifiers update for the user.
+                let modifiers = udata.update_modifiers();
+                data.update_modifiers(
+                    conn,
+                    qh,
+                    keyboard,
+                    serial,
+                    modifiers,
+                    raw_modifiers,
+                );
+            }
+
+            zwp_input_method_keyboard_grab_v2::Event::RepeatInfo {
+                rate,
+                delay,
+            } => {
+                let info = if rate != 0 {
+                    RepeatInfo::Repeat {
+                        rate: NonZeroU32::new(rate as u32).unwrap(),
+                        delay: delay as u32,
+                    }
+                } else {
+                    RepeatInfo::Disable
+                };
+
+                #[cfg(feature = "calloop")]
+                {
+                    if let Some(repeat_data) =
+                        udata.repeat_data.lock().unwrap().as_mut()
+                    {
+                        repeat_data.repeat_info = info;
+                    }
+                }
+                data.update_repeat_info(conn, qh, keyboard, info);
+            }
+
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RawModifiers {
+    pub mods_depressed: u32,
+    pub mods_latched: u32,
+    pub mods_locked: u32,
+    pub group: u32,
+}
+
+impl From<iced_futures::core::event::wayland::RawModifiers> for RawModifiers {
+    fn from(value: iced_futures::core::event::wayland::RawModifiers) -> Self {
+        RawModifiers {
+            mods_depressed: value.mods_depressed,
+            mods_latched: value.mods_latched,
+            mods_locked: value.mods_locked,
+            group: value.group,
+        }
+    }
+}
+
+impl From<RawModifiers> for iced_futures::core::event::wayland::RawModifiers {
+    fn from(value: RawModifiers) -> Self {
+        iced_futures::core::event::wayland::RawModifiers {
+            mods_depressed: value.mods_depressed,
+            mods_latched: value.mods_latched,
+            mods_locked: value.mods_locked,
+            group: value.group,
+        }
+    }
+}

--- a/sctk/src/handlers/input_method/mod.rs
+++ b/sctk/src/handlers/input_method/mod.rs
@@ -1,0 +1,373 @@
+pub mod keyboard;
+use std::fmt::Debug;
+use std::io::Write;
+use std::marker::PhantomData;
+use std::os::fd::AsFd;
+use std::sync::{Arc, Mutex};
+
+use iced_runtime::command::platform_specific::wayland::input_method_popup::InputMethodPopupSettings;
+use iced_runtime::window;
+use sctk::reexports::calloop::LoopHandle;
+use sctk::reexports::client::globals::{BindError, GlobalList};
+use sctk::reexports::client::protocol::wl_keyboard::KeymapFormat;
+use sctk::reexports::client::protocol::wl_seat::WlSeat;
+use sctk::reexports::client::protocol::wl_surface::WlSurface;
+use sctk::reexports::client::Dispatch;
+use sctk::reexports::client::{
+    delegate_dispatch, Connection, Proxy, QueueHandle,
+};
+use sctk::seat::keyboard::{KeyEvent, Modifiers};
+use wayland_protocols_misc::zwp_input_method_v2::client::zwp_input_method_v2;
+use wayland_protocols_misc::zwp_input_method_v2::client::zwp_input_popup_surface_v2;
+use wayland_protocols_misc::zwp_input_method_v2::client::{
+    zwp_input_method_keyboard_grab_v2::ZwpInputMethodKeyboardGrabV2,
+    zwp_input_method_manager_v2::ZwpInputMethodManagerV2,
+    zwp_input_method_v2::ZwpInputMethodV2,
+    zwp_input_popup_surface_v2::ZwpInputPopupSurfaceV2,
+};
+
+use sctk::globals::GlobalData;
+
+use crate::delegate_input_method_keyboard;
+use crate::event_loop::state::SctkState;
+use crate::sctk_event::{
+    InputMethodEventVariant, InputMethodKeyboardEventVariant, SctkEvent,
+};
+
+use self::keyboard::{InputMethodKeyboardHandler, RawModifiers};
+
+#[derive(Debug)]
+pub struct InputMethodManager<T> {
+    manager: ZwpInputMethodManagerV2,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: 'static> InputMethodManager<T> {
+    pub fn new(
+        globals: &GlobalList,
+        queue_handle: &QueueHandle<SctkState<T>>,
+    ) -> Result<Self, BindError> {
+        let manager = globals.bind(queue_handle, 1..=1, GlobalData)?;
+        Ok(Self {
+            manager,
+            _phantom: PhantomData,
+        })
+    }
+
+    pub fn input_method(
+        &self,
+        seat: &WlSeat,
+        queue_handle: &QueueHandle<SctkState<T>>,
+        loop_handle: LoopHandle<'static, SctkState<T>>,
+    ) -> ZwpInputMethodV2 {
+        let mut data = InputMethod {
+            inner: Arc::new(Mutex::new(Inner::default())),
+        };
+        let im =
+            self.manager
+                .get_input_method(seat, queue_handle, data.clone());
+        data.grab_keyboard_with_repeat(
+            queue_handle,
+            &im,
+            None,
+            loop_handle,
+            Box::new(move |state, _kbd: &ZwpInputMethodKeyboardGrabV2, e| {
+                state.sctk_events.push(SctkEvent::InputMethodKeyboardEvent {
+                    variant: InputMethodKeyboardEventVariant::Repeat(e),
+                })
+            }),
+        )
+        .expect("Input method keyboard grab failed");
+        im
+    }
+}
+
+impl<T: 'static> Dispatch<ZwpInputMethodManagerV2, GlobalData, SctkState<T>>
+    for InputMethodManager<T>
+{
+    fn event(
+        _: &mut SctkState<T>,
+        _: &ZwpInputMethodManagerV2,
+        _: <ZwpInputMethodManagerV2 as Proxy>::Event,
+        _: &GlobalData,
+        _: &Connection,
+        _: &QueueHandle<SctkState<T>>,
+    ) {
+        // No events.
+    }
+}
+
+#[derive(Clone, Default)]
+struct Inner {
+    serial: u32,
+}
+
+#[derive(Clone)]
+pub struct InputMethod {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl<T: 'static> Dispatch<ZwpInputMethodV2, InputMethod, SctkState<T>>
+    for InputMethodManager<T>
+{
+    fn event(
+        state: &mut SctkState<T>,
+        _: &ZwpInputMethodV2,
+        event: <ZwpInputMethodV2 as Proxy>::Event,
+        data: &InputMethod,
+        _: &Connection,
+        _: &QueueHandle<SctkState<T>>,
+    ) {
+        match event {
+            zwp_input_method_v2::Event::Activate => {
+                state.sctk_events.push(SctkEvent::InputMethodEvent {
+                    variant: InputMethodEventVariant::Activate,
+                })
+            }
+            zwp_input_method_v2::Event::Deactivate => {
+                state.sctk_events.push(SctkEvent::InputMethodEvent {
+                    variant: InputMethodEventVariant::Deactivate,
+                })
+            }
+            zwp_input_method_v2::Event::SurroundingText {
+                text,
+                cursor,
+                anchor,
+            } => state.sctk_events.push(SctkEvent::InputMethodEvent {
+                variant: InputMethodEventVariant::SurroundingText {
+                    text,
+                    cursor,
+                    anchor,
+                },
+            }),
+            zwp_input_method_v2::Event::TextChangeCause { cause } => {
+                state.sctk_events.push(SctkEvent::InputMethodEvent {
+                    variant: InputMethodEventVariant::TextChangeCause(cause),
+                })
+            }
+            zwp_input_method_v2::Event::ContentType { hint, purpose } => {
+                state.sctk_events.push(SctkEvent::InputMethodEvent {
+                    variant: InputMethodEventVariant::ContentType(
+                        hint, purpose,
+                    ),
+                })
+            }
+            zwp_input_method_v2::Event::Done => {
+                data.inner.lock().unwrap().serial += 1;
+                state.sctk_events.push(SctkEvent::InputMethodEvent {
+                    variant: InputMethodEventVariant::Done,
+                })
+            }
+            zwp_input_method_v2::Event::Unavailable => {
+                panic!("Another input method already present!")
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InputMethodPopup {
+    popup_role: Option<ZwpInputPopupSurfaceV2>,
+    pub wl_surface: WlSurface,
+    pub wp_viewport: Option<wayland_protocols::wp::viewporter::client::wp_viewport::WpViewport>,
+    pub scale_factor: Option<f64>,
+    pub wp_fractional_scale: Option<wayland_protocols::wp::fractional_scale::v1::client::wp_fractional_scale_v1::WpFractionalScaleV1>,
+}
+
+impl<T: 'static>
+    Dispatch<ZwpInputPopupSurfaceV2, InputMethodPopup, SctkState<T>>
+    for InputMethodManager<T>
+{
+    fn event(
+        _: &mut SctkState<T>,
+        _: &ZwpInputPopupSurfaceV2,
+        event: <ZwpInputPopupSurfaceV2 as Proxy>::Event,
+        _: &InputMethodPopup,
+        _: &Connection,
+        _: &QueueHandle<SctkState<T>>,
+    ) {
+        match event {
+            zwp_input_popup_surface_v2::Event::TextInputRectangle {
+                x: _,
+                y: _,
+                width: _,
+                height: _,
+            } => {
+                // just let the compositor decide placement
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+delegate_dispatch!(@<T: 'static> SctkState<T>: [ZwpInputMethodManagerV2: GlobalData] => InputMethodManager<T>);
+delegate_dispatch!(@<T: 'static> SctkState<T>: [ZwpInputMethodV2: InputMethod] => InputMethodManager<T>);
+delegate_dispatch!(@<T: 'static> SctkState<T>: [ZwpInputPopupSurfaceV2: InputMethodPopup] => InputMethodManager<T>);
+
+impl<T: 'static> InputMethodKeyboardHandler for SctkState<T> {
+    fn press_key(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &ZwpInputMethodKeyboardGrabV2,
+        _serial: u32,
+        event: KeyEvent,
+    ) {
+        self.sctk_events.push(SctkEvent::InputMethodKeyboardEvent {
+            variant: InputMethodKeyboardEventVariant::Press(event),
+        });
+    }
+
+    fn release_key(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &ZwpInputMethodKeyboardGrabV2,
+        _serial: u32,
+        event: KeyEvent,
+    ) {
+        self.sctk_events.push(SctkEvent::InputMethodKeyboardEvent {
+            variant: InputMethodKeyboardEventVariant::Release(event),
+        });
+    }
+
+    fn update_modifiers(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &ZwpInputMethodKeyboardGrabV2,
+        _serial: u32,
+        modifiers: Modifiers,
+        raw_modifiers: RawModifiers,
+    ) {
+        self.sctk_events.push(SctkEvent::InputMethodKeyboardEvent {
+            variant: InputMethodKeyboardEventVariant::Modifiers(
+                modifiers,
+                raw_modifiers,
+            ),
+        });
+    }
+
+    fn update_keymap(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _keyboard: &ZwpInputMethodKeyboardGrabV2,
+        keymap: keyboard::Keymap<'_>,
+    ) {
+        self.seats.iter().for_each(|seat| {
+            if let Some(vk) = &seat.virtual_keyboard {
+                let mut file =
+                    tempfile::tempfile().expect("tempfile cannot be set");
+                let keymap = keymap.as_string();
+                file.write_all(keymap.as_bytes())
+                    .expect("Tempfile not writeable");
+                file.flush().expect("Tempfile not flushable");
+                vk.keymap(
+                    KeymapFormat::XkbV1.into(),
+                    file.as_fd(),
+                    keymap.len() as u32,
+                );
+            }
+        });
+    }
+}
+
+delegate_input_method_keyboard!(@<T: 'static> SctkState<T>);
+
+impl<T> SctkState<T>
+where
+    T: 'static + Debug,
+{
+    pub fn commit(&self) {
+        let seat = self.seats.first().expect("seat not present");
+        if let Some(im) = seat.input_method.as_ref() {
+            let inner = im.data::<InputMethod>().unwrap().inner.lock().unwrap();
+            im.commit(inner.serial);
+        }
+    }
+
+    pub fn commit_string(&self, string: String) {
+        let seat = self.seats.first().expect("seat not present");
+        if let Some(im) = seat.input_method.as_ref() {
+            im.commit_string(string)
+        }
+    }
+
+    pub fn set_preedit_string(
+        &self,
+        string: String,
+        cursor_begin: i32,
+        cursor_end: i32,
+    ) {
+        let seat = self.seats.first().expect("seat not present");
+        if let Some(im) = seat.input_method.as_ref() {
+            im.set_preedit_string(string, cursor_begin, cursor_end)
+        }
+    }
+
+    pub fn delete_surrounding_text(
+        &self,
+        before_length: u32,
+        after_length: u32,
+    ) {
+        let seat = self.seats.first().expect("seat not present");
+        if let Some(im) = seat.input_method.as_ref() {
+            im.delete_surrounding_text(before_length, after_length)
+        }
+    }
+
+    pub fn get_input_method_popup(
+        &mut self,
+        settings: InputMethodPopupSettings,
+    ) -> (window::Id, WlSurface) {
+        let wl_surface =
+            self.compositor_state.create_surface(&self.queue_handle);
+        wl_surface.commit();
+        let wp_viewport = self
+            .viewporter_state
+            .as_ref()
+            .map(|state| state.get_viewport(&wl_surface, &self.queue_handle));
+        let wp_fractional_scale = self
+            .fractional_scaling_manager
+            .as_ref()
+            .map(|fsm| fsm.fractional_scaling(&wl_surface, &self.queue_handle));
+        self.input_method_popup = Some(InputMethodPopup {
+            wl_surface: wl_surface.clone(),
+            popup_role: None,
+            wp_viewport,
+            scale_factor: None,
+            wp_fractional_scale,
+        });
+        (settings.id, wl_surface)
+    }
+
+    pub fn show_input_method_popup(&mut self) {
+        let seat = self.seats.first().expect("seat not present");
+        let popup_state = self
+            .input_method_popup
+            .as_mut()
+            .expect("Input Method popup not present");
+        if popup_state.popup_role.is_none() {
+            popup_state.popup_role = seat.input_method.as_ref().map(|im| {
+                im.get_input_popup_surface(
+                    &popup_state.wl_surface,
+                    &self.queue_handle,
+                    popup_state.clone(),
+                )
+            });
+        }
+    }
+
+    pub fn hide_input_method_popup(&mut self) {
+        let popup_state = self
+            .input_method_popup
+            .as_mut()
+            .expect("Input Method popup not present");
+        if let Some(role) = &popup_state.popup_role {
+            role.destroy();
+            popup_state.popup_role = None;
+        }
+    }
+}

--- a/sctk/src/handlers/mod.rs
+++ b/sctk/src/handlers/mod.rs
@@ -2,11 +2,15 @@
 pub mod activation;
 pub mod compositor;
 pub mod data_device;
+#[cfg(feature = "input_method")]
+pub mod input_method;
 pub mod output;
 pub mod seat;
 pub mod session_lock;
 pub mod shell;
 pub mod subcompositor;
+#[cfg(feature = "virtual_keyboard")]
+pub mod virtual_keyboard;
 pub mod wp_fractional_scaling;
 pub mod wp_viewporter;
 

--- a/sctk/src/handlers/seat/seat.rs
+++ b/sctk/src/handlers/seat/seat.rs
@@ -31,7 +31,7 @@ where
         let data_device =
             self.data_device_manager_state.get_data_device(qh, &seat);
         self.seats.push(SctkSeat {
-            seat,
+            seat: seat.clone(),
             kbd: None,
             ptr: None,
             _touch: None,
@@ -42,6 +42,16 @@ where
             last_ptr_press: None,
             last_kbd_press: None,
             icon: None,
+            #[cfg(feature = "virtual_keyboard")]            
+            virtual_keyboard: self
+                .virtual_keyboard_manager
+                .as_ref()
+                .map(|vk| vk.virtual_keyboard(&seat, qh)),
+            #[cfg(feature = "input_method")]
+            input_method: self
+                .input_method_manager
+                .as_ref()
+                .map(|im| im.input_method(&seat, qh, self.loop_handle.clone())),
         });
     }
 
@@ -69,6 +79,17 @@ where
                     last_ptr_press: None,
                     last_kbd_press: None,
                     icon: None,
+                    #[cfg(feature = "virtual_keyboard")]
+                    virtual_keyboard: self
+                        .virtual_keyboard_manager
+                        .as_ref()
+                        .map(|vk| vk.virtual_keyboard(&seat.clone(), qh)),
+                    #[cfg(feature = "input_method")]
+                    input_method: self.input_method_manager.as_ref().map(
+                        |im| {
+                            im.input_method(&seat, qh, self.loop_handle.clone())
+                        },
+                    ),
                 });
                 self.seats.last_mut().unwrap()
             }

--- a/sctk/src/handlers/virtual_keyboard.rs
+++ b/sctk/src/handlers/virtual_keyboard.rs
@@ -1,0 +1,123 @@
+use std::{fmt::Debug, marker::PhantomData};
+
+use iced_futures::core::event::wayland::KeyEvent;
+use sctk::reexports::client::{
+    delegate_dispatch,
+    globals::{BindError, GlobalList},
+    protocol::{wl_keyboard, wl_seat::WlSeat},
+    Connection, Dispatch, Proxy, QueueHandle,
+};
+
+use wayland_protocols_misc::zwp_virtual_keyboard_v1::client::{
+    zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1,
+    zwp_virtual_keyboard_v1::ZwpVirtualKeyboardV1,
+};
+
+use sctk::globals::GlobalData;
+
+use crate::event_loop::state::SctkState;
+
+use super::input_method::keyboard::RawModifiers;
+
+#[derive(Debug)]
+pub struct VirtualKeyboardManager<T> {
+    manager: ZwpVirtualKeyboardManagerV1,
+    _phantom: PhantomData<T>,
+}
+
+pub struct VirtualKeyboard {}
+
+impl<T: 'static> VirtualKeyboardManager<T> {
+    pub fn new(
+        globals: &GlobalList,
+        queue_handle: &QueueHandle<SctkState<T>>,
+    ) -> Result<Self, BindError> {
+        let manager = globals.bind(queue_handle, 1..=1, GlobalData)?;
+        Ok(Self {
+            manager,
+            _phantom: PhantomData,
+        })
+    }
+
+    pub fn virtual_keyboard(
+        &self,
+        seat: &WlSeat,
+        queue_handle: &QueueHandle<SctkState<T>>,
+    ) -> ZwpVirtualKeyboardV1 {
+        let data = VirtualKeyboard {};
+        self.manager
+            .create_virtual_keyboard(seat, queue_handle, data)
+    }
+}
+
+impl<T: 'static> Dispatch<ZwpVirtualKeyboardManagerV1, GlobalData, SctkState<T>>
+    for VirtualKeyboardManager<T>
+{
+    fn event(
+        _: &mut SctkState<T>,
+        _: &ZwpVirtualKeyboardManagerV1,
+        _: <ZwpVirtualKeyboardManagerV1 as Proxy>::Event,
+        _: &GlobalData,
+        _: &Connection,
+        _: &QueueHandle<SctkState<T>>,
+    ) {
+        // Ignore zwp_virtual_keyboard_manager events
+    }
+}
+
+impl<T: 'static> Dispatch<ZwpVirtualKeyboardV1, VirtualKeyboard, SctkState<T>>
+    for VirtualKeyboardManager<T>
+{
+    fn event(
+        _: &mut SctkState<T>,
+        _: &ZwpVirtualKeyboardV1,
+        _: <ZwpVirtualKeyboardV1 as Proxy>::Event,
+        _: &VirtualKeyboard,
+        _: &Connection,
+        _: &QueueHandle<SctkState<T>>,
+    ) {
+        // virtual keyboard has no events
+    }
+}
+
+delegate_dispatch!(@<T: 'static> SctkState<T>: [ZwpVirtualKeyboardManagerV1: GlobalData] => VirtualKeyboardManager<T>);
+delegate_dispatch!(@<T: 'static> SctkState<T>: [ZwpVirtualKeyboardV1: VirtualKeyboard] => VirtualKeyboardManager<T>);
+
+impl<T> SctkState<T>
+where
+    T: 'static + Debug,
+{
+    pub fn press_key(&mut self, key: KeyEvent) {
+        let seat = self.seats.first().expect("seat not present"); //TODO: Handle this better
+        if let Some(vk) = seat.virtual_keyboard.as_ref() {
+            vk.key(
+                key.time,
+                key.raw_code,
+                wl_keyboard::KeyState::Pressed.into(),
+            );
+        }
+    }
+
+    pub fn release_key(&mut self, key: KeyEvent) {
+        let seat = self.seats.first().expect("seat not present"); //TODO: Handle this better
+        if let Some(vk) = seat.virtual_keyboard.as_ref() {
+            vk.key(
+                key.time,
+                key.raw_code,
+                wl_keyboard::KeyState::Released.into(),
+            );
+        }
+    }
+
+    pub fn update_modifiers(&mut self, modifiers: RawModifiers) {
+        let seat = self.seats.first().expect("seat not present"); //TODO: Handle this better
+        if let Some(vk) = seat.virtual_keyboard.as_ref() {
+            vk.modifiers(
+                modifiers.mods_depressed,
+                modifiers.mods_latched,
+                modifiers.mods_locked,
+                modifiers.group,
+            );
+        }
+    }
+}

--- a/sctk/src/settings.rs
+++ b/sctk/src/settings.rs
@@ -1,6 +1,8 @@
 use iced_runtime::command::platform_specific::wayland::{
     layer_surface::SctkLayerSurfaceSettings, window::SctkWindowSettings,
 };
+#[cfg(feature = "input_method")]
+use iced_runtime::command::platform_specific::wayland::input_method_popup::InputMethodPopupSettings;
 
 #[derive(Debug)]
 pub struct Settings<Flags> {
@@ -22,6 +24,8 @@ pub struct Settings<Flags> {
 pub enum InitialSurface {
     LayerSurface(SctkLayerSurfaceSettings),
     XdgWindow(SctkWindowSettings),
+    #[cfg(feature = "input_method")]
+    InputMethodPopup(InputMethodPopupSettings),
     None,
 }
 


### PR DESCRIPTION
Adds input method client support to make input methods. Input method support is enabled with a flag and will grab the keyboard. Current protocol also needs virtual keyboard to make a complete input method, therefore support for this is also added.