### PR TITLE
feat: winit dnd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,22 @@ multi-window = ["iced_winit?/multi-window"]
 # Enables the advanced module
 advanced = []
 # Enables the `accesskit` accessibility library
-a11y = ["iced_accessibility", "iced_core/a11y", "iced_widget/a11y", "iced_winit?/a11y", "iced_sctk?/a11y"]
+a11y = [
+    "iced_accessibility",
+    "iced_core/a11y",
+    "iced_widget/a11y",
+    "iced_winit?/a11y",
+    "iced_sctk?/a11y",
+]
 # Enables the winit shell. Conflicts with `wayland` and `glutin`.
 winit = ["iced_winit", "iced_accessibility?/accesskit_winit"]
 # Enables the sctk shell. Conflicts with `winit` and `glutin`.
-wayland = ["iced_sctk", "iced_widget/wayland", "iced_accessibility?/accesskit_unix", "iced_core/wayland"]
+wayland = [
+    "iced_sctk",
+    "iced_widget/wayland",
+    "iced_accessibility?/accesskit_unix",
+    "iced_core/wayland",
+]
 # Enables clipboard for iced_sctk
 wayland-clipboard = ["iced_sctk?/clipboard"]
 
@@ -75,6 +86,8 @@ iced_accessibility.workspace = true
 iced_accessibility.optional = true
 thiserror.workspace = true
 window_clipboard.workspace = true
+mime.workspace = true
+dnd.workspace = true
 
 image.workspace = true
 image.optional = true
@@ -94,7 +107,7 @@ members = [
     "winit",
     "examples/*",
     "accessibility",
-    "sctk"
+    "sctk",
 ]
 exclude = ["examples/integration"]
 
@@ -158,7 +171,7 @@ qrcode = { version = "0.12", default-features = false }
 raw-window-handle = "0.6"
 resvg = "0.37"
 rustc-hash = "1.0"
-sctk = { package = "smithay-client-toolkit", git = "https://github.com/smithay/client-toolkit", rev = "2e9bf9f" }
+sctk = { package = "smithay-client-toolkit", git = "https://github.com/smithay/client-toolkit", rev = "3bed072" }
 smol = "1.0"
 smol_str = "0.2"
 softbuffer = { git = "https://github.com/pop-os/softbuffer", tag = "cosmic-4.0" }
@@ -172,13 +185,17 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 unicode-segmentation = "1.0"
 wasm-bindgen-futures = "0.4"
 wasm-timer = "0.2"
-wayland-protocols = { version = "0.31.0", features = [ "staging"]}
+wayland-protocols = { version = "0.31.0", features = ["staging"] }
 web-sys = "0.3"
 web-time = "0.2"
 # wgpu = "0.19"
 # Newer wgpu commit that fixes Vulkan backend on Nvidia
 wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "20fda69" }
 winapi = "0.3"
-window_clipboard = { git = "https://github.com/pop-os/window_clipboard.git", tag = "pop-mime-types" } 
-# window_clipboard = { path = "../window_clipboard" } 
+window_clipboard = { git = "https://github.com/pop-os/window_clipboard.git", tag = "pop-dnd" }
+dnd = { git = "https://github.com/pop-os/window_clipboard.git", tag = "pop-dnd" }
+mime = { git = "https://github.com/pop-os/window_clipboard.git", tag = "pop-dnd" }
+# window_clipboard = { path = "../window_clipboard" }
+# dnd = { path = "../window_clipboard/dnd" }
+# mime = { path = "../window_clipboard/mime" }
 winit = { git = "https://github.com/pop-os/winit.git", branch = "winit-0.29" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,6 +23,8 @@ thiserror.workspace = true
 web-time.workspace = true
 xxhash-rust.workspace = true
 window_clipboard.workspace = true
+dnd.workspace = true
+mime.workspace = true
 
 sctk.workspace = true
 sctk.optional = true

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -1,4 +1,7 @@
 //! Handle events of a user interface.
+use dnd::DndEvent;
+use dnd::DndSurface;
+
 use crate::keyboard;
 use crate::mouse;
 use crate::touch;
@@ -32,6 +35,9 @@ pub enum Event {
         crate::widget::Id,
         iced_accessibility::accesskit::ActionRequest,
     ),
+
+    /// A DnD event.
+    Dnd(DndEvent<DndSurface>),
 
     /// A platform specific event
     PlatformSpecific(PlatformSpecific),

--- a/core/src/widget/tree.rs
+++ b/core/src/widget/tree.rs
@@ -53,6 +53,21 @@ impl Tree {
         }
     }
 
+    /// Finds a widget state in the tree by its id.
+    pub fn find<'a>(&'a self, id: &Id) -> Option<&'a Tree> {
+        if self.id == Some(id.clone()) {
+            return Some(self);
+        }
+
+        for child in self.children.iter() {
+            if let Some(tree) = child.find(id) {
+                return Some(tree);
+            }
+        }
+
+        None
+    }
+
     /// Reconciliates the current tree with the provided [`Widget`].
     ///
     /// If the tag of the [`Widget`] matches the tag of the [`Tree`], then the

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,3 +26,4 @@ thiserror.workspace = true
 iced_accessibility.workspace = true
 iced_accessibility.optional = true
 window_clipboard.workspace = true
+dnd.workspace = true

--- a/runtime/src/command/action.rs
+++ b/runtime/src/command/action.rs
@@ -4,6 +4,7 @@ use crate::font;
 use crate::system;
 use crate::window;
 
+use dnd::DndAction;
 use iced_futures::MaybeSend;
 
 use std::borrow::Cow;
@@ -34,6 +35,9 @@ pub enum Action<T> {
 
     /// Run a widget action.
     Widget(Box<dyn widget::Operation<T>>),
+
+    /// Run a Dnd action.
+    Dnd(crate::dnd::DndAction<T>),
 
     /// Load a font from its bytes.
     LoadFont {
@@ -78,6 +82,9 @@ impl<T> Action<T> {
             Self::PlatformSpecific(action) => {
                 Action::PlatformSpecific(action.map(f))
             }
+            Self::Dnd(a) => Action::Dnd(a.map(f)),
+            Action::LoadFont { bytes, tagger } => todo!(),
+            Action::PlatformSpecific(_) => todo!(),
         }
     }
 }
@@ -99,6 +106,7 @@ impl<T> fmt::Debug for Action<T> {
             Self::PlatformSpecific(action) => {
                 write!(f, "Action::PlatformSpecific({:?})", action)
             }
+            Self::Dnd(action) => write!(f, "Action::Dnd"),
         }
     }
 }

--- a/runtime/src/dnd.rs
+++ b/runtime/src/dnd.rs
@@ -1,0 +1,162 @@
+//! Access the clipboard.
+
+use std::any::Any;
+
+use dnd::{DndDestinationRectangle, DndSurface};
+use iced_core::clipboard::DndSource;
+use iced_futures::MaybeSend;
+use window_clipboard::mime::{AllowedMimeTypes, AsMimeTypes};
+
+use crate::{command, Command};
+
+/// An action to be performed on the system.
+pub enum DndAction<T> {
+    /// Register a Dnd destination.
+    RegisterDndDestination {
+        /// The surface to register.
+        surface: DndSurface,
+        /// The rectangles to register.
+        rectangles: Vec<DndDestinationRectangle>,
+    },
+    /// Start a Dnd operation.
+    StartDnd {
+        /// Whether the Dnd operation is internal.
+        internal: bool,
+        /// The source surface of the Dnd operation.
+        source_surface: Option<DndSource>,
+        /// The icon surface of the Dnd operation.
+        icon_surface: Option<Box<dyn Any>>,
+        /// The content of the Dnd operation.
+        content: Box<dyn AsMimeTypes + Send + 'static>,
+        /// The actions of the Dnd operation.
+        actions: dnd::DndAction,
+    },
+    /// End a Dnd operation.
+    EndDnd,
+    /// Peek the current Dnd operation.
+    PeekDnd(String, Box<dyn Fn(Option<(Vec<u8>, String)>) -> T>),
+    /// Set the action of the Dnd operation.
+    SetAction(dnd::DndAction),
+}
+
+impl<T> std::fmt::Debug for DndAction<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RegisterDndDestination {
+                surface,
+                rectangles,
+            } => f
+                .debug_struct("RegisterDndDestination")
+                .field("surface", surface)
+                .field("rectangles", rectangles)
+                .finish(),
+            Self::StartDnd {
+                internal,
+                source_surface,
+                icon_surface,
+                content: _,
+                actions,
+            } => f
+                .debug_struct("StartDnd")
+                .field("internal", internal)
+                .field("source_surface", source_surface)
+                .field("icon_surface", icon_surface)
+                .field("actions", actions)
+                .finish(),
+            Self::EndDnd => f.write_str("EndDnd"),
+            Self::PeekDnd(mime, _) => {
+                f.debug_struct("PeekDnd").field("mime", mime).finish()
+            }
+            Self::SetAction(a) => f.debug_tuple("SetAction").field(a).finish(),
+        }
+    }
+}
+
+impl<T> DndAction<T> {
+    /// Maps the output of a system [`Action`] using the provided closure.
+    pub fn map<A>(
+        self,
+        f: impl Fn(T) -> A + 'static + MaybeSend + Sync,
+    ) -> DndAction<A>
+    where
+        T: 'static,
+    {
+        match self {
+            Self::PeekDnd(m, o) => {
+                DndAction::PeekDnd(m, Box::new(move |d| f(o(d))))
+            }
+            Self::EndDnd => DndAction::EndDnd,
+            Self::SetAction(a) => DndAction::SetAction(a),
+            Self::StartDnd {
+                internal,
+                source_surface,
+                icon_surface,
+                content,
+                actions,
+            } => DndAction::StartDnd {
+                internal,
+                source_surface,
+                icon_surface,
+                content,
+                actions,
+            },
+            Self::RegisterDndDestination {
+                surface,
+                rectangles,
+            } => DndAction::RegisterDndDestination {
+                surface,
+                rectangles,
+            },
+        }
+    }
+}
+
+/// Read the current contents of the Dnd operation.
+pub fn peek_dnd<T: AllowedMimeTypes + Send + Sync + 'static, Message>(
+    f: impl Fn(Option<T>) -> Message + 'static,
+) -> Command<Message> {
+    Command::single(command::Action::Dnd(DndAction::PeekDnd(
+        T::allowed()
+            .get(0)
+            .map_or_else(|| String::new(), |s| s.to_string()),
+        Box::new(move |d| f(d.and_then(|d| T::try_from(d).ok()))),
+    )))
+}
+
+/// Register a Dnd destination.
+pub fn register_dnd_destination<Message>(
+    surface: DndSurface,
+    rectangles: Vec<DndDestinationRectangle>,
+) -> Command<Message> {
+    Command::single(command::Action::Dnd(DndAction::RegisterDndDestination {
+        surface,
+        rectangles,
+    }))
+}
+
+/// Start a Dnd operation.
+pub fn start_dnd<Message>(
+    internal: bool,
+    source_surface: Option<DndSource>,
+    icon_surface: Option<Box<dyn Any>>,
+    content: Box<dyn AsMimeTypes + Send + 'static>,
+    actions: dnd::DndAction,
+) -> Command<Message> {
+    Command::single(command::Action::Dnd(DndAction::StartDnd {
+        internal,
+        source_surface,
+        icon_surface,
+        content,
+        actions,
+    }))
+}
+
+/// End a Dnd operation.
+pub fn end_dnd<Message>() -> Command<Message> {
+    Command::single(command::Action::Dnd(DndAction::EndDnd))
+}
+
+/// Set the action of the Dnd operation.
+pub fn set_action<Message>(a: dnd::DndAction) -> Command<Message> {
+    Command::single(command::Action::Dnd(DndAction::SetAction(a)))
+}

--- a/runtime/src/dnd.rs
+++ b/runtime/src/dnd.rs
@@ -73,7 +73,7 @@ impl<T> std::fmt::Debug for DndAction<T> {
 }
 
 impl<T> DndAction<T> {
-    /// Maps the output of a system [`Action`] using the provided closure.
+    /// Maps the output of a [`DndAction`] using the provided closure.
     pub fn map<A>(
         self,
         f: impl Fn(T) -> A + 'static + MaybeSend + Sync,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -18,6 +18,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub mod clipboard;
 pub mod command;
+pub mod dnd;
 pub mod font;
 pub mod keyboard;
 pub mod overlay;

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -620,6 +620,11 @@ where
             cursor,
         )
     }
+
+    /// Find widget with given id
+    pub fn find(&self, id: &widget::Id) -> Option<&widget::Tree> {
+        self.state.find(id)
+    }
 }
 
 /// Reusable data of a specific [`UserInterface`].

--- a/sctk/src/event_loop/state.rs
+++ b/sctk/src/event_loop/state.rs
@@ -248,8 +248,9 @@ impl<T> Debug for Dnd<T> {
 #[derive(Debug)]
 pub struct SctkDragOffer {
     pub(crate) dropped: bool,
-    pub(crate) offer: DragOffer,
+    pub(crate) offer: Option<DragOffer>,
     pub(crate) cur_read: Option<(String, Vec<u8>, RegistrationToken)>,
+    pub(crate) surface: WlSurface,
 }
 
 #[derive(Debug)]

--- a/sctk/src/handlers/data_device/data_offer.rs
+++ b/sctk/src/handlers/data_device/data_offer.rs
@@ -18,7 +18,7 @@ impl<T> DataOfferHandler for SctkState<T> {
         if self
             .dnd_offer
             .as_ref()
-            .map(|o| o.offer.inner() == offer.inner())
+            .map(|o| o.offer.as_ref().map(|o| o.inner()) == Some(offer.inner()))
             .unwrap_or(false)
         {
             self.sctk_events
@@ -41,7 +41,7 @@ impl<T> DataOfferHandler for SctkState<T> {
         if self
             .dnd_offer
             .as_ref()
-            .map(|o| o.offer.inner() == offer.inner())
+            .map(|o| o.offer.as_ref().map(|o| o.inner()) == Some(offer.inner()))
             .unwrap_or(false)
         {
             self.sctk_events

--- a/sctk/src/handlers/seat/keyboard.rs
+++ b/sctk/src/handlers/seat/keyboard.rs
@@ -172,6 +172,7 @@ impl<T: Debug> KeyboardHandler for SctkState<T> {
         keyboard: &sctk::reexports::client::protocol::wl_keyboard::WlKeyboard,
         _serial: u32,
         modifiers: sctk::seat::keyboard::Modifiers,
+        layout: u32,
     ) {
         let (is_active, my_seat) =
             match self.seats.iter_mut().enumerate().find_map(|(i, s)| {

--- a/src/application.rs
+++ b/src/application.rs
@@ -97,7 +97,7 @@ pub trait Application: Sized {
     type Executor: Executor;
 
     /// The type of __messages__ your [`Application`] will produce.
-    type Message: std::fmt::Debug + Send;
+    type Message: std::fmt::Debug + Send + Sync + 'static;
 
     /// The theme of your [`Application`].
     type Theme: Default + StyleSheet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,8 +225,9 @@ pub use crate::core::{
 pub mod clipboard {
     //! Access the clipboard.
     pub use crate::runtime::clipboard::{read, write};
+    pub use dnd;
     pub use iced_core::clipboard::{read_data, read_primary_data};
-    pub use window_clipboard::mime;
+    pub use mime;
 }
 
 pub mod executor {

--- a/src/multi_window/application.rs
+++ b/src/multi_window/application.rs
@@ -73,7 +73,7 @@ pub trait Application: Sized {
     type Executor: Executor;
 
     /// The type of __messages__ your [`Application`] will produce.
-    type Message: std::fmt::Debug + Send;
+    type Message: std::fmt::Debug + Send + Sync + 'static;
 
     /// The theme of your [`Application`].
     type Theme: Default + StyleSheet;

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -84,7 +84,7 @@ use crate::{Application, Command, Element, Error, Settings, Subscription};
 /// ```
 pub trait Sandbox {
     /// The type of __messages__ your [`Sandbox`] will produce.
-    type Message: std::fmt::Debug + Send;
+    type Message: std::fmt::Debug + Send + Sync + 'static;
 
     /// Initializes the [`Sandbox`].
     ///
@@ -155,6 +155,7 @@ pub trait Sandbox {
 impl<T> Application for T
 where
     T: Sandbox,
+    T::Message: Send + Sync + 'static,
 {
     type Executor = iced_futures::backend::null::Executor;
     type Flags = ();

--- a/widget/Cargo.toml
+++ b/widget/Cargo.toml
@@ -35,6 +35,8 @@ sctk.optional = true
 num-traits.workspace = true
 thiserror.workspace = true
 unicode-segmentation.workspace = true
+window_clipboard.workspace = true
+dnd.workspace = true
 
 ouroboros.workspace = true
 ouroboros.optional = true

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -33,6 +33,7 @@ log.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 window_clipboard.workspace = true
+dnd.workspace = true
 winit.workspace = true
 
 sysinfo.workspace = true

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -580,13 +580,17 @@ async fn run_instance<A, E, C>(
                                     },
                                     Default::default(),
                                 );
-                                let bytes = compositor.screenshot(
+                                let mut bytes = compositor.screenshot(
                                     &mut renderer,
                                     &mut surface,
                                     &viewport,
                                     state.background_color(),
                                     &debug.overlay(),
                                 );
+                                for pix in bytes.chunks_exact_mut(4) {
+                                    // rgba -> argb little endian
+                                    pix.swap(0, 2);
+                                }
                                 Icon::Buffer {
                                     data: Arc::new(bytes),
                                     width: viewport.physical_width(),

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -22,7 +22,6 @@
     missing_debug_implementations,
     missing_docs,
     unused_results,
-    unsafe_code,
     rustdoc::broken_intra_doc_links
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]


### PR DESCRIPTION
This implements DnD via window-clipboard for iced. iced-sctk is not refactored here except to update to the latest version. I think a separate PR updating iced-sctk along with an effort to update the iced-sctk libcosmic apps might be better timed after the alpha release? In any case, this should make it possible to add DnD to cosmic-files.