### PR TITLE
fix: Clear mouse area drag_initiated state on dbl click

### DIFF
--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -464,6 +464,7 @@ fn update<Message: Clone, Theme, Renderer>(
                 state.last_click = Some(click);
                 if let mouse::click::Kind::Double = click.kind() {
                     shell.publish(message.clone());
+                    state.drag_initiated = None;
                     return event::Status::Captured;
                 }
             }


### PR DESCRIPTION
### Change
This PR changes the mouse_area event handling code to clear the `drag_initiated` flag in the widget state on a double-click.

### Reason
After some investigation into [issue #536 for libcosmic](https://github.com/pop-os/libcosmic/issues/536), I think I've pinned this down as the cause. As far as I can tell, when you double-click on the header bar to maximize, a drag message is emitted after. Something about this drag event is not handled properly in the winit windows platform code. Specifically the issue is [here](https://github.com/pop-os/winit/blob/1cc02bdab141072eaabad639d74b032fd0fcc62e/src/platform_impl/windows/window.rs#L190):
```rust
 unsafe fn handle_os_dragging(&self, wparam: WPARAM) {
        let window = self.window;
        let window_state = self.window_state.clone();

        self.thread_executor.execute_in_thread(move || {
            {
                let mut guard = window_state.lock().unwrap();
                if !guard.dragging {
                    guard.dragging = true;
                } else {
                    return;
                }
            }
// ...continues on to trigger dragging...
```

When a drag is initiated, a flag is set in the window_state to mark that the window is being dragged. As far as I can tell, this is supposed to be cleaned up [here](https://github.com/pop-os/winit/blob/1cc02bdab141072eaabad639d74b032fd0fcc62e/src/platform_impl/windows/event_loop.rs#L1112) but for some reason the odd drag request being emitted after a double-click maximize doesn't get handled properly and that dragging flag in the window state is never cleared, so any future drag requests just get ignored since the "handle_os_dragging" function exits early if that flag is set.

The cause of the odd drag request appears to be the way mouse_area handles checking for potential drag events. On a double-click, the first click will set the `drag_initiated` flag, then the double_press event is triggered. But the `drag_initiated` flag is still set, so, after a maximize, the mouse position changes relative to the window, triggering the drag event. At least, as far as I can tell.