### PR TITLE
apply scale to lock surface

### DIFF
--- a/sctk/src/application.rs
+++ b/sctk/src/application.rs
@@ -824,6 +824,15 @@ where
                             destroyed_surface_ids.insert(surface.id(), surface_id);
                         }
                     }
+                    SctkEvent::SessionLockSurfaceScaleFactorChanged { surface, scale_factor, viewport } => {
+                        if let Some(state) = surface_ids
+                            .get(&surface.id())
+                            .and_then(|id| states.get_mut(&id.inner()))
+                        {
+                            state.wp_viewport = viewport;
+                            state.set_scale_factor(scale_factor);
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -2363,6 +2372,9 @@ where
             &surface.id() == object_id
         }
         SctkEvent::SessionLockSurfaceDone { surface } => {
+            &surface.id() == object_id
+        }
+        SctkEvent::SessionLockSurfaceScaleFactorChanged { surface, .. } => {
             &surface.id() == object_id
         }
         SctkEvent::SessionUnlocked => false,

--- a/sctk/src/event_loop/mod.rs
+++ b/sctk/src/event_loop/mod.rs
@@ -516,6 +516,9 @@ where
                     | SctkEvent::WindowEvent {
                         variant: WindowEventVariant::ScaleFactorChanged(..),
                         ..
+                    }
+                    | SctkEvent::SessionLockSurfaceScaleFactorChanged {
+                        ..
                     } => true,
                     // ignore other events that shouldn't be in this buffer
                     event => {

--- a/sctk/src/sctk_event.rs
+++ b/sctk/src/sctk_event.rs
@@ -215,6 +215,11 @@ pub enum SctkEvent {
     SessionLockSurfaceDone {
         surface: WlSurface,
     },
+    SessionLockSurfaceScaleFactorChanged {
+        surface: WlSurface,
+        scale_factor: f64,
+        viewport: Option<WpViewport>,
+    },
     SessionUnlocked,
 }
 
@@ -988,6 +993,7 @@ impl SctkEvent {
                 .into_iter()
                 .collect()
             }
+            SctkEvent::SessionLockSurfaceScaleFactorChanged { .. } => vec![],
         }
     }
 }


### PR DESCRIPTION
Currently produces https://wayland.app/protocols/ext-session-lock-v1#ext_session_lock_surface_v1:enum:error:entry:dimensions_mismatch when used with cosmic-greeter.

The protocol error is fixed by https://github.com/pop-os/cosmic-comp/pull/675