### PR TITLE
fix: correct event types for Windows

### DIFF
--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -314,7 +314,7 @@ where
             #[cfg(target_os = "windows")]
             let is_move_or_resize = matches!(
                 event,
-                winit::event::WindowEvent::Resized(_)
+                winit::event::WindowEvent::SurfaceResized(_)
                     | winit::event::WindowEvent::Moved(_)
             );
 
@@ -330,12 +330,7 @@ where
             #[cfg(target_os = "windows")]
             {
                 if is_move_or_resize {
-                    self.process_event(
-                        event_loop,
-                        Event::EventLoopAwakened(
-                            winit::event::Event::AboutToWait,
-                        ),
-                    );
+                    self.process_event(event_loop, Some(Event::AboutToWait));
                 }
             }
         }


### PR DESCRIPTION
It looks like a couple of Windows-specific lines in iced_winit weren't updated to work with the current code. I think this should be right (at least, it fixes compiling on Windows), but it should probably get a double-check before merging.

There are still a few Windows bugs ([#593](https://github.com/pop-os/libcosmic/issues/593) and [#536](https://github.com/pop-os/libcosmic/issues/536)), but I don't know if they are related to this (reasonably sure the first one isn't, not sure about the second one).
