### PR TITLE
fix: autosize surface layout

### DIFF
--- a/graphics/src/viewport.rs
+++ b/graphics/src/viewport.rs
@@ -12,6 +12,23 @@ pub struct Viewport {
 }
 
 impl Viewport {
+    /// Creates a new [`Viewport`] with the given logical dimensions and scale factor
+    pub fn with_logical_size(size: Size<f32>, scale_factor: f64) -> Viewport {
+        let physical_size = Size::new(
+            (size.width as f64 * scale_factor).ceil() as u32,
+            (size.height as f64 * scale_factor).ceil() as u32,
+        );
+        Viewport {
+            physical_size,
+            logical_size: size,
+            scale_factor,
+            projection: Transformation::orthographic(
+                physical_size.width,
+                physical_size.height,
+            ),
+        }
+    }
+
     /// Creates a new [`Viewport`] with the given physical dimensions and scale
     /// factor.
     pub fn with_physical_size(size: Size<u32>, scale_factor: f64) -> Viewport {

--- a/sctk/src/settings.rs
+++ b/sctk/src/settings.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use iced_runtime::command::platform_specific::wayland::{
     layer_surface::SctkLayerSurfaceSettings, window::SctkWindowSettings,
 };
@@ -16,6 +18,8 @@ pub struct Settings<Flags> {
     pub surface: InitialSurface,
     /// whether the application should exit on close of all windows
     pub exit_on_close_request: bool,
+    /// event loop dispatch timeout
+    pub control_flow_timeout: Option<Duration>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -190,6 +190,7 @@ impl<Flags> From<Settings<Flags>> for iced_sctk::Settings<Flags> {
             flags: settings.flags,
             exit_on_close_request: settings.exit_on_close_request,
             ptr_theme: None,
+            control_flow_timeout: Some(std::time::Duration::from_millis(250)),
         }
     }
 }


### PR DESCRIPTION
Autosized surfaces perform the layout step to get the size and then again when building the interface, but sometimes the calculated size is not enough space when used as a bound, so we need to add a tiny amount to the calculated size. This also makes the event loop timeout duration configurable. Viewport physical size is calculated directly from the logical size now as well in iced-sctk to avoid inconsistencies that resulted from recalculating the logical size after using it to calculate the physical size.
