### PR TITLE
sctk: Fix handling of layer surface `pointer_interactivity`

### DIFF
--- a/sctk/src/event_loop/state.rs
+++ b/sctk/src/event_loop/state.rs
@@ -45,6 +45,7 @@ use sctk::{
             protocol::{
                 wl_keyboard::WlKeyboard,
                 wl_output::WlOutput,
+                wl_region::WlRegion,
                 wl_seat::WlSeat,
                 wl_subsurface::WlSubsurface,
                 wl_surface::{self, WlSurface},
@@ -786,7 +787,12 @@ where
             .set_size(size.0.unwrap_or_default(), size.1.unwrap_or_default());
         layer_surface.set_exclusive_zone(exclusive_zone);
         if !pointer_interactivity {
-            layer_surface.set_input_region(None);
+            let region = self
+                .compositor_state
+                .wl_compositor()
+                .create_region(&self.queue_handle, ());
+            layer_surface.set_input_region(Some(&region));
+            region.destroy();
         }
         layer_surface.commit();
 
@@ -846,3 +852,4 @@ where
 }
 
 delegate_noop!(@<T: 'static + Debug> SctkState<T>: ignore WlSubsurface);
+delegate_noop!(@<T: 'static + Debug> SctkState<T>: ignore WlRegion);


### PR DESCRIPTION
A null `region` represents an infinite region (the default). To set an empty region, we need to create a `wl_region`.