### PR TITLE
sctk: Fixes for subsurfaces

### DIFF
--- a/examples/sctk_subsurface/src/main.rs
+++ b/examples/sctk_subsurface/src/main.rs
@@ -26,6 +26,7 @@ struct SubsurfaceApp {
 pub enum Message {
     WaylandEvent(WaylandEvent),
     Wayland(wayland::Event),
+    Pressed(&'static str),
 }
 
 impl Application for SubsurfaceApp {
@@ -65,16 +66,32 @@ impl Application for SubsurfaceApp {
                     self.red_buffer = Some(buffer);
                 }
             },
+            Message::Pressed(side) => println!("{side} surface pressed"),
         }
         Command::none()
     }
 
     fn view(&self, _id: window::Id) -> Element<Self::Message> {
         if let Some(buffer) = &self.red_buffer {
-            iced_sctk::subsurface_widget::Subsurface::new(1, 1, buffer)
+            iced::widget::row![
+                iced::widget::button(
+                    iced_sctk::subsurface_widget::Subsurface::new(1, 1, buffer)
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                )
                 .width(Length::Fill)
                 .height(Length::Fill)
-                .into()
+                .on_press(Message::Pressed("left")),
+                iced::widget::button(
+                    iced_sctk::subsurface_widget::Subsurface::new(1, 1, buffer)
+                        .width(Length::Fill)
+                        .height(Length::Fill)
+                )
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .on_press(Message::Pressed("right"))
+            ]
+            .into()
         } else {
             text("No subsurface").into()
         }

--- a/sctk/src/application.rs
+++ b/sctk/src/application.rs
@@ -898,7 +898,7 @@ where
                 );
 
                 let subsurfaces = crate::subsurface_widget::take_subsurfaces();
-                if let Some(subsurface_state) = subsurface_state.as_ref() {
+                if let Some(subsurface_state) = subsurface_state.as_mut() {
                     subsurface_state.update_subsurfaces(
                         &state.wrapper.wl_surface,
                         &mut state.subsurfaces,
@@ -1385,7 +1385,7 @@ where
                     // Update subsurfaces based on what view requested.
                     let subsurfaces =
                         crate::subsurface_widget::take_subsurfaces();
-                    if let Some(subsurface_state) = subsurface_state.as_ref() {
+                    if let Some(subsurface_state) = subsurface_state.as_mut() {
                         subsurface_state.update_subsurfaces(
                             &state.wrapper.wl_surface,
                             &mut state.subsurfaces,

--- a/sctk/src/event_loop/mod.rs
+++ b/sctk/src/event_loop/mod.rs
@@ -528,7 +528,7 @@ where
 
             for event in frame_event_back_buffer.drain(..) {
                 sticky_exit_callback(
-                    IcedSctkEvent::Frame(event),
+                    IcedSctkEvent::Frame(event.0, event.1),
                     &self.state,
                     &mut control_flow,
                     &mut callback,

--- a/sctk/src/event_loop/mod.rs
+++ b/sctk/src/event_loop/mod.rs
@@ -333,6 +333,7 @@ where
                         wl_shm,
                         wp_dmabuf,
                         qh: self.state.queue_handle.clone(),
+                        buffers: HashMap::new(),
                     }),
                     &self.state,
                     &mut control_flow,

--- a/sctk/src/event_loop/state.rs
+++ b/sctk/src/event_loop/state.rs
@@ -296,7 +296,7 @@ pub struct SctkState<T> {
     /// A sink for window and device events that is being filled during dispatching
     /// event loop and forwarded downstream afterwards.
     pub(crate) sctk_events: Vec<SctkEvent>,
-    pub(crate) frame_events: Vec<WlSurface>,
+    pub(crate) frame_events: Vec<(WlSurface, u32)>,
 
     /// pending user events
     pub pending_user_events: Vec<Event<T>>,

--- a/sctk/src/handlers/compositor.rs
+++ b/sctk/src/handlers/compositor.rs
@@ -26,7 +26,8 @@ impl<T: Debug> CompositorHandler for SctkState<T> {
         surface: &wl_surface::WlSurface,
         _time: u32,
     ) {
-        self.frame_events.push(surface.clone());
+        // TODO time; map subsurface to parent:w
+        self.frame_events.push((surface.clone(), 0));
     }
 
     fn transform_changed(

--- a/sctk/src/handlers/shell/layer.rs
+++ b/sctk/src/handlers/shell/layer.rs
@@ -72,7 +72,8 @@ impl<T: Debug> LayerShellHandler for SctkState<T> {
             ),
             id: layer.surface.wl_surface().clone(),
         });
-        self.frame_events.push(layer.surface.wl_surface().clone());
+        self.frame_events
+            .push((layer.surface.wl_surface().clone(), 0));
     }
 }
 

--- a/sctk/src/handlers/shell/xdg_popup.rs
+++ b/sctk/src/handlers/shell/xdg_popup.rs
@@ -36,7 +36,7 @@ impl<T: Debug> PopupHandler for SctkState<T> {
                 SctkSurface::Popup(s) => s.clone(),
             },
         });
-        self.frame_events.push(popup.wl_surface().clone());
+        self.frame_events.push((popup.wl_surface().clone(), 0));
     }
 
     fn done(

--- a/sctk/src/handlers/shell/xdg_window.rs
+++ b/sctk/src/handlers/shell/xdg_window.rs
@@ -104,7 +104,7 @@ impl<T: Debug> WindowHandler for SctkState<T> {
             ),
             id,
         });
-        self.frame_events.push(wl_surface.clone());
+        self.frame_events.push((wl_surface.clone(), 0));
     }
 }
 

--- a/sctk/src/sctk_event.rs
+++ b/sctk/src/sctk_event.rs
@@ -393,6 +393,7 @@ impl SctkEvent {
         modifiers: &mut Modifiers,
         surface_ids: &HashMap<ObjectId, SurfaceIdWrapper>,
         destroyed_surface_ids: &HashMap<ObjectId, SurfaceIdWrapper>,
+        subsurface_ids: &HashMap<ObjectId, (i32, i32, SurfaceIdWrapper)>,
     ) -> Vec<iced_runtime::core::Event> {
         match self {
             // TODO Ashley: Platform specific multi-seat events?
@@ -409,11 +410,18 @@ impl SctkEvent {
                     )]
                 }
                 PointerEventKind::Motion { .. } => {
+                    let offset = if let Some((x_offset, y_offset, _)) =
+                        subsurface_ids.get(&variant.surface.id())
+                    {
+                        (*x_offset, *y_offset)
+                    } else {
+                        (0, 0)
+                    };
                     vec![iced_runtime::core::Event::Mouse(
                         mouse::Event::CursorMoved {
                             position: Point::new(
-                                variant.position.0 as f32,
-                                variant.position.1 as f32,
+                                variant.position.0 as f32 + offset.0 as f32,
+                                variant.position.1 as f32 + offset.1 as f32,
                             ),
                         },
                     )]

--- a/sctk/src/sctk_event.rs
+++ b/sctk/src/sctk_event.rs
@@ -122,7 +122,7 @@ pub enum IcedSctkEvent<T> {
     DndSurfaceCreated(WlSurface, DndIcon, SurfaceId),
 
     /// Frame callback event
-    Frame(WlSurface),
+    Frame(WlSurface, u32),
 
     Subcompositor(SubsurfaceState<T>),
 }

--- a/sctk/src/subsurface_widget.rs
+++ b/sctk/src/subsurface_widget.rs
@@ -8,11 +8,15 @@ use crate::core::{
 };
 use std::{
     cell::RefCell,
+    collections::HashMap,
+    fmt::Debug,
     future::Future,
+    hash::{Hash, Hasher},
     mem,
     os::unix::io::{AsFd, OwnedFd},
     pin::Pin,
-    sync::Arc,
+    ptr,
+    sync::{Arc, Mutex, Weak},
     task,
 };
 
@@ -103,7 +107,15 @@ struct SubsurfaceBufferInner {
 pub struct SubsurfaceBuffer(Arc<SubsurfaceBufferInner>);
 
 pub struct BufferData {
-    source: SubsurfaceBuffer,
+    source: WeakBufferSource,
+    // This reference is held until the surface `release`s the buffer
+    subsurface_buffer: Mutex<Option<SubsurfaceBuffer>>,
+}
+
+impl BufferData {
+    fn for_buffer(buffer: &WlBuffer) -> Option<&Self> {
+        buffer.data::<BufferData>()
+    }
 }
 
 /// Future signalled when subsurface buffer is released
@@ -163,7 +175,10 @@ impl SubsurfaceBuffer {
                     buf.format,
                     qh,
                     BufferData {
-                        source: self.clone(),
+                        source: WeakBufferSource(Arc::downgrade(
+                            &self.0.source,
+                        )),
+                        subsurface_buffer: Mutex::new(Some(self.clone())),
                     },
                 );
                 pool.destroy();
@@ -192,7 +207,10 @@ impl SubsurfaceBuffer {
                         zwp_linux_buffer_params_v1::Flags::empty(),
                         qh,
                         BufferData {
-                            source: self.clone(),
+                            source: WeakBufferSource(Arc::downgrade(
+                                &self.0.source,
+                            )),
+                            subsurface_buffer: Mutex::new(Some(self.clone())),
                         },
                     ))
                 } else {
@@ -200,10 +218,6 @@ impl SubsurfaceBuffer {
                 }
             }
         }
-    }
-
-    fn for_buffer(buffer: &WlBuffer) -> Option<&Self> {
-        Some(&buffer.data::<BufferData>()?.source)
     }
 }
 
@@ -255,14 +269,35 @@ impl<T> Dispatch<WlBuffer, BufferData> for SctkState<T> {
         _: &mut SctkState<T>,
         _: &WlBuffer,
         event: wl_buffer::Event,
-        _: &BufferData,
+        data: &BufferData,
         _: &Connection,
         _: &QueueHandle<SctkState<T>>,
     ) {
         match event {
-            wl_buffer::Event::Release => {}
+            wl_buffer::Event::Release => {
+                // Release reference to `SubsurfaceBuffer`
+                data.subsurface_buffer.lock().unwrap().take();
+            }
             _ => unreachable!(),
         }
+    }
+}
+
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub(crate) struct WeakBufferSource(Weak<BufferSource>);
+
+impl PartialEq for WeakBufferSource {
+    fn eq(&self, rhs: &Self) -> bool {
+        Weak::ptr_eq(&self.0, &rhs.0)
+    }
+}
+
+impl Eq for WeakBufferSource {}
+
+impl Hash for WeakBufferSource {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        ptr::hash::<BufferSource, _>(self.0.as_ptr(), state)
     }
 }
 
@@ -276,9 +311,10 @@ pub struct SubsurfaceState<T> {
     pub wl_shm: WlShm,
     pub wp_dmabuf: Option<ZwpLinuxDmabufV1>,
     pub qh: QueueHandle<SctkState<T>>,
+    pub(crate) buffers: HashMap<WeakBufferSource, Vec<WlBuffer>>,
 }
 
-impl<T: std::fmt::Debug + 'static> SubsurfaceState<T> {
+impl<T: Debug + 'static> SubsurfaceState<T> {
     fn create_subsurface(&self, parent: &WlSurface) -> SubsurfaceInstance {
         let wl_surface = self
             .wl_compositor
@@ -305,11 +341,20 @@ impl<T: std::fmt::Debug + 'static> SubsurfaceState<T> {
 
     // Update `subsurfaces` from `view_subsurfaces`
     pub(crate) fn update_subsurfaces(
-        &self,
+        &mut self,
         parent: &WlSurface,
         subsurfaces: &mut Vec<SubsurfaceInstance>,
         view_subsurfaces: &[SubsurfaceInfo],
     ) {
+        // Remove cached `wl_buffers` for any `BufferSource`s that no longer exist.
+        self.buffers.retain(|k, v| {
+            let retain = k.0.strong_count() > 0;
+            if !retain {
+                v.iter().for_each(|b| b.destroy());
+            }
+            retain
+        });
+
         // If view requested fewer subsurfaces than there currently are,
         // destroy excess.
         if view_subsurfaces.len() < subsurfaces.len() {
@@ -323,13 +368,53 @@ impl<T: std::fmt::Debug + 'static> SubsurfaceState<T> {
         for (subsurface_data, subsurface) in
             view_subsurfaces.iter().zip(subsurfaces.iter_mut())
         {
-            subsurface.attach_and_commit(
-                subsurface_data,
-                &self.wl_shm,
-                self.wp_dmabuf.as_ref(),
-                &self.qh,
-            );
+            subsurface.attach_and_commit(subsurface_data, self);
         }
+    }
+
+    // Cache `wl_buffer` for use when `BufferSource` is used in future
+    // (Avoid creating wl_buffer each buffer swap)
+    fn insert_cached_wl_buffer(&mut self, buffer: WlBuffer) {
+        let source = BufferData::for_buffer(&buffer).unwrap().source.clone();
+        self.buffers.entry(source).or_default().push(buffer);
+    }
+
+    // Gets a cached `wl_buffer` for the `SubsurfaceBuffer`, if any. And stores `SubsurfaceBuffer`
+    // reference to be releated on `wl_buffer` release.
+    //
+    // If `wl_buffer` isn't released, it is destroyed instead.
+    fn get_cached_wl_buffer(
+        &mut self,
+        subsurface_buffer: &SubsurfaceBuffer,
+    ) -> Option<WlBuffer> {
+        let buffers = self.buffers.get_mut(&WeakBufferSource(
+            Arc::downgrade(&subsurface_buffer.0.source),
+        ))?;
+        while let Some(buffer) = buffers.pop() {
+            let mut subsurface_buffer_ref = buffer
+                .data::<BufferData>()
+                .unwrap()
+                .subsurface_buffer
+                .lock()
+                .unwrap();
+            if subsurface_buffer_ref.is_none() {
+                *subsurface_buffer_ref = Some(subsurface_buffer.clone());
+                drop(subsurface_buffer_ref);
+                return Some(buffer);
+            } else {
+                buffer.destroy();
+            }
+        }
+        None
+    }
+}
+
+impl<T> Drop for SubsurfaceState<T> {
+    fn drop(&mut self) {
+        self.buffers
+            .values()
+            .flatten()
+            .for_each(|buffer| buffer.destroy());
     }
 }
 
@@ -343,36 +428,41 @@ pub(crate) struct SubsurfaceInstance {
 
 impl SubsurfaceInstance {
     // TODO correct damage? no damage/commit if unchanged?
-    fn attach_and_commit<T: 'static>(
+    fn attach_and_commit<T: Debug + 'static>(
         &mut self,
         info: &SubsurfaceInfo,
-        shm: &WlShm,
-        dmabuf: Option<&ZwpLinuxDmabufV1>,
-        qh: &QueueHandle<SctkState<T>>,
+        state: &mut SubsurfaceState<T>,
     ) {
         let buffer_changed;
-        let buffer = match self.wl_buffer.take() {
-            Some(buffer)
-                if SubsurfaceBuffer::for_buffer(&buffer)
-                    == Some(&info.buffer) =>
-            {
-                // Same buffer is already attached to this subsurface. Don't create new `wl_buffer`.
-                buffer_changed = false;
-                buffer
+
+        let old_buffer = self.wl_buffer.take();
+        let old_buffer_data =
+            old_buffer.as_ref().and_then(|b| BufferData::for_buffer(&b));
+        let buffer = if old_buffer_data.is_some_and(|b| {
+            b.subsurface_buffer.lock().unwrap().as_ref() == Some(&info.buffer)
+        }) {
+            // Same "BufferSource" is already attached to this subsurface. Don't create new `wl_buffer`.
+            buffer_changed = false;
+            old_buffer.unwrap()
+        } else {
+            if let Some(old_buffer) = old_buffer {
+                state.insert_cached_wl_buffer(old_buffer);
             }
-            buffer => {
-                if let Some(buffer) = buffer {
-                    buffer.destroy();
-                }
-                if let Some(buffer) = info.buffer.create_buffer(shm, dmabuf, qh)
-                {
-                    buffer_changed = true;
-                    buffer
-                } else {
-                    // TODO log error
-                    self.wl_surface.attach(None, 0, 0);
-                    return;
-                }
+
+            buffer_changed = true;
+
+            if let Some(buffer) = state.get_cached_wl_buffer(&info.buffer) {
+                buffer
+            } else if let Some(buffer) = info.buffer.create_buffer(
+                &state.wl_shm,
+                state.wp_dmabuf.as_ref(),
+                &state.qh,
+            ) {
+                buffer
+            } else {
+                // TODO log error
+                self.wl_surface.attach(None, 0, 0);
+                return;
             }
         };
 

--- a/sctk/src/subsurface_widget.rs
+++ b/sctk/src/subsurface_widget.rs
@@ -419,7 +419,7 @@ impl<T> Drop for SubsurfaceState<T> {
 }
 
 pub(crate) struct SubsurfaceInstance {
-    wl_surface: WlSurface,
+    pub(crate) wl_surface: WlSurface,
     wl_subsurface: WlSubsurface,
     wp_viewport: WpViewport,
     wl_buffer: Option<WlBuffer>,
@@ -482,6 +482,7 @@ impl SubsurfaceInstance {
             self.wl_surface.damage(0, 0, i32::MAX, i32::MAX);
         }
         if buffer_changed || bounds_changed {
+            self.wl_surface.frame(&state.qh, self.wl_surface.clone());
             self.wl_surface.commit();
         }
 


### PR DESCRIPTION
Fixes issue with compositor not redrawing subsurfaces in some cases, avoids creating unnecessary `wl_buffers`s, maps input to subsurfaces with correct offset within window, and other improvements.