### PR TITLE
sctk: Add support for drag-and-drop surface offsets

### DIFF
--- a/runtime/src/command/platform_specific/wayland/data_device.rs
+++ b/runtime/src/command/platform_specific/wayland/data_device.rs
@@ -1,4 +1,4 @@
-use iced_core::window::Id;
+use iced_core::{window::Id, Vector};
 use iced_futures::MaybeSend;
 use sctk::reexports::client::protocol::wl_data_device_manager::DndAction;
 use std::{any::Any, fmt, marker::PhantomData};
@@ -52,7 +52,7 @@ pub enum ActionInner {
         /// The window id of the window that is the source of the drag.
         origin_id: Id,
         /// An optional window id for the cursor icon surface.
-        icon_id: Option<DndIcon>,
+        icon_id: Option<(DndIcon, Vector)>,
         /// The data to send.
         data: Box<dyn DataFromMimeType + Send + Sync>,
     },

--- a/runtime/src/dnd.rs
+++ b/runtime/src/dnd.rs
@@ -3,7 +3,7 @@
 use std::any::Any;
 
 use dnd::{DndDestinationRectangle, DndSurface};
-use iced_core::clipboard::DndSource;
+use iced_core::{clipboard::DndSource, Vector};
 use iced_futures::MaybeSend;
 use window_clipboard::mime::{AllowedMimeTypes, AsMimeTypes};
 

--- a/sctk/src/commands/data_device.rs
+++ b/sctk/src/commands/data_device.rs
@@ -15,6 +15,8 @@ use iced_runtime::{
 };
 use sctk::reexports::client::protocol::wl_data_device_manager::DndAction;
 
+use crate::core::Vector;
+
 /// start an internal drag and drop operation. Events will only be delivered to the same client.
 /// The client is responsible for data transfer.
 pub fn start_internal_drag<Message>(
@@ -38,7 +40,7 @@ pub fn start_drag<Message>(
     mime_types: Vec<String>,
     actions: DndAction,
     origin_id: window::Id,
-    icon_id: Option<DndIcon>,
+    icon_id: Option<(DndIcon, Vector)>,
     data: Box<dyn DataFromMimeType + Send + Sync>,
 ) -> Command<Message> {
     Command::single(command::Action::PlatformSpecific(

--- a/sctk/src/event_loop/mod.rs
+++ b/sctk/src/event_loop/mod.rs
@@ -1163,12 +1163,15 @@ where
                                     None => continue,
                                 };
                                 let source = self.state.data_device_manager_state.create_drag_and_drop_source(qh, mime_types.iter().map(|s| s.as_str()).collect::<Vec<_>>(), actions);
-                                let icon_surface =  if let Some(icon_id) = icon_id{
+                                let icon_surface =  if let Some((icon_id, offset)) = icon_id{
                                     let icon_native_id = match &icon_id {
                                         DndIcon::Custom(icon_id) => *icon_id,
                                         DndIcon::Widget(icon_id, _) => *icon_id,
                                     };
                                     let wl_surface = self.state.compositor_state.create_surface(qh);
+                                    if offset != crate::core::Vector::ZERO {
+                                        wl_surface.offset(offset.x as i32, offset.y as i32);
+                                    }
                                     source.start_drag(device, &origin, Some(&wl_surface), serial);
                                     sticky_exit_callback(
                                         IcedSctkEvent::DndSurfaceCreated(


### PR DESCRIPTION
This adds an offset `Vector` as an argument to `on_drag`, and allows passing an offset to `start_drag`.

Some applications using drag and drop want the top left corner of the drag surface (as happens without an offset). But others want the drag surface to be offset based on where the cursor is on the widget when starting the drag. This can just be `-1 * offset`, but may be scaled if the drag surface is a different size from the original widget.