### PR TITLE
dep: update `glyphon` to `0.4`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ bytemuck = { version = "1.0", features = ["derive"] }
 cosmic-text = { git = "https://github.com/pop-os/cosmic-text.git", branch = "refactor" }
 futures = "0.3"
 glam = "0.24"
-glyphon = { git = "https://github.com/jackpot51/glyphon.git", branch = "refactor" }
+glyphon = "0.4"
 guillotiere = "0.6"
 half = "2.2"
 image = "0.24"
@@ -156,7 +156,7 @@ resvg = "0.37"
 rustc-hash = "1.0"
 sctk = { package = "smithay-client-toolkit", git = "https://github.com/smithay/client-toolkit", rev = "2e9bf9f" }
 smol = "1.0"
-softbuffer = { git = "https://github.com/pop-os/softbuffer", tag = "v0.3-cosmic" } 
+softbuffer = { git = "https://github.com/pop-os/softbuffer", tag = "v0.3-cosmic" }
 syntect = "5.1"
 sysinfo = "0.28"
 thiserror = "1.0"

--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -9,7 +9,6 @@ pub use paragraph::Paragraph;
 
 pub use cosmic_text;
 
-use crate::color;
 use crate::core::font::{self, Font};
 use crate::core::text::Shaping;
 use crate::core::{Color, Point, Rectangle, Size};
@@ -173,12 +172,7 @@ pub fn to_shaping(shaping: Shaping) -> cosmic_text::Shaping {
 
 /// Converts some [`Color`] to a [`cosmic_text::Color`].
 pub fn to_color(color: Color) -> cosmic_text::Color {
-    let [r, g, b, a] = color::pack(color).components();
+    let [r, g, b, a] = color.into_rgba8();
 
-    cosmic_text::Color::rgba(
-        (r * 255.0) as u8,
-        (g * 255.0) as u8,
-        (b * 255.0) as u8,
-        (a * 255.0) as u8,
-    )
+    cosmic_text::Color::rgba(r, g, b, a)
 }

--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -1,7 +1,6 @@
 use crate::core::alignment;
 use crate::core::text::{LineHeight, Shaping};
 use crate::core::{Color, Font, Pixels, Point, Rectangle, Size};
-use crate::graphics::color;
 use crate::graphics::text::cache::{self, Cache};
 use crate::graphics::text::editor;
 use crate::graphics::text::font_system;
@@ -244,18 +243,7 @@ fn draw(
 fn from_color(color: cosmic_text::Color) -> Color {
     let [r, g, b, a] = color.as_rgba();
 
-    if color::GAMMA_CORRECTION {
-        // `cosmic_text::Color` is linear RGB in this case, so we
-        // need to convert back to sRGB
-        Color::from_linear_rgba(
-            r as f32 / 255.0,
-            g as f32 / 255.0,
-            b as f32 / 255.0,
-            a as f32 / 255.0,
-        )
-    } else {
-        Color::from_rgba8(r, g, b, a as f32 / 255.0)
-    }
+    Color::from_rgba8(r, g, b, a as f32 / 255.0)
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
Fixes `Color` to always be in the sRGBA space. Backport from upstream.