### PR TITLE
Expose blur to the user

### DIFF
--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -159,6 +159,9 @@ pub enum Action {
     /// This enables mouse events for the window and stops mouse events
     /// from being passed to whatever is underneath.
     DisableMousePassthrough(Id),
+
+    /// Set window blur.
+    SetBlur(bool),
 }
 
 /// Subscribes to the frames of the window of the running application.
@@ -455,4 +458,11 @@ pub fn enable_mouse_passthrough<Message>(id: Id) -> Task<Message> {
 /// from being passed to whatever is underneath.
 pub fn disable_mouse_passthrough<Message>(id: Id) -> Task<Message> {
     task::effect(crate::Action::Window(Action::DisableMousePassthrough(id)))
+}
+
+/// Sets the blur effect for the window.
+///
+/// This is only supported on platforms that support window blur.
+pub fn set_blur<Message>(enable: bool) -> Task<Message> {
+    task::effect(crate::Action::Window(Action::SetBlur(enable)))
 }

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -160,8 +160,11 @@ pub enum Action {
     /// from being passed to whatever is underneath.
     DisableMousePassthrough(Id),
 
-    /// Set window blur.
-    SetBlur(bool),
+    /// Enable window blur.
+    EnableBlur(Id),
+
+    /// Disable window blur.
+    DisableBlur(Id),
 }
 
 /// Subscribes to the frames of the window of the running application.
@@ -460,9 +463,16 @@ pub fn disable_mouse_passthrough<Message>(id: Id) -> Task<Message> {
     task::effect(crate::Action::Window(Action::DisableMousePassthrough(id)))
 }
 
-/// Sets the blur effect for the window.
+/// Enable the blur effect for a window.
 ///
 /// This is only supported on platforms that support window blur.
-pub fn set_blur<Message>(enable: bool) -> Task<Message> {
-    task::effect(crate::Action::Window(Action::SetBlur(enable)))
+pub fn enable_blur<Message>(id: Id) -> Task<Message> {
+    task::effect(crate::Action::Window(Action::EnableBlur(id)))
+}
+
+/// Enable the blur effect for a window.
+///
+/// This is only supported on platforms that support window blur.
+pub fn disable_blur<Message>(id: Id) -> Task<Message> {
+    task::effect(crate::Action::Window(Action::DisableBlur(id)))
 }

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -470,7 +470,7 @@ pub fn enable_blur<Message>(id: Id) -> Task<Message> {
     task::effect(crate::Action::Window(Action::EnableBlur(id)))
 }
 
-/// Enable the blur effect for a window.
+/// Disable the blur effect for a window.
 ///
 /// This is only supported on platforms that support window blur.
 pub fn disable_blur<Message>(id: Id) -> Task<Message> {

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -2202,6 +2202,11 @@ fn run_action<P, C>(
                     let _ = window.raw.set_cursor_hittest(true);
                 }
             }
+            window::Action::SetBlur(enable) => {
+                if let Some(window) = window_manager.get_mut(0) {
+                    window.raw.set_blur(enable);
+                }
+            }
         },
         Action::System(action) => match action {
             system::Action::QueryInformation(_channel) => {

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -2202,9 +2202,14 @@ fn run_action<P, C>(
                     let _ = window.raw.set_cursor_hittest(true);
                 }
             }
-            window::Action::SetBlur(enable) => {
-                if let Some(window) = window_manager.get_mut(0) {
-                    window.raw.set_blur(enable);
+            window::Action::EnableBlur(id) => {
+                if let Some(window) = window_manager.get_mut(id) {
+                    window.raw.set_blur(true);
+                }
+            }
+            window::Action::DisableBlur(id) => {
+                if let Some(window) = window_manager.get_mut(id) {
+                    window.raw.set_blur(false);
                 }
             }
         },


### PR DESCRIPTION
This PR exposes `set_blur` to the user, allowing it to enable blur effects to the window on supported platforms.