### PR TITLE
fix: Replace current drag-resize support check with hard-coded support values

### DIFF
--- a/winit/src/application/drag_resize.rs
+++ b/winit/src/application/drag_resize.rs
@@ -1,5 +1,27 @@
 use winit::window::{CursorIcon, ResizeDirection};
 
+#[cfg(any(
+    all(
+        unix,
+        not(target_vendor = "apple"),
+        not(target_os = "android"),
+        not(target_os = "emscripten"),
+    ),
+    target_os = "windows",
+))]
+const DRAG_RESIZE_SUPPORTED: bool = true;
+
+#[cfg(not(any(
+    all(
+        unix,
+        not(target_vendor = "apple"),
+        not(target_os = "android"),
+        not(target_os = "emscripten"),
+    ),
+    target_os = "windows",
+)))]
+const DRAG_RESIZE_SUPPORTED: bool = false;
+
 /// If supported by winit, returns a closure that implements cursor resize support.
 pub fn event_func(
     window: &dyn winit::window::Window,
@@ -12,7 +34,7 @@ pub fn event_func(
         ) -> bool,
     >,
 > {
-    if drag_resize_supported() {
+    if DRAG_RESIZE_SUPPORTED {
         // Keep track of cursor when it is within a resizeable border.
         let mut cursor_prev_resize_direction = None;
 
@@ -60,27 +82,6 @@ pub fn event_func(
     } else {
         None
     }
-}
-
-/// Test if the current target should be assumed to have winit drag_resize support
-const fn drag_resize_supported() -> bool {
-    #[cfg(all(
-        unix,
-        not(target_vendor = "apple"),
-        not(target_os = "android"),
-        not(target_os = "emscripten")
-    ))]
-    {
-        return true;
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        return true;
-    }
-
-    #[allow(unreachable_code)]
-    false
 }
 
 /// Get the cursor icon that corresponds to the resize direction.

--- a/winit/src/application/drag_resize.rs
+++ b/winit/src/application/drag_resize.rs
@@ -12,7 +12,7 @@ pub fn event_func(
         ) -> bool,
     >,
 > {
-    if window.drag_resize_window(ResizeDirection::East).is_ok() {
+    if drag_resize_supported() {
         // Keep track of cursor when it is within a resizeable border.
         let mut cursor_prev_resize_direction = None;
 
@@ -60,6 +60,27 @@ pub fn event_func(
     } else {
         None
     }
+}
+
+/// Test if the current target should be assumed to have winit drag_resize support
+const fn drag_resize_supported() -> bool {
+    #[cfg(all(
+        unix,
+        not(target_vendor = "apple"),
+        not(target_os = "android"),
+        not(target_os = "emscripten")
+    ))]
+    {
+        return true;
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return true;
+    }
+
+    #[allow(unreachable_code)]
+    false
 }
 
 /// Get the cursor icon that corresponds to the resize direction.


### PR DESCRIPTION
The current check for winit drag-resize support relies on calling `window.drag_resize_window()` on startup and seeing if an error is returned. Despite [the warning in the API documentation](https://docs.rs/winit/latest/winit/window/struct.Window.html#method.drag_resize_window) that calling this function without a left mouse button click happening does not guarantee that a drag-resize will actually be triggered, on Windows this does appear to trigger a drag-resize event ([see libcosmic issue #593](https://github.com/pop-os/libcosmic/issues/593)). Unfortunately, I don't see another way in winit to dynamically check for this support at runtime.

This PR replaces the current check with a check of a constant variable set at compile time.