### PR TITLE
Subsurfaces for drag surfaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,6 +214,7 @@ wasm-timer = "0.2"
 web-time = "1.1"
 wgpu = "22.0"
 wayland-protocols = { version = "0.32.1", features = ["staging"] }
+wayland-client = { version = "0.31.5" }
 # web-time = "1.1"
 
 
@@ -222,9 +223,9 @@ wayland-protocols = { version = "0.32.1", features = ["staging"] }
 winapi = "0.3"
 # window_clipboard = "0.4.1"
 
-window_clipboard = { git = "https://github.com/pop-os/window_clipboard.git", tag = "pop-0.13" }
-dnd = { git = "https://github.com/pop-os/window_clipboard.git", tag = "pop-0.13" }
-mime = { git = "https://github.com/pop-os/window_clipboard.git", tag = "pop-0.13" }
+window_clipboard = { git = "https://github.com/pop-os/window_clipboard.git", tag = "pop-0.13-2" }
+dnd = { git = "https://github.com/pop-os/window_clipboard.git", tag = "pop-0.13-2" }
+mime = { git = "https://github.com/pop-os/window_clipboard.git", tag = "pop-0.13-2" }
 winit = { git = "https://github.com/pop-os/winit.git", tag = "iced-xdg-surface-0.13" }
 # winit = { path = "../../winit" }
 # winit = { git = "https://github.com/iced-rs/winit.git", rev = "254d6b3420ce4e674f516f7a2bd440665e05484d" }

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -62,12 +62,14 @@ cctk.workspace = true
 cctk.optional = true
 wayland-protocols.workspace = true
 wayland-protocols.optional = true
+wayland-client.workspace = true
 wayland-backend = { version = "0.3.1", features = [
     "client_system",
 ], optional = true }
 xkbcommon = { version = "0.7", features = ["wayland"], optional = true }
 xkbcommon-dl = { version = "0.4.1", optional = true }
 xkeysym = { version = "0.2.0", optional = true }
+rustix = { version = "0.38" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi.workspace = true

--- a/winit/src/platform_specific/mod.rs
+++ b/winit/src/platform_specific/mod.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use iced_graphics::Compositor;
 use iced_runtime::{core::window, user_interface, Debug};
+use raw_window_handle::HasWindowHandle;
 
 #[cfg(all(feature = "wayland", target_os = "linux"))]
 pub mod wayland;
@@ -69,7 +70,7 @@ impl PlatformSpecific {
     pub(crate) fn update_subsurfaces(
         &mut self,
         id: window::Id,
-        window: &dyn winit::window::Window,
+        window: &dyn HasWindowHandle,
     ) {
         #[cfg(all(feature = "wayland", target_os = "linux"))]
         {
@@ -78,31 +79,12 @@ impl PlatformSpecific {
             };
             use wayland_backend::client::ObjectId;
 
-            let Ok(backend) = window.rwh_06_display_handle().display_handle()
-            else {
-                log::error!("No display handle");
+            let Some(conn) = self.wayland.conn() else {
+                log::error!("No Wayland conn");
                 return;
             };
 
-            let conn = match backend.as_raw() {
-                raw_window_handle::RawDisplayHandle::Wayland(
-                    wayland_display_handle,
-                ) => {
-                    let backend = unsafe {
-                        Backend::from_foreign_display(
-                            wayland_display_handle.display.as_ptr().cast(),
-                        )
-                    };
-                    cctk::sctk::reexports::client::Connection::from_backend(
-                        backend,
-                    )
-                }
-                _ => {
-                    return;
-                }
-            };
-
-            let Ok(raw) = window.rwh_06_window_handle().window_handle() else {
+            let Ok(raw) = window.window_handle() else {
                 log::error!("Invalid window handle {id:?}");
                 return;
             };
@@ -135,6 +117,21 @@ impl PlatformSpecific {
                 }
             };
             self.wayland.update_subsurfaces(id, &wl_surface);
+        }
+    }
+
+    pub(crate) fn create_surface(&mut self) -> Option<Box<dyn HasWindowHandle + Send + Sync + 'static>> {
+        #[cfg(all(feature = "wayland", target_os = "linux"))]
+        {
+            return self.wayland.create_surface();
+        }
+        None
+    }
+
+    pub(crate) fn update_surface_shm(&mut self, surface: &dyn HasWindowHandle, width: u32, height: u32, data: &[u8]) {
+        #[cfg(all(feature = "wayland", target_os = "linux"))]
+        {
+            return self.wayland.update_surface_shm(surface, width, height, data);
         }
     }
 }

--- a/winit/src/platform_specific/wayland/mod.rs
+++ b/winit/src/platform_specific/wayland/mod.rs
@@ -62,7 +62,6 @@ pub(crate) struct WaylandSpecific {
     display_handle: Option<OwnedDisplayHandle>,
     modifiers: Modifiers,
     surface_ids: HashMap<ObjectId, SurfaceIdWrapper>,
-    destroyed_surface_ids: HashMap<ObjectId, SurfaceIdWrapper>,
     subsurface_state: Option<SubsurfaceState>,
     surface_subsurfaces: HashMap<window::Id, Vec<SubsurfaceInstance>>,
 }
@@ -136,7 +135,6 @@ impl WaylandSpecific {
             sender,
             display_handle,
             surface_ids,
-            destroyed_surface_ids,
             modifiers,
             subsurface_state,
             surface_subsurfaces,


### PR DESCRIPTION
Use `Icon::Surface` instead of `Icon::Buffer`, so we can then create subsurfaces of the `wl_surface`.

Using `.screenshot()` then copying to an shm buffer is suboptimal, but this does seem overall better than with the older Iced version when a drag surface didn't appear until a Vulkan surface could be created for it.

This seems to be working okay now, but there are a few things to fix. As well as a bug I'm seeing in cosmic-comp. `cosmic-workspaces` also wants the `offset` support for drag surfaces we previously had.