### PR TITLE
Add support for drag-and-drop surface offsets

### DIFF
--- a/core/src/clipboard.rs
+++ b/core/src/clipboard.rs
@@ -5,25 +5,27 @@ use std::any::Any;
 use dnd::{DndAction, DndDestinationRectangle, DndSurface};
 use mime::{self, AllowedMimeTypes, AsMimeTypes, ClipboardStoreData};
 
-use crate::{widget::tree::State, window, Element};
+use crate::{widget::tree::State, window, Element, Vector};
 
 #[derive(Debug)]
 pub struct IconSurface<E> {
     pub element: E,
     pub state: State,
+    pub offset: Vector,
 }
 
 pub type DynIconSurface = IconSurface<Box<dyn Any>>;
 
 impl<T: 'static, R: 'static> IconSurface<Element<'static, (), T, R>> {
-    pub fn new(element: Element<'static, (), T, R>, state: State) -> Self {
-        Self { element, state }
+    pub fn new(element: Element<'static, (), T, R>, state: State, offset: Vector) -> Self {
+        Self { element, state, offset }
     }
 
     fn upcast(self) -> DynIconSurface {
         IconSurface {
             element: Box::new(self.element),
             state: self.state,
+            offset: self.offset,
         }
     }
 }
@@ -36,6 +38,7 @@ impl DynIconSurface {
         IconSurface {
             element: *self.element.downcast().expect("drag-and-drop icon surface has invalid element type"),
             state: self.state,
+            offset: self.offset,
         }
     }
 }

--- a/core/src/clipboard.rs
+++ b/core/src/clipboard.rs
@@ -1,6 +1,6 @@
 //! Access the clipboard.
 
-use std::{any::Any, sync::Arc};
+use std::any::Any;
 
 use dnd::{DndAction, DndDestinationRectangle, DndSurface};
 use mime::{self, AllowedMimeTypes, AsMimeTypes, ClipboardStoreData};
@@ -98,7 +98,7 @@ pub fn start_dnd<T: 'static, R: 'static, M: 'static>(
         internal,
         source_surface,
         icon_surface.map(|i| {
-            let i: Box<dyn Any> = Box::new(Arc::new(i));
+            let i: Box<dyn Any> = Box::new(i);
             i
         }),
         content,

--- a/core/src/clipboard.rs
+++ b/core/src/clipboard.rs
@@ -7,6 +7,39 @@ use mime::{self, AllowedMimeTypes, AsMimeTypes, ClipboardStoreData};
 
 use crate::{widget::tree::State, window, Element};
 
+#[derive(Debug)]
+pub struct IconSurface<E> {
+    pub element: E,
+    pub state: State,
+}
+
+pub type DynIconSurface = IconSurface<Box<dyn Any>>;
+
+impl<T: 'static, R: 'static> IconSurface<Element<'static, (), T, R>> {
+    pub fn new(element: Element<'static, (), T, R>, state: State) -> Self {
+        Self { element, state }
+    }
+
+    fn upcast(self) -> DynIconSurface {
+        IconSurface {
+            element: Box::new(self.element),
+            state: self.state,
+        }
+    }
+}
+
+impl DynIconSurface {
+    /// Downcast `element` to concrete type `Element<(), T, R>`
+    ///
+    /// Panics if type doesn't match
+    pub fn downcast<T: 'static, R: 'static>(self) -> IconSurface<Element<'static, (), T, R>> {
+        IconSurface {
+            element: *self.element.downcast().expect("drag-and-drop icon surface has invalid element type"),
+            state: self.state,
+        }
+    }
+}
+
 /// A buffer for short-term storage and transfer within and between
 /// applications.
 pub trait Clipboard {
@@ -53,7 +86,7 @@ pub trait Clipboard {
         &mut self,
         _internal: bool,
         _source_surface: Option<DndSource>,
-        _icon_surface: Option<Box<dyn Any>>,
+        _icon_surface: Option<DynIconSurface>,
         _content: Box<dyn AsMimeTypes + Send + 'static>,
         _actions: DndAction,
     ) {
@@ -86,21 +119,18 @@ pub enum Kind {
 
 /// Starts a DnD operation.
 /// icon surface is a tuple of the icon element and optionally the icon element state.
-pub fn start_dnd<T: 'static, R: 'static, M: 'static>(
+pub fn start_dnd<T: 'static, R: 'static>(
     clipboard: &mut dyn Clipboard,
     internal: bool,
     source_surface: Option<DndSource>,
-    icon_surface: Option<(Element<'static, M, T, R>, State)>,
+    icon_surface: Option<IconSurface<Element<'static, (), T, R>>>,
     content: Box<dyn AsMimeTypes + Send + 'static>,
     actions: DndAction,
 ) {
     clipboard.start_dnd(
         internal,
         source_surface,
-        icon_surface.map(|i| {
-            let i: Box<dyn Any> = Box::new(i);
-            i
-        }),
+        icon_surface.map(IconSurface::upcast),
         content,
         actions,
     );

--- a/runtime/src/dnd.rs
+++ b/runtime/src/dnd.rs
@@ -17,19 +17,6 @@ pub enum DndAction {
         /// The rectangles to register.
         rectangles: Vec<DndDestinationRectangle>,
     },
-    /// Start a Dnd operation.
-    StartDnd {
-        /// Whether the Dnd operation is internal.
-        internal: bool,
-        /// The source surface of the Dnd operation.
-        source_surface: Option<DndSource>,
-        /// The icon surface of the Dnd operation.
-        icon_surface: Option<Box<dyn Any + Send>>,
-        /// The content of the Dnd operation.
-        content: Box<dyn AsMimeTypes + Send + 'static>,
-        /// The actions of the Dnd operation.
-        actions: dnd::DndAction,
-    },
     /// End a Dnd operation.
     EndDnd,
     /// Peek the current Dnd operation.
@@ -52,19 +39,6 @@ impl std::fmt::Debug for DndAction {
                 .debug_struct("RegisterDndDestination")
                 .field("surface", surface)
                 .field("rectangles", rectangles)
-                .finish(),
-            Self::StartDnd {
-                internal,
-                source_surface,
-                icon_surface,
-                content: _,
-                actions,
-            } => f
-                .debug_struct("StartDnd")
-                .field("internal", internal)
-                .field("source_surface", source_surface)
-                .field("icon_surface", icon_surface)
-                .field("actions", actions)
                 .finish(),
             Self::EndDnd => f.write_str("EndDnd"),
             Self::PeekDnd(mime, _) => {
@@ -96,23 +70,6 @@ pub fn register_dnd_destination<Message>(
     task::effect(Action::Dnd(DndAction::RegisterDndDestination {
         surface,
         rectangles,
-    }))
-}
-
-/// Start a Dnd operation.
-pub fn start_dnd<Message>(
-    internal: bool,
-    source_surface: Option<DndSource>,
-    icon_surface: Option<Box<dyn Any + Send>>,
-    content: Box<dyn AsMimeTypes + Send + 'static>,
-    actions: dnd::DndAction,
-) -> Task<Message> {
-    task::effect(Action::Dnd(DndAction::StartDnd {
-        internal,
-        source_surface,
-        icon_surface,
-        content,
-        actions,
     }))
 }
 

--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -3,7 +3,7 @@
 use std::sync::Mutex;
 use std::{any::Any, borrow::Cow};
 
-use crate::core::clipboard::DndSource;
+use crate::core::clipboard::{DndSource, DynIconSurface};
 use crate::core::clipboard::Kind;
 use std::sync::Arc;
 use winit::dpi::LogicalSize;
@@ -26,7 +26,7 @@ pub struct Clipboard {
 pub(crate) struct StartDnd {
     pub(crate) internal: bool,
     pub(crate) source_surface: Option<DndSource>,
-    pub(crate) icon_surface: Option<Box<dyn Any>>,
+    pub(crate) icon_surface: Option<DynIconSurface>,
     pub(crate) content: Box<dyn mime::AsMimeTypes + Send + 'static>,
     pub(crate) actions: DndAction,
 }
@@ -261,7 +261,7 @@ impl crate::core::Clipboard for Clipboard {
         &mut self,
         internal: bool,
         source_surface: Option<DndSource>,
-        icon_surface: Option<Box<dyn Any>>,
+        icon_surface: Option<DynIconSurface>,
         content: Box<dyn mime::AsMimeTypes + Send + 'static>,
         actions: DndAction,
     ) {

--- a/winit/src/platform_specific/mod.rs
+++ b/winit/src/platform_specific/mod.rs
@@ -128,10 +128,10 @@ impl PlatformSpecific {
         None
     }
 
-    pub(crate) fn update_surface_shm(&mut self, surface: &dyn HasWindowHandle, width: u32, height: u32, data: &[u8], offset: Vector) {
+    pub(crate) fn update_surface_shm(&mut self, surface: &dyn HasWindowHandle, width: u32, height: u32, scale: f64, data: &[u8], offset: Vector) {
         #[cfg(all(feature = "wayland", target_os = "linux"))]
         {
-            return self.wayland.update_surface_shm(surface, width, height, data, offset);
+            return self.wayland.update_surface_shm(surface, width, height, scale, data, offset);
         }
     }
 }

--- a/winit/src/platform_specific/mod.rs
+++ b/winit/src/platform_specific/mod.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 use iced_graphics::Compositor;
-use iced_runtime::{core::window, user_interface, Debug};
+use iced_runtime::{core::{window, Vector}, user_interface, Debug};
 use raw_window_handle::HasWindowHandle;
 
 #[cfg(all(feature = "wayland", target_os = "linux"))]
@@ -128,10 +128,10 @@ impl PlatformSpecific {
         None
     }
 
-    pub(crate) fn update_surface_shm(&mut self, surface: &dyn HasWindowHandle, width: u32, height: u32, data: &[u8]) {
+    pub(crate) fn update_surface_shm(&mut self, surface: &dyn HasWindowHandle, width: u32, height: u32, data: &[u8], offset: Vector) {
         #[cfg(all(feature = "wayland", target_os = "linux"))]
         {
-            return self.wayland.update_surface_shm(surface, width, height, data);
+            return self.wayland.update_surface_shm(surface, width, height, data, offset);
         }
     }
 }

--- a/winit/src/platform_specific/wayland/mod.rs
+++ b/winit/src/platform_specific/wayland/mod.rs
@@ -15,7 +15,7 @@ use cctk::sctk::reexports::client::protocol::wl_surface::WlSurface;
 use cctk::sctk::seat::keyboard::Modifiers;
 use iced_futures::futures::channel::mpsc;
 use iced_graphics::Compositor;
-use iced_runtime::core::window;
+use iced_runtime::core::{window, Vector};
 use iced_runtime::Debug;
 use raw_window_handle::{DisplayHandle, HasDisplayHandle, HasWindowHandle};
 use raw_window_handle::{HasRawDisplayHandle, RawWindowHandle};
@@ -239,12 +239,12 @@ impl WaylandSpecific {
         }
     }
 
-    pub(crate) fn update_surface_shm(&mut self, window: &dyn HasWindowHandle, width: u32, height: u32, data: &[u8]) {
+    pub(crate) fn update_surface_shm(&mut self, window: &dyn HasWindowHandle, width: u32, height: u32, data: &[u8], offset: Vector) {
         if let Some(subsurface_state) = self.subsurface_state.as_mut() {
             if let RawWindowHandle::Wayland(window) = window.window_handle().unwrap().as_raw() {
                 let id = unsafe { ObjectId::from_ptr(WlSurface::interface(), window.surface.as_ptr().cast()).unwrap() };
                 let surface = WlSurface::from_id(self.conn.as_ref().unwrap(), id).unwrap();
-                subsurface_state.update_surface_shm(&surface, width, height, data);
+                subsurface_state.update_surface_shm(&surface, width, height, data, offset);
             }
         }
     }

--- a/winit/src/platform_specific/wayland/mod.rs
+++ b/winit/src/platform_specific/wayland/mod.rs
@@ -239,12 +239,12 @@ impl WaylandSpecific {
         }
     }
 
-    pub(crate) fn update_surface_shm(&mut self, window: &dyn HasWindowHandle, width: u32, height: u32, data: &[u8], offset: Vector) {
+    pub(crate) fn update_surface_shm(&mut self, window: &dyn HasWindowHandle, width: u32, height: u32, scale: f64, data: &[u8], offset: Vector) {
         if let Some(subsurface_state) = self.subsurface_state.as_mut() {
             if let RawWindowHandle::Wayland(window) = window.window_handle().unwrap().as_raw() {
                 let id = unsafe { ObjectId::from_ptr(WlSurface::interface(), window.surface.as_ptr().cast()).unwrap() };
                 let surface = WlSurface::from_id(self.conn.as_ref().unwrap(), id).unwrap();
-                subsurface_state.update_surface_shm(&surface, width, height, data, offset);
+                subsurface_state.update_surface_shm(&surface, width, height, scale, data, offset);
             }
         }
     }

--- a/winit/src/platform_specific/wayland/subsurface_widget.rs
+++ b/winit/src/platform_specific/wayland/subsurface_widget.rs
@@ -4,7 +4,7 @@ use crate::core::{
     layout::{self, Layout},
     mouse, renderer,
     widget::{self, Widget},
-    ContentFit, Element, Length, Rectangle, Size,
+    ContentFit, Element, Length, Rectangle, Size, Vector,
 };
 use std::{
     cell::RefCell,
@@ -377,13 +377,14 @@ impl SubsurfaceState {
             .create_surface(&self.qh, SurfaceData::new(None, 1))
     }
 
-    pub fn update_surface_shm(&self, surface: &WlSurface, width: u32, height: u32, data: &[u8]) {
+    pub fn update_surface_shm(&self, surface: &WlSurface, width: u32, height: u32, data: &[u8], offset: Vector) {
         let shm = ShmGlobal(&self.wl_shm);
         let mut pool = SlotPool::new(width as usize * height as usize * 4, &shm).unwrap();
         let (buffer, canvas) = pool.create_buffer(width as i32, height as i32, width as i32 * 4, wl_shm::Format::Argb8888).unwrap();
         canvas[0..width as usize * height as usize * 4].copy_from_slice(data);
         surface.damage_buffer(0, 0, width as i32, height as i32);
         buffer.attach_to(&surface);
+        surface.offset(offset.x as i32, offset.y as i32);
         surface.commit();
     }
 

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -888,7 +888,7 @@ async fn run_instance<'a, P, C>(
                     let state = &window.state;
                     let icon_surface = icon_surface
                         .map(|i| {
-                            let e = i.downcast::<Arc<(
+                            let e = i.downcast::<(
                                 core::Element<
                                     'static,
                                     (),
@@ -896,10 +896,9 @@ async fn run_instance<'a, P, C>(
                                     P::Renderer,
                                 >,
                                 core::widget::tree::State,
-                            )>>()
+                            )>()
                             .unwrap();
-                            let e = Arc::into_inner(*e).unwrap();
-                            let (mut e, widget_state) = e;
+                            let (mut e, widget_state) = *e;
 
                             let mut renderer = compositor.create_renderer();
 

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -888,17 +888,7 @@ async fn run_instance<'a, P, C>(
                     let state = &window.state;
                     let icon_surface = icon_surface
                         .map(|i| {
-                            let e = i.downcast::<(
-                                core::Element<
-                                    'static,
-                                    (),
-                                    P::Theme,
-                                    P::Renderer,
-                                >,
-                                core::widget::tree::State,
-                            )>()
-                            .unwrap();
-                            let (mut e, widget_state) = *e;
+                            let mut icon_surface = i.downcast::<P::Theme, P::Renderer>();
 
                             let mut renderer = compositor.create_renderer();
 
@@ -913,16 +903,16 @@ async fn run_instance<'a, P, C>(
                             );
 
                             let mut tree = core::widget::Tree {
-                                id: e.as_widget().id(),
-                                tag: e.as_widget().tag(),
-                                state: widget_state,
-                                children: e.as_widget().children(),
+                                id: icon_surface.element.as_widget().id(),
+                                tag: icon_surface.element.as_widget().tag(),
+                                state: icon_surface.state,
+                                children: icon_surface.element.as_widget().children(),
                             };
 
-                            let size = e
+                            let size = icon_surface.element
                                 .as_widget()
                                 .layout(&mut tree, &renderer, &lim);
-                            e.as_widget_mut().diff(&mut tree);
+                            icon_surface.element.as_widget_mut().diff(&mut tree);
 
                             let size = lim.resolve(
                                 Length::Shrink,
@@ -935,7 +925,7 @@ async fn run_instance<'a, P, C>(
                             );
 
                             let mut ui = UserInterface::build(
-                                e,
+                                icon_surface.element,
                                 size,
                                 user_interface::Cache::default(),
                                 &mut renderer,

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -2279,21 +2279,6 @@ where
             } => {
                 clipboard.register_dnd_destination(surface, rectangles);
             }
-            iced_runtime::dnd::DndAction::StartDnd {
-                internal,
-                source_surface,
-                icon_surface,
-                content,
-                actions,
-            } => {
-                clipboard.start_dnd(
-                    internal,
-                    source_surface,
-                    icon_surface.map(|d| d as Box<dyn Any>),
-                    content,
-                    actions,
-                );
-            }
             iced_runtime::dnd::DndAction::EndDnd => {
                 clipboard.end_dnd();
             }

--- a/winit/src/program.rs
+++ b/winit/src/program.rs
@@ -959,7 +959,7 @@ async fn run_instance<'a, P, C>(
                                     .update_subsurfaces(id, &surface);
                                 let surface = Arc::new(surface);
                                 dnd_surface = Some(surface.clone());
-                                dnd_buffer = Some((viewport.physical_size(), bytes, icon_surface.offset));
+                                dnd_buffer = Some((viewport.physical_size(), state.scale_factor(), bytes, icon_surface.offset));
                                 Icon::Surface(dnd::DndSurface(surface))
                             } else {
                                 platform_specific_handler
@@ -982,8 +982,8 @@ async fn run_instance<'a, P, C>(
                     );
 
                     // This needs to be after `wl_data_device::start_drag` for the offset to have an effect
-                    if let (Some(surface), Some((size, bytes, offset))) = (dnd_surface.as_ref(), dnd_buffer) {
-                        platform_specific_handler.update_surface_shm(&surface, size.width, size.height, &bytes, offset);
+                    if let (Some(surface), Some((size, scale, bytes, offset))) = (dnd_surface.as_ref(), dnd_buffer) {
+                        platform_specific_handler.update_surface_shm(&surface, size.width, size.height, scale, &bytes, offset);
                     }
                 }
             }


### PR DESCRIPTION
Provides the same functionality as https://github.com/pop-os/iced/pull/134.

Still needs `libcosmic` update to pass on offset on drag start, and provide a way to set the offset of the surface. This also doesn't seem to be working as expected currently....

This also tries to clean up the way a tuple and `Box<dyn Any>` was used to be a little more organized.