### PR TITLE
Use cached alpha mode instead of calling surface.get_capabilities every time the window is redrawn

### DIFF
--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -402,21 +402,6 @@ impl graphics::Compositor for Compositor {
         width: u32,
         height: u32,
     ) {
-        let caps = surface.get_capabilities(&self.adapter);
-        let alpha_mode = if caps
-            .alpha_modes
-            .contains(&wgpu::CompositeAlphaMode::PostMultiplied)
-        {
-            wgpu::CompositeAlphaMode::PostMultiplied
-        } else if caps
-            .alpha_modes
-            .contains(&wgpu::CompositeAlphaMode::PreMultiplied)
-        {
-            wgpu::CompositeAlphaMode::PreMultiplied
-        } else {
-            wgpu::CompositeAlphaMode::Auto
-        };
-
         surface.configure(
             &self.device,
             &wgpu::SurfaceConfiguration {
@@ -425,7 +410,7 @@ impl graphics::Compositor for Compositor {
                 present_mode: self.settings.present_mode,
                 width,
                 height,
-                alpha_mode,
+                alpha_mode: self.alpha_mode,
                 view_formats: vec![],
                 desired_maximum_frame_latency: 1,
             },


### PR DESCRIPTION
This somewhat improves performance on resizing by using the cached self.alpha_mode on the wgpu backend instead of calling surface.get_capabilities every time, which results in a roughly 50% reduction in resize draw time.

Note: resizing is still somewhat choppy and I've traced it to surface.configure in the same function, though I cannot figure out why this takes many times longer to run than base iced. If I figure it out, I'll let y'all know
