### PR TITLE
fix: log warning instead of panicing for current_monitor

### DIFF
--- a/winit/src/platform_specific/wayland/winit_window.rs
+++ b/winit/src/platform_specific/wayland/winit_window.rs
@@ -224,17 +224,21 @@ impl winit::window::Window for SctkWinitWindow {
     }
 
     fn current_monitor(&self) -> Option<winit::monitor::MonitorHandle> {
-        todo!()
+        tracing::warn!(
+            "current_monitor is not implemented for wayland windows."
+        );
+        None
     }
 
     fn available_monitors(
         &self,
     ) -> Box<dyn Iterator<Item = winit::monitor::MonitorHandle>> {
-        todo!()
+        Box::new(None.into_iter())
     }
 
     fn has_focus(&self) -> bool {
-        todo!()
+        tracing::warn!("has_focus is not implemented for wayland windows.");
+        false
     }
 
     fn set_ime_cursor_area(


### PR DESCRIPTION
The core team is busy and does not have time to mentor nor babysit new contributors. If a member of the core team thinks that reviewing and understanding your work will take more time and effort than writing it from scratch by themselves, your contribution will be dismissed. It is your responsibility to communicate and figure out how to reduce the likelihood of this!

Read the contributing guidelines for more details: https://github.com/iced-rs/iced/blob/master/CONTRIBUTING.md
