### PR TITLE
refactor(sctk): optional clipboard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,10 @@ advanced = []
 a11y = ["iced_accessibility", "iced_core/a11y", "iced_widget/a11y", "iced_winit?/a11y", "iced_sctk?/a11y"]
 # Enables the winit shell. Conflicts with `wayland` and `glutin`.
 winit = ["iced_winit", "iced_accessibility?/accesskit_winit"]
-# Enables the sctk shell. COnflicts with `winit` and `glutin`.
+# Enables the sctk shell. Conflicts with `winit` and `glutin`.
 wayland = ["iced_sctk", "iced_widget/wayland", "iced_accessibility?/accesskit_unix", "iced_core/wayland"]
+# Enables clipboard for iced_sctk
+wayland-clipboard = ["iced_sctk?/clipboard"]
 
 [dependencies]
 iced_core.workspace = true

--- a/sctk/Cargo.toml
+++ b/sctk/Cargo.toml
@@ -10,6 +10,7 @@ debug = ["iced_runtime/debug"]
 system = ["sysinfo"]
 application = []
 a11y = ["iced_accessibility", "iced_runtime/a11y"]
+clipboard = ["smithay-clipboard"]
 
 [dependencies]
 tracing = "0.1"
@@ -22,7 +23,7 @@ enum-repr = "0.2"
 futures = "0.3"
 wayland-backend = {version = "0.3.1", features = ["client_system"]}
 float-cmp = "0.9"
-smithay-clipboard = "0.6"
+smithay-clipboard = { version = "0.7", optional = true }
 xkbcommon-dl = "0.4.1"
 xkbcommon = { version = "0.7", features = ["wayland"] }
 itertools = "0.12"

--- a/sctk/src/application.rs
+++ b/sctk/src/application.rs
@@ -38,17 +38,7 @@ use iced_futures::{
 };
 use tracing::error;
 
-use sctk::{
-    reexports::client::{protocol::wl_surface::WlSurface, Proxy, QueueHandle},
-    seat::{keyboard::Modifiers, pointer::PointerEventKind},
-};
-use std::{
-    collections::HashMap, hash::Hash, marker::PhantomData, os::raw::c_void,
-    ptr::NonNull, time::Duration,
-};
-use wayland_backend::client::ObjectId;
-use wayland_protocols::wp::viewporter::client::wp_viewport::WpViewport;
-
+use iced_futures::core::Clipboard as IcedClipboard;
 use iced_graphics::{compositor, Compositor, Viewport};
 use iced_runtime::{
     clipboard,
@@ -72,7 +62,17 @@ use raw_window_handle::{
     RawDisplayHandle, RawWindowHandle, WaylandDisplayHandle,
     WaylandWindowHandle, WindowHandle,
 };
+use sctk::{
+    reexports::client::{protocol::wl_surface::WlSurface, Proxy, QueueHandle},
+    seat::{keyboard::Modifiers, pointer::PointerEventKind},
+};
 use std::mem::ManuallyDrop;
+use std::{
+    collections::HashMap, hash::Hash, marker::PhantomData, os::raw::c_void,
+    ptr::NonNull, time::Duration,
+};
+use wayland_backend::client::ObjectId;
+use wayland_protocols::wp::viewporter::client::wp_viewport::WpViewport;
 
 use crate::subsurface_widget::{SubsurfaceInstance, SubsurfaceState};
 
@@ -523,7 +523,7 @@ where
                                         backend: backend.clone(),
                                         wl_surface
                                     };
-                                    if matches!(simple_clipboard.state,  crate::clipboard::State::Unavailable) {
+                                    if matches!(simple_clipboard.state(),  crate::clipboard::State::Unavailable) {
                                        if let Ok(h) = wrapper.display_handle() {
                                            if let RawDisplayHandle::Wayland(mut h) = h.as_raw() {
                                            simple_clipboard = unsafe { Clipboard::connect(h.display.as_mut()) };
@@ -601,7 +601,7 @@ where
                                          backend: backend.clone(),
                                          wl_surface
                                      };
-                                     if matches!(simple_clipboard.state,  crate::clipboard::State::Unavailable) {
+                                     if matches!(simple_clipboard.state(),  crate::clipboard::State::Unavailable) {
                                         if let Ok(h) = wrapper.display_handle() {
                                             if let RawDisplayHandle::Wayland(mut h) = h.as_raw() {
                                             simple_clipboard = unsafe { Clipboard::connect(h.display.as_mut()) };
@@ -2006,14 +2006,14 @@ where
             }
             command::Action::Clipboard(action) => match action {
                 clipboard::Action::Read(s_to_msg) => {
-                    if matches!(clipboard.state,  crate::clipboard::State::Connected(_)) {
+                    if matches!(clipboard.state(),  crate::clipboard::State::Connected(_)) {
                         let contents = clipboard.read();
                         let message = s_to_msg(contents);
                         proxy.send_event(Event::Message(message));
                     }
                 }
                 clipboard::Action::Write(contents) => {
-                    if matches!(clipboard.state,  crate::clipboard::State::Connected(_)) {
+                    if matches!(clipboard.state(),  crate::clipboard::State::Connected(_)) {
                         clipboard.write(contents)
                     }
                 }

--- a/sctk/src/clipboard/clipboard.rs
+++ b/sctk/src/clipboard/clipboard.rs
@@ -28,6 +28,10 @@ impl Clipboard {
         }
     }
 
+    pub fn state(&self) -> State {
+        self.state
+    }
+
     /// Creates a new [`Clipboard`] that isn't associated with a window.
     /// This clipboard will never contain a copied value.
     pub fn unconnected() -> Clipboard {

--- a/sctk/src/clipboard/mod.rs
+++ b/sctk/src/clipboard/mod.rs
@@ -1,0 +1,41 @@
+#[cfg(feature = "clipboard")]
+mod clipboard;
+
+#[cfg(not(feature = "clipboard"))]
+mod clipboard {
+    use std::ffi::c_void;
+    /// A buffer for short-term storage and transfer within and between
+    /// applications.
+    #[allow(missing_debug_implementations)]
+    pub struct Clipboard;
+
+    pub(crate) enum State {
+        Connected(()),
+        Unavailable,
+    }
+
+    impl Clipboard {
+        pub unsafe fn connect(display: *mut c_void) -> Clipboard {
+            Clipboard
+        }
+
+        pub fn state(&self) -> State {
+            State::Connected(())
+        }
+
+        /// Creates a new [`Clipboard`]
+        pub fn unconnected() -> Clipboard {
+            Clipboard
+        }
+    }
+}
+
+impl iced_runtime::core::clipboard::Clipboard for Clipboard {
+    fn read(&self) -> Option<String> {
+        None
+    }
+
+    fn write(&mut self, contents: String) {}
+}
+
+pub use clipboard::*;


### PR DESCRIPTION
This updates smithay-clipboard for iced_sctk and makes it optional. None of the applets really need the clipboard, so it could be disabled for them, and should lower cpu usage basically to 0 for many of them like the time applet. I think by default, libcosmic could disable clipboard for applets, but enable it for regular applications.