### PR TITLE
mouse_area: Fix `on_drag` behavior without `on_release`

### DIFF
--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -506,11 +506,11 @@ fn update<Message: Clone, Theme, Renderer>(
         }
     }
 
-    if let Some(message) = widget.on_release.as_ref() {
-        if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
-        | Event::Touch(touch::Event::FingerLifted { .. }) = event
-        {
-            state.drag_initiated = None;
+    if let Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
+    | Event::Touch(touch::Event::FingerLifted { .. }) = event
+    {
+        state.drag_initiated = None;
+        if let Some(message) = widget.on_release.as_ref() {
             shell.publish(message.clone());
 
             return event::Status::Captured;


### PR DESCRIPTION
Mouse/touch release events should end the drag even if there's not an `on_release` callback.

This was causing https://github.com/pop-os/cosmic-comp/issues/1071.

The core team is busy and does not have time to mentor nor babysit new contributors. If a member of the core team thinks that reviewing and understanding your work will take more time and effort than writing it from scratch by themselves, your contribution will be dismissed. It is your responsibility to communicate and figure out how to reduce the likelihood of this!

Read the contributing guidelines for more details: https://github.com/iced-rs/iced/blob/master/CONTRIBUTING.md
