### PR TITLE
iced_wgpu: don't query Wayland on macos

### DIFF
--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -43,7 +43,7 @@ resvg.optional = true
 tracing.workspace = true
 tracing.optional = true
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 rustix = { version = "0.38" }
 raw-window-handle.workspace = true
 sctk.workspace = true

--- a/wgpu/src/window.rs
+++ b/wgpu/src/window.rs
@@ -1,6 +1,6 @@
 //! Display rendering results on windows.
 pub mod compositor;
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 mod wayland;
 
 pub use compositor::Compositor;

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -6,7 +6,7 @@ use crate::graphics::compositor;
 use crate::graphics::{Error, Viewport};
 use crate::{Backend, Primitive, Renderer, Settings};
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "macos")))]
 use super::wayland::get_wayland_device_ids;
 
 /// A window graphics backend for iced powered by `wgpu`.
@@ -28,7 +28,7 @@ impl Compositor {
         settings: Settings,
         compatible_window: Option<W>,
     ) -> Option<Self> {
-        #[cfg(unix)]
+        #[cfg(all(unix, not(target_os = "macos")))]
         let ids = compatible_window.as_ref().and_then(get_wayland_device_ids);
 
         // HACK:
@@ -36,7 +36,7 @@ impl Compositor {
         //  2. and nobody set an adapter name,
         //  3. and the user didn't request the high power pref
         // => don't load the nvidia icd, as it might power on the gpu in hybrid setups causing severe delays
-        #[cfg(unix)]
+        #[cfg(all(unix, not(target_os = "macos")))]
         if !matches!(ids, Some((0x10de, _)))
             && std::env::var_os("WGPU_ADAPTER_NAME").is_none()
             && std::env::var("WGPU_POWER_PREF").as_deref() != Ok("high")
@@ -72,7 +72,7 @@ impl Compositor {
         let mut adapter = None;
         #[cfg_attr(not(unix), allow(dead_code))]
         if std::env::var_os("WGPU_ADAPTER_NAME").is_none() {
-            #[cfg(unix)]
+            #[cfg(all(unix, not(target_os = "macos")))]
             if let Some((vendor_id, device_id)) = ids {
                 adapter = available_adapters
                     .into_iter()


### PR DESCRIPTION
After https://github.com/pop-os/iced/pull/138 was merged, iced with the feature wgpu set, no longer compiles on macos.

After some digging it turns out this was due to some wayland dependencies brought in by that PR.

This is a suggested fix to that problem, by changing the conditional compilation attributes added to exclude macos.
