### PR TITLE
fix: scrollbar width

### DIFF
--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -376,9 +376,9 @@ pub struct Scrollbar {
 impl Default for Scrollbar {
     fn default() -> Self {
         Self {
-            width: 10.0,
+            width: 8.0,
             margin: 0.0,
-            scroller_width: 10.0,
+            scroller_width: 8.0,
             alignment: Anchor::Start,
             spacing: None,
         }


### PR DESCRIPTION
This makes the scrollbar width 8, to more closely match designs. Complete design matching would be more complex, since the scrollbar end radius should be a rectangle, unless the end is in white space.