### PR TITLE
fix: filter out events with no window id, if the window id is needed

### DIFF
--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -1611,6 +1611,16 @@ async fn run_instance<'a, P, C>(
                 }
 
                 for (id, event) in events.drain(..) {
+                    if id.is_none()
+                        && matches!(
+                            event,
+                            core::Event::Keyboard(_)
+                                | core::Event::Touch(_)
+                                | core::Event::Mouse(_)
+                        )
+                    {
+                        continue;
+                    }
                     runtime.broadcast(subscription::Event::Interaction {
                         window: id.unwrap_or(window::Id::NONE),
                         event,


### PR DESCRIPTION
Should prevent extra events not associated with a tracked window.