### PR TITLE
feat: image operations

### DIFF
--- a/core/src/widget/operation.rs
+++ b/core/src/widget/operation.rs
@@ -1,10 +1,12 @@
 //! Query or update internal widget state.
 pub mod focusable;
+pub mod image;
 pub mod scrollable;
 pub mod search_id;
 pub mod text_input;
 
 pub use focusable::Focusable;
+pub use image::Image;
 pub use scrollable::Scrollable;
 pub use text_input::TextInput;
 
@@ -46,6 +48,9 @@ pub trait Operation<T = ()>: Send {
 
     /// Operates on a widget that has text input.
     fn text_input(&mut self, _state: &mut dyn TextInput, _id: Option<&Id>) {}
+
+    /// Operates on a widget that displays an image.
+    fn image(&mut self, _state: &mut dyn Image, _id: Option<&Id>) {}
 
     /// Operates on a custom widget.
     fn custom(&mut self, _state: &mut dyn Any, _id: Option<&Id>) {}
@@ -92,6 +97,10 @@ where
 
     fn text_input(&mut self, state: &mut dyn TextInput, id: Option<&Id>) {
         self.as_mut().text_input(state, id);
+    }
+
+    fn image(&mut self, state: &mut dyn Image, id: Option<&Id>) {
+        self.as_mut().image(state, id);
     }
 
     fn custom(&mut self, state: &mut dyn Any, id: Option<&Id>) {
@@ -174,6 +183,10 @@ where
 
         fn text_input(&mut self, state: &mut dyn TextInput, id: Option<&Id>) {
             self.operation.text_input(state, id);
+        }
+
+        fn image(&mut self, state: &mut dyn Image, id: Option<&Id>) {
+            self.operation.image(state, id);
         }
 
         fn custom(&mut self, state: &mut dyn Any, id: Option<&Id>) {
@@ -266,6 +279,10 @@ where
                     self.operation.text_input(state, id);
                 }
 
+                fn image(&mut self, state: &mut dyn Image, id: Option<&Id>) {
+                    self.operation.image(state, id);
+                }
+
                 fn custom(&mut self, state: &mut dyn Any, id: Option<&Id>) {
                     self.operation.custom(state, id);
                 }
@@ -299,6 +316,10 @@ where
 
         fn text_input(&mut self, state: &mut dyn TextInput, id: Option<&Id>) {
             self.operation.text_input(state, id);
+        }
+
+        fn image(&mut self, state: &mut dyn Image, id: Option<&Id>) {
+            self.operation.image(state, id);
         }
 
         fn custom(&mut self, state: &mut dyn Any, id: Option<&Id>) {
@@ -385,6 +406,10 @@ where
 
         fn text_input(&mut self, state: &mut dyn TextInput, id: Option<&Id>) {
             self.operation.text_input(state, id);
+        }
+
+        fn image(&mut self, state: &mut dyn Image, id: Option<&Id>) {
+            self.operation.image(state, id);
         }
 
         fn custom(&mut self, state: &mut dyn std::any::Any, id: Option<&Id>) {

--- a/core/src/widget/operation/image.rs
+++ b/core/src/widget/operation/image.rs
@@ -1,0 +1,42 @@
+//! Operate on widgets that display an image.
+use crate::widget::Id;
+
+use crate::image::Handle;
+
+use super::Operation;
+
+/// The internal state of a widget that displays an image.
+pub trait Image {
+    /// Sets the handle of the image.
+    fn set_handle(&mut self, handle: Handle);
+}
+
+/// Produces an [`Operation`] that sets the handle of the widget with the given [`Id`].
+pub fn set_handle<T>(target: Id, handle: Handle) -> impl Operation<T> {
+    struct SetHandle {
+        target: Id,
+        handle: Handle,
+    }
+
+    impl<T> Operation<T> for SetHandle {
+        fn image(&mut self, state: &mut dyn Image, id: Option<&Id>) {
+            match id {
+                Some(id) if id == &self.target => {
+                    state.set_handle(self.handle.clone());
+                }
+                _ => println!("Invalid id for image widget: {:?}", id),
+            }
+        }
+
+        fn container(
+            &mut self,
+            _id: Option<&Id>,
+            _bounds: crate::Rectangle,
+            operate_on_children: &mut dyn FnMut(&mut dyn Operation<T>),
+        ) {
+            operate_on_children(self);
+        }
+    }
+
+    SetHandle { target, handle }
+}


### PR DESCRIPTION
This pull request adds support for operations on image widgets, including setting image handles.

* Created the `core/src/widget/operation/image.rs` file, which defines the `Image` trait and an operation to set the image handle of a widget.
* Updated the `widget/src/image.rs` file to integrate the new image operation.