### PR TITLE
Clean up after lock surfaces are destroyed

### DIFF
--- a/sctk/src/application.rs
+++ b/sctk/src/application.rs
@@ -787,6 +787,17 @@ where
                         }
 
                     }
+                    SctkEvent::SessionLockSurfaceDone { surface } => {
+                        if let Some(surface_id) = surface_ids.remove(&surface.id()) {
+                            if kbd_surface_id == Some(surface.id()) {
+                                kbd_surface_id = None;
+                            }
+                            auto_size_surfaces.remove(&surface_id);
+                            interfaces.remove(&surface_id.inner());
+                            states.remove(&surface_id.inner());
+                            destroyed_surface_ids.insert(surface.id(), surface_id);
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -2290,6 +2301,9 @@ where
             &surface.id() == object_id
         }
         SctkEvent::SessionLockSurfaceConfigure { surface, .. } => {
+            &surface.id() == object_id
+        }
+        SctkEvent::SessionLockSurfaceDone { surface } => {
             &surface.id() == object_id
         }
         SctkEvent::SessionUnlocked => false,

--- a/sctk/src/event_loop/mod.rs
+++ b/sctk/src/event_loop/mod.rs
@@ -1368,7 +1368,15 @@ where
                                     s.id == id
                                 })
                             {
-                                self.state.lock_surfaces.remove(i);
+                                let surface = self.state.lock_surfaces.remove(i);
+                                sticky_exit_callback(
+                                    IcedSctkEvent::SctkEvent(SctkEvent::SessionLockSurfaceDone {
+                                        surface: surface.session_lock_surface.wl_surface().clone()
+                                    }),
+                                    &self.state,
+                                    &mut control_flow,
+                                    &mut callback,
+                                );
                             }
                         }
                     }

--- a/sctk/src/sctk_event.rs
+++ b/sctk/src/sctk_event.rs
@@ -206,6 +206,9 @@ pub enum SctkEvent {
         configure: SessionLockSurfaceConfigure,
         first: bool,
     },
+    SessionLockSurfaceDone {
+        surface: WlSurface,
+    },
     SessionUnlocked,
 }
 
@@ -947,6 +950,7 @@ impl SctkEvent {
             }
             SctkEvent::SessionLockSurfaceCreated { .. } => vec![],
             SctkEvent::SessionLockSurfaceConfigure { .. } => vec![],
+            SctkEvent::SessionLockSurfaceDone { .. } => vec![],
             SctkEvent::SessionUnlocked => {
                 Some(iced_runtime::core::Event::PlatformSpecific(
                     PlatformSpecific::Wayland(wayland::Event::SessionLock(


### PR DESCRIPTION
Fixes cosmic-greeter running persistently.