### PR TITLE
Remove unnecessary redraw request

### DIFF
--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -533,8 +533,6 @@ async fn run_instance<A, E, C>(
                     mouse_interaction = new_mouse_interaction;
                 }
 
-                window.request_redraw();
-
                 redraw_pending = false;
 
                 let physical_size = state.physical_size();


### PR DESCRIPTION
This was particularly visible on Redox where there is no vsync, but also  causes unnecessary redraws on Linux
