### PR TITLE
fix: avoid overwriting id when diffing children

### DIFF
--- a/core/src/widget/tree.rs
+++ b/core/src/widget/tree.rs
@@ -334,9 +334,6 @@ impl Tree {
                 )
             {
                 let c = &mut id_list[child_state_i];
-                if len_changed {
-                    c.id.clone_from(new_id);
-                }
                 child_state_i += 1;
                 c
             } else {


### PR DESCRIPTION
this can interact with the named IDs, and cause state mismatches, and doesn't need to be done, because the ID will be updated by the diff method if there is a Tag match anyways.
