### PR TITLE
Make iced_wgpu build on redox

### DIFF
--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -43,7 +43,7 @@ resvg.optional = true
 tracing.workspace = true
 tracing.optional = true
 
-[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
+[target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "redox")))'.dependencies]
 rustix = { version = "0.38" }
 raw-window-handle.workspace = true
 sctk.workspace = true

--- a/wgpu/src/window.rs
+++ b/wgpu/src/window.rs
@@ -1,19 +1,19 @@
 //! Display rendering results on windows.
 pub mod compositor;
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "redox")))]
 mod wayland;
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "redox")))]
 mod x11;
 
 pub use compositor::Compositor;
 pub use wgpu::Surface;
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "redox")))]
 use rustix::fs::{major, minor};
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "redox")))]
 use std::{fs::File, io::Read, path::PathBuf};
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "redox")))]
 fn ids_from_dev(dev: u64) -> Option<(u16, u16)> {
     let path = PathBuf::from(format!(
         "/sys/dev/char/{}:{}/device",

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -6,9 +6,9 @@ use crate::graphics::compositor;
 use crate::graphics::{Error, Viewport};
 use crate::{Backend, Primitive, Renderer, Settings};
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "redox")))]
 use super::wayland::get_wayland_device_ids;
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "redox")))]
 use super::x11::get_x11_device_ids;
 
 /// A window graphics backend for iced powered by `wgpu`.
@@ -30,7 +30,7 @@ impl Compositor {
         settings: Settings,
         compatible_window: Option<W>,
     ) -> Option<Self> {
-        #[cfg(all(unix, not(target_os = "macos")))]
+        #[cfg(all(unix, not(target_os = "macos"), not(target_os = "redox")))]
         let ids = compatible_window.as_ref().and_then(|window| {
             get_wayland_device_ids(window)
                 .or_else(|| get_x11_device_ids(window))
@@ -41,7 +41,7 @@ impl Compositor {
         //  2. and nobody set an adapter name,
         //  3. and the user didn't request the high power pref
         // => don't load the nvidia icd, as it might power on the gpu in hybrid setups causing severe delays
-        #[cfg(all(unix, not(target_os = "macos")))]
+        #[cfg(all(unix, not(target_os = "macos"), not(target_os = "redox")))]
         if !matches!(ids, Some((0x10de, _)))
             && std::env::var_os("WGPU_ADAPTER_NAME").is_none()
             && std::env::var("WGPU_POWER_PREF").as_deref() != Ok("high")
@@ -77,7 +77,11 @@ impl Compositor {
         let mut adapter = None;
         #[cfg_attr(not(unix), allow(dead_code))]
         if std::env::var_os("WGPU_ADAPTER_NAME").is_none() {
-            #[cfg(all(unix, not(target_os = "macos")))]
+            #[cfg(all(
+                unix,
+                not(target_os = "macos"),
+                not(target_os = "redox")
+            ))]
             if let Some((vendor_id, device_id)) = ids {
                 adapter = available_adapters
                     .into_iter()


### PR DESCRIPTION
This does not provide wgpu capabilities, it just ensures the wgpu feature does not need to be disabled when building for Redox.