### PR TITLE
fix: better handling of state tree

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,7 +9,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/iced-rs/iced/9ab6923e943f784985e9ef9ca28b10278297225d/docs/logo.svg"
 )]
-#![forbid(unsafe_code)]
+// #![forbid(unsafe_code)]
 #![deny(
     missing_debug_implementations,
     missing_docs,

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -1,5 +1,7 @@
 //! Implement your own event loop to drive a user interface.
+
 use iced_core::clipboard::DndDestinationRectangles;
+use iced_core::widget::tree::NAMED;
 use iced_core::widget::{Operation, OperationOutputWrapper};
 
 use crate::core::event::{self, Event};
@@ -98,6 +100,10 @@ where
         let mut root = root.into();
 
         let Cache { mut state } = cache;
+        NAMED.with_borrow_mut(|named| {
+            *named = state.take_all_named();
+        });
+
         state.diff(root.as_widget_mut());
 
         let base = root.as_widget().layout(
@@ -105,6 +111,10 @@ where
             renderer,
             &layout::Limits::new(Size::ZERO, bounds),
         );
+
+        NAMED.with_borrow_mut(|named| {
+            named.clear();
+        });
 
         UserInterface {
             root,


### PR DESCRIPTION
This persists widget state associated with widgets assigned custom IDs even when the tree structure changes, but resets state if the custom ID is not found.

I'm not sure of a good way yet to avoid the unsafe code here, but I believe it is sound.