### PR TITLE
feat: update advertised drag destinations after rebuilding an interface

### DIFF
--- a/core/src/clipboard.rs
+++ b/core/src/clipboard.rs
@@ -1,6 +1,6 @@
 //! Access the clipboard.
 
-use std::{any::Any, borrow::Cow, sync::Arc};
+use std::{any::Any, sync::Arc};
 
 use dnd::{DndAction, DndDestinationRectangle, DndSurface};
 use mime::{self, AllowedMimeTypes, AsMimeTypes, ClipboardStoreData};
@@ -164,4 +164,50 @@ pub enum DndSource {
     Widget(crate::id::Id),
     /// A surface is the source of the DnD operation.
     Surface(window::Id),
+}
+
+/// A list of DnD destination rectangles.
+#[derive(Debug, Clone)]
+pub struct DndDestinationRectangles {
+    /// The rectangle of the DnD destination.
+    rectangles: Vec<DndDestinationRectangle>,
+}
+
+impl DndDestinationRectangles {
+    /// Creates a new [`DestinationRectangle`].
+    pub fn new() -> Self {
+        Self {
+            rectangles: Vec::new(),
+        }
+    }
+
+    /// Creates a new [`DestinationRectangle`] with the given capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            rectangles: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Pushes a new rectangle to the list of DnD destination rectangles.
+    pub fn push(&mut self, rectangle: DndDestinationRectangle) {
+        self.rectangles.push(rectangle);
+    }
+
+    /// Appends the list of DnD destination rectangles to the current list.
+    pub fn append(&mut self, other: &mut Vec<DndDestinationRectangle>) {
+        self.rectangles.append(other);
+    }
+
+    /// Returns the list of DnD destination rectangles.
+    /// This consumes the [`DestinationRectangles`].
+    pub fn into_rectangles(mut self) -> Vec<DndDestinationRectangle> {
+        self.rectangles.reverse();
+        self.rectangles
+    }
+}
+
+impl AsRef<[DndDestinationRectangle]> for DndDestinationRectangles {
+    fn as_ref(&self) -> &[DndDestinationRectangle] {
+        &self.rectangles
+    }
 }

--- a/core/src/clipboard.rs
+++ b/core/src/clipboard.rs
@@ -174,14 +174,14 @@ pub struct DndDestinationRectangles {
 }
 
 impl DndDestinationRectangles {
-    /// Creates a new [`DestinationRectangle`].
+    /// Creates a new [`DndDestinationRectangles`].
     pub fn new() -> Self {
         Self {
             rectangles: Vec::new(),
         }
     }
 
-    /// Creates a new [`DestinationRectangle`] with the given capacity.
+    /// Creates a new [`DndDestinationRectangles`] with the given capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             rectangles: Vec::with_capacity(capacity),
@@ -199,7 +199,7 @@ impl DndDestinationRectangles {
     }
 
     /// Returns the list of DnD destination rectangles.
-    /// This consumes the [`DestinationRectangles`].
+    /// This consumes the [`DndDestinationRectangles`].
     pub fn into_rectangles(mut self) -> Vec<DndDestinationRectangle> {
         self.rectangles.reverse();
         self.rectangles

--- a/core/src/widget.rs
+++ b/core/src/widget.rs
@@ -167,4 +167,14 @@ where
     /// Sets the id of the widget
     /// This may be called while diffing the widget tree
     fn set_id(&mut self, _id: Id) {}
+
+    /// Adds the drag destination rectangles of the widget.
+    /// Runs after the layout phase for each widget in the tree.
+    fn drag_destinations(
+        &self,
+        _state: &Tree,
+        _layout: Layout<'_>,
+        _dnd_rectangles: &mut crate::clipboard::DndDestinationRectangles,
+    ) {
+    }
 }

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -1,4 +1,5 @@
 //! Implement your own event loop to drive a user interface.
+use iced_core::clipboard::DndDestinationRectangles;
 use iced_core::widget::{Operation, OperationOutputWrapper};
 
 use crate::core::event::{self, Event};
@@ -624,6 +625,20 @@ where
     /// Find widget with given id
     pub fn find(&self, id: &widget::Id) -> Option<&widget::Tree> {
         self.state.find(id)
+    }
+
+    /// Get the destination rectangles for the user interface.
+    pub fn dnd_rectangles(
+        &self,
+        prev_capacity: usize,
+    ) -> DndDestinationRectangles {
+        let ret = DndDestinationRectangles::with_capacity(prev_capacity);
+        self.root.as_widget().drag_destinations(
+            &self.state,
+            Layout::new(&self.base),
+            &mut ret.clone(),
+        );
+        ret
     }
 }
 

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -284,6 +284,23 @@ where
                 }),
         )
     }
+
+    fn drag_destinations(
+        &self,
+        state: &Tree,
+        layout: Layout<'_>,
+        dnd_rectangles: &mut iced_style::core::clipboard::DndDestinationRectangles,
+    ) {
+        for ((e, layout), state) in self
+            .children
+            .iter()
+            .zip(layout.children())
+            .zip(state.children.iter())
+        {
+            e.as_widget()
+                .drag_destinations(state, layout, dnd_rectangles);
+        }
+    }
 }
 
 impl<'a, Message, Theme, Renderer> From<Column<'a, Message, Theme, Renderer>>

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -316,15 +316,11 @@ where
         layout: Layout<'_>,
         dnd_rectangles: &mut iced_style::core::clipboard::DndDestinationRectangles,
     ) {
-        if let Some((layout, state)) =
-            layout.children().zip(state.children.iter()).next()
-        {
-            self.content.as_widget().drag_destinations(
-                state,
-                layout,
-                dnd_rectangles,
-            );
-        }
+        self.content.as_widget().drag_destinations(
+            state,
+            layout,
+            dnd_rectangles,
+        );
     }
 }
 

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -309,6 +309,23 @@ where
             cursor,
         )
     }
+
+    fn drag_destinations(
+        &self,
+        state: &Tree,
+        layout: Layout<'_>,
+        dnd_rectangles: &mut iced_style::core::clipboard::DndDestinationRectangles,
+    ) {
+        if let Some((layout, state)) =
+            layout.children().zip(state.children.iter()).next()
+        {
+            self.content.as_widget().drag_destinations(
+                state,
+                layout,
+                dnd_rectangles,
+            );
+        }
+    }
 }
 
 impl<'a, Message, Theme, Renderer> From<Container<'a, Message, Theme, Renderer>>

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -244,6 +244,23 @@ where
             renderer,
         )
     }
+
+    fn drag_destinations(
+        &self,
+        state: &Tree,
+        layout: Layout<'_>,
+        dnd_rectangles: &mut iced_style::core::clipboard::DndDestinationRectangles,
+    ) {
+        if let Some((layout, state)) =
+            layout.children().zip(state.children.iter()).next()
+        {
+            self.content.as_widget().drag_destinations(
+                state,
+                layout,
+                dnd_rectangles,
+            );
+        }
+    }
 }
 
 impl<'a, Message, Theme, Renderer> From<MouseArea<'a, Message, Theme, Renderer>>

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -251,9 +251,7 @@ where
         layout: Layout<'_>,
         dnd_rectangles: &mut iced_style::core::clipboard::DndDestinationRectangles,
     ) {
-        if let Some((layout, state)) =
-            layout.children().zip(state.children.iter()).next()
-        {
+        if let Some(state) = state.children.iter().next() {
             self.content.as_widget().drag_destinations(
                 state,
                 layout,

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -273,6 +273,23 @@ where
                 }),
         )
     }
+
+    fn drag_destinations(
+        &self,
+        state: &Tree,
+        layout: Layout<'_>,
+        dnd_rectangles: &mut iced_style::core::clipboard::DndDestinationRectangles,
+    ) {
+        for ((e, layout), state) in self
+            .children
+            .iter()
+            .zip(layout.children())
+            .zip(state.children.iter())
+        {
+            e.as_widget()
+                .drag_destinations(state, layout, dnd_rectangles);
+        }
+    }
 }
 
 impl<'a, Message, Theme, Renderer> From<Row<'a, Message, Theme, Renderer>>

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -1,5 +1,6 @@
 //! Navigate an endless amount of content with a scrollbar.
 use iced_runtime::core::widget::Id;
+use iced_style::core::clipboard::DndDestinationRectangles;
 #[cfg(feature = "a11y")]
 use std::borrow::Cow;
 
@@ -586,6 +587,36 @@ where
                 self.id.0 = list[0].clone();
                 self.scrollbar_id.0 = list[1].clone();
             }
+        }
+    }
+
+    fn drag_destinations(
+        &self,
+        state: &Tree,
+        layout: Layout<'_>,
+        dnd_rectangles: &mut iced_style::core::clipboard::DndDestinationRectangles,
+    ) {
+        if let Some((c_layout, c_state)) =
+            layout.children().zip(state.children.iter()).next()
+        {
+            let mut my_dnd_rectangles = DndDestinationRectangles::new();
+            self.content.as_widget().drag_destinations(
+                c_state,
+                layout,
+                &mut my_dnd_rectangles,
+            );
+            let mut my_dnd_rectangles = my_dnd_rectangles.into_rectangles();
+
+            let bounds = layout.bounds();
+            let content_bounds = c_layout.bounds();
+            let state = state.state.downcast_ref::<State>();
+            for r in &mut my_dnd_rectangles {
+                let translation =
+                    state.translation(self.direction, bounds, content_bounds);
+                r.rectangle.x -= translation.x as f64;
+                r.rectangle.y -= translation.y as f64;
+            }
+            dnd_rectangles.append(&mut my_dnd_rectangles);
         }
     }
 }

--- a/winit/src/application.rs
+++ b/winit/src/application.rs
@@ -23,7 +23,6 @@ use crate::conversion;
 use crate::core;
 use crate::core::mouse;
 use crate::core::renderer;
-use crate::core::renderer::Renderer;
 use crate::core::time::Instant;
 use crate::core::widget::operation;
 use crate::core::window;
@@ -410,6 +409,8 @@ async fn run_instance<A, E, C>(
         state.logical_size(),
         &mut debug,
     ));
+
+    let mut prev_dnd_rectangles_count = 0;
 
     // Creates closure for handling the window drag resize state with winit.
     let mut drag_resize_window_func = drag_resize::event_func(
@@ -892,6 +893,22 @@ async fn run_instance<A, E, C>(
                         state.logical_size(),
                         &mut debug,
                     ));
+
+                    let dnd_rectangles = user_interface
+                        .dnd_rectangles(prev_dnd_rectangles_count);
+                    let new_dnd_rectangles_count =
+                        dnd_rectangles.as_ref().len();
+
+                    if new_dnd_rectangles_count > 0
+                        || prev_dnd_rectangles_count > 0
+                    {
+                        clipboard.register_dnd_destination(
+                            DndSurface(Arc::new(Box::new(window.clone()))),
+                            dnd_rectangles.into_rectangles(),
+                        );
+                    }
+
+                    prev_dnd_rectangles_count = new_dnd_rectangles_count;
 
                     if should_exit {
                         break;

--- a/winit/src/multi_window/window_manager.rs
+++ b/winit/src/multi_window/window_manager.rs
@@ -69,6 +69,7 @@ where
                 surface,
                 renderer,
                 mouse_interaction: mouse::Interaction::Idle,
+                prev_dnd_destination_rectangles_count: 0,
             },
         );
 
@@ -142,6 +143,7 @@ where
             ) -> bool,
         >,
     >,
+    pub prev_dnd_destination_rectangles_count: usize,
     pub mouse_interaction: mouse::Interaction,
     pub surface: C::Surface,
     pub renderer: A::Renderer,


### PR DESCRIPTION
This collects drag destination rectangles after rebuilding the interface and performing the layout step. It advertises the rectangles so that child element's rectangles are prioritized over their parent element's rectangles.