### PR TITLE
Add `show_window_menu` action

### DIFF
--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -179,6 +179,11 @@ pub fn change_level<Message>(id: Id, level: Level) -> Command<Message> {
     Command::single(command::Action::Window(Action::ChangeLevel(id, level)))
 }
 
+/// Show window menu at cursor position.
+pub fn show_window_menu<Message>(id: Id) -> Command<Message> {
+    Command::single(command::Action::Window(Action::ShowWindowMenu(id)))
+}
+
 /// Fetches an identifier unique to the window, provided by the underlying windowing system. This is
 /// not to be confused with [`Id`].
 pub fn fetch_id<Message>(

--- a/runtime/src/window/action.rs
+++ b/runtime/src/window/action.rs
@@ -79,6 +79,11 @@ pub enum Action<T> {
     GainFocus(Id),
     /// Change the window [`Level`].
     ChangeLevel(Id, Level),
+    /// Show window menu at cursor position.
+    ///
+    /// ## Platform-specific
+    /// Android / iOS / macOS / Orbital / Wayland / Web / X11: Unsupported.
+    ShowWindowMenu(Id),
     /// Fetch the raw identifier unique to the window.
     FetchId(Id, Box<dyn FnOnce(u64) -> T + 'static>),
     /// Change the window [`Icon`].
@@ -137,6 +142,7 @@ impl<T> Action<T> {
             }
             Self::GainFocus(id) => Action::GainFocus(id),
             Self::ChangeLevel(id, level) => Action::ChangeLevel(id, level),
+            Self::ShowWindowMenu(id) => Action::ShowWindowMenu(id),
             Self::FetchId(id, o) => {
                 Action::FetchId(id, Box::new(move |s| f(o(s))))
             }
@@ -192,6 +198,9 @@ impl<T> fmt::Debug for Action<T> {
             Self::GainFocus(id) => write!(f, "Action::GainFocus({id:?})"),
             Self::ChangeLevel(id, level) => {
                 write!(f, "Action::ChangeLevel({id:?}, {level:?})")
+            }
+            Self::ShowWindowMenu(id) => {
+                write!(f, "Action::ShowWindowMenu({id:?})")
             }
             Self::FetchId(id, _) => write!(f, "Action::FetchId({id:?})"),
             Self::ChangeIcon(id, _icon) => {

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -1014,6 +1014,14 @@ pub fn run_command<A, C, E>(
                 window::Action::ChangeLevel(_id, level) => {
                     window.set_window_level(conversion::window_level(level));
                 }
+                window::Action::ShowWindowMenu(_id) => {
+                    if let mouse::Cursor::Available(point) = state.cursor() {
+                        window.show_window_menu(winit::dpi::LogicalPosition {
+                            x: point.x,
+                            y: point.y,
+                        });
+                    }
+                }
                 window::Action::FetchId(_id, tag) => {
                     proxy
                         .send_event(UserEventWrapper::Message(tag(window

--- a/winit/src/multi_window.rs
+++ b/winit/src/multi_window.rs
@@ -5,6 +5,7 @@ mod window_manager;
 use crate::application::UserEventWrapper;
 use crate::conversion;
 use crate::core;
+use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::widget::operation;
 use crate::core::widget::Operation;
@@ -1269,6 +1270,20 @@ fn run_command<A, C, E>(
                         window
                             .raw
                             .set_window_level(conversion::window_level(level));
+                    }
+                }
+                window::Action::ShowWindowMenu(id) => {
+                    if let Some(window) = window_manager.get_mut(id) {
+                        if let mouse::Cursor::Available(point) =
+                            window.state.cursor()
+                        {
+                            window.raw.show_window_menu(
+                                winit::dpi::LogicalPosition {
+                                    x: point.x,
+                                    y: point.y,
+                                },
+                            );
+                        }
                     }
                 }
                 window::Action::FetchId(id, tag) => {


### PR DESCRIPTION
Winit currently supports this only on Windows and Wayland.

This requests that a context menu is shown at the cursor position, like the menu normally triggered by right clicking the title bar. This is important for implementing client side decorations with Iced widgets.

Sent upstream in https://github.com/iced-rs/iced/pull/2243.