### PR TITLE
fix: use dummy window for clipboard

### DIFF
--- a/winit/src/platform_specific/wayland/sctk_event.rs
+++ b/winit/src/platform_specific/wayland/sctk_event.rs
@@ -666,16 +666,14 @@ impl SctkEvent {
                 LayerSurfaceEventVariant::Done => {
                     if let Some(id) = surface_ids.remove(&surface.id()) {
                         if let Some(w) = window_manager.remove(id.inner()) {
+                            clipboard.register_dnd_destination(
+                                DndSurface(Arc::new(Box::new(w.raw.clone()))),
+                                Vec::new(),
+                            );
                             if clipboard
                                 .window_id()
                                 .is_some_and(|id| w.raw.id() == id)
                             {
-                                clipboard.register_dnd_destination(
-                                    DndSurface(Arc::new(Box::new(
-                                        w.raw.clone(),
-                                    ))),
-                                    Vec::new(),
-                                );
                                 *clipboard = Clipboard::unconnected();
                             }
                         }


### PR DESCRIPTION
This avoids issues with apps like the portal that creates a screenshot, sets the clipboard, and then has the data device destroyed when the window is closed.
