### PR TITLE
refactor: include virtual offset in Layout

### DIFF
--- a/core/src/layout.rs
+++ b/core/src/layout.rs
@@ -12,6 +12,9 @@ use crate::{Length, Padding, Point, Rectangle, Size, Vector};
 /// The bounds of a [`Node`] and its children, using absolute coordinates.
 #[derive(Debug, Clone, Copy)]
 pub struct Layout<'a> {
+    /// The virtual offset of the layout.
+    /// May represent the scroll positions in pixels of a scrollable, for example.
+    virtual_offset: Vector,
     position: Point,
     node: &'a Node,
 }
@@ -28,14 +31,27 @@ impl<'a> Layout<'a> {
         let bounds = node.bounds();
 
         Self {
+            virtual_offset: Vector::new(0., 0.),
             position: Point::new(bounds.x, bounds.y) + offset,
             node,
         }
     }
 
+    /// Returns a new layout with the virtual offset
+    pub fn with_virtual_offset(mut self, virtual_offset: Vector) -> Self {
+        self.virtual_offset = virtual_offset;
+        self
+    }
+
     /// Returns the position of the [`Layout`].
     pub fn position(&self) -> Point {
         self.position
+    }
+
+    /// The virtual offset of the layout.
+    /// May represent the scroll positions in pixels of a scrollable, for example.
+    pub fn virtual_offset(&self) -> Vector {
+        self.virtual_offset
     }
 
     /// Returns the bounds of the [`Layout`].

--- a/core/src/overlay.rs
+++ b/core/src/overlay.rs
@@ -122,10 +122,13 @@ where
         .iter_mut()
         .zip(&mut tree.children)
         .zip(layout.children())
-        .filter_map(|((child, state), layout)| {
-            child
-                .as_widget_mut()
-                .overlay(state, layout, renderer, translation)
+        .filter_map(|((child, state), c_layout)| {
+            child.as_widget_mut().overlay(
+                state,
+                c_layout.with_virtual_offset(layout.virtual_offset()),
+                renderer,
+                translation,
+            )
         })
         .collect::<Vec<_>>();
 

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -329,7 +329,11 @@ where
         operation.container(None, layout.bounds(), &mut |operation| {
             self.content.as_widget().operate(
                 &mut tree.children[0],
-                layout.children().next().unwrap(),
+                layout
+                    .children()
+                    .next()
+                    .unwrap()
+                    .with_virtual_offset(layout.virtual_offset()),
                 renderer,
                 operation,
             );
@@ -350,7 +354,11 @@ where
         if let event::Status::Captured = self.content.as_widget_mut().on_event(
             &mut tree.children[0],
             event.clone(),
-            layout.children().next().unwrap(),
+            layout
+                .children()
+                .next()
+                .unwrap()
+                .with_virtual_offset(layout.virtual_offset()),
             cursor,
             renderer,
             clipboard,
@@ -450,7 +458,11 @@ where
         viewport: &Rectangle,
     ) {
         let bounds = layout.bounds();
-        let content_layout = layout.children().next().unwrap();
+        let content_layout = layout
+            .children()
+            .next()
+            .unwrap()
+            .with_virtual_offset(layout.virtual_offset());
         let is_mouse_over = cursor.is_over(bounds);
 
         let status = if self.on_press.is_none() {
@@ -534,7 +546,11 @@ where
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         self.content.as_widget_mut().overlay(
             &mut tree.children[0],
-            layout.children().next().unwrap(),
+            layout
+                .children()
+                .next()
+                .unwrap()
+                .with_virtual_offset(layout.virtual_offset()),
             renderer,
             translation,
         )
@@ -557,10 +573,11 @@ where
 
         let child_layout = layout.children().next().unwrap();
         let child_tree = &state.children[0];
-        let child_tree =
-            self.content
-                .as_widget()
-                .a11y_nodes(child_layout, child_tree, p);
+        let child_tree = self.content.as_widget().a11y_nodes(
+            child_layout.with_virtual_offset(layout.virtual_offset()),
+            child_tree,
+            p,
+        );
 
         let Rectangle {
             x,

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -250,10 +250,13 @@ where
                 .iter()
                 .zip(&mut tree.children)
                 .zip(layout.children())
-                .for_each(|((child, state), layout)| {
-                    child
-                        .as_widget()
-                        .operate(state, layout, renderer, operation);
+                .for_each(|((child, state), c_layout)| {
+                    child.as_widget().operate(
+                        state,
+                        c_layout.with_virtual_offset(layout.virtual_offset()),
+                        renderer,
+                        operation,
+                    );
                 });
         });
     }
@@ -273,11 +276,11 @@ where
             .iter_mut()
             .zip(&mut tree.children)
             .zip(layout.children())
-            .map(|((child, state), layout)| {
+            .map(|((child, state), c_layout)| {
                 child.as_widget_mut().on_event(
                     state,
                     event.clone(),
-                    layout,
+                    c_layout.with_virtual_offset(layout.virtual_offset()),
                     cursor,
                     renderer,
                     clipboard,
@@ -300,9 +303,13 @@ where
             .iter()
             .zip(&tree.children)
             .zip(layout.children())
-            .map(|((child, state), layout)| {
+            .map(|((child, state), c_layout)| {
                 child.as_widget().mouse_interaction(
-                    state, layout, cursor, viewport, renderer,
+                    state,
+                    c_layout.with_virtual_offset(layout.virtual_offset()),
+                    cursor,
+                    viewport,
+                    renderer,
                 )
             })
             .max()
@@ -326,7 +333,7 @@ where
                 viewport
             };
 
-            for ((child, state), layout) in self
+            for ((child, state), c_layout) in self
                 .children
                 .iter()
                 .zip(&tree.children)
@@ -334,7 +341,13 @@ where
                 .filter(|(_, layout)| layout.bounds().intersects(viewport))
             {
                 child.as_widget().draw(
-                    state, renderer, theme, style, layout, cursor, viewport,
+                    state,
+                    renderer,
+                    theme,
+                    style,
+                    c_layout.with_virtual_offset(layout.virtual_offset()),
+                    cursor,
+                    viewport,
                 );
             }
         }
@@ -371,7 +384,11 @@ where
                 .zip(layout.children())
                 .zip(state.children.iter())
                 .map(|((c, c_layout), state)| {
-                    c.as_widget().a11y_nodes(c_layout, state, cursor)
+                    c.as_widget().a11y_nodes(
+                        c_layout.with_virtual_offset(layout.virtual_offset()),
+                        state,
+                        cursor,
+                    )
                 }),
         )
     }
@@ -383,7 +400,7 @@ where
         renderer: &Renderer,
         dnd_rectangles: &mut crate::core::clipboard::DndDestinationRectangles,
     ) {
-        for ((e, layout), state) in self
+        for ((e, c_layout), state) in self
             .children
             .iter()
             .zip(layout.children())
@@ -391,7 +408,7 @@ where
         {
             e.as_widget().drag_destinations(
                 state,
-                layout,
+                c_layout.with_virtual_offset(layout.virtual_offset()),
                 renderer,
                 dnd_rectangles,
             );

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -282,7 +282,11 @@ where
             &mut |operation| {
                 self.content.as_widget().operate(
                     tree,
-                    layout.children().next().unwrap(),
+                    layout
+                        .children()
+                        .next()
+                        .unwrap()
+                        .with_virtual_offset(layout.virtual_offset()),
                     renderer,
                     operation,
                 );
@@ -304,7 +308,11 @@ where
         self.content.as_widget_mut().on_event(
             tree,
             event,
-            layout.children().next().unwrap(),
+            layout
+                .children()
+                .next()
+                .unwrap()
+                .with_virtual_offset(layout.virtual_offset()),
             cursor,
             renderer,
             clipboard,
@@ -323,7 +331,11 @@ where
     ) -> mouse::Interaction {
         self.content.as_widget().mouse_interaction(
             tree,
-            layout.children().next().unwrap(),
+            layout
+                .children()
+                .next()
+                .unwrap()
+                .with_virtual_offset(layout.virtual_offset()),
             cursor,
             viewport,
             renderer,
@@ -359,7 +371,11 @@ where
                         .unwrap_or(renderer_style.text_color),
                     scale_factor: renderer_style.scale_factor,
                 },
-                layout.children().next().unwrap(),
+                layout
+                    .children()
+                    .next()
+                    .unwrap()
+                    .with_virtual_offset(layout.virtual_offset()),
                 cursor,
                 if self.clip {
                     &clipped_viewport
@@ -379,7 +395,11 @@ where
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         self.content.as_widget_mut().overlay(
             tree,
-            layout.children().next().unwrap(),
+            layout
+                .children()
+                .next()
+                .unwrap()
+                .with_virtual_offset(layout.virtual_offset()),
             renderer,
             translation,
         )
@@ -395,7 +415,11 @@ where
     ) -> iced_accessibility::A11yTree {
         let c_layout = layout.children().next().unwrap();
 
-        self.content.as_widget().a11y_nodes(c_layout, state, cursor)
+        self.content.as_widget().a11y_nodes(
+            c_layout.with_virtual_offset(layout.virtual_offset()),
+            state,
+            cursor,
+        )
     }
 
     fn drag_destinations(
@@ -408,7 +432,7 @@ where
         if let Some(l) = layout.children().next() {
             self.content.as_widget().drag_destinations(
                 state,
-                l,
+                l.with_virtual_offset(layout.virtual_offset()),
                 renderer,
                 dnd_rectangles,
             );

--- a/widget/src/keyed/column.rs
+++ b/widget/src/keyed/column.rs
@@ -292,10 +292,13 @@ where
                 .iter()
                 .zip(&mut tree.children)
                 .zip(layout.children())
-                .for_each(|((child, state), layout)| {
-                    child
-                        .as_widget()
-                        .operate(state, layout, renderer, operation);
+                .for_each(|((child, state), c_layout)| {
+                    child.as_widget().operate(
+                        state,
+                        c_layout.with_virtual_offset(layout.virtual_offset()),
+                        renderer,
+                        operation,
+                    );
                 });
         });
     }
@@ -315,11 +318,11 @@ where
             .iter_mut()
             .zip(&mut tree.children)
             .zip(layout.children())
-            .map(|((child, state), layout)| {
+            .map(|((child, state), c_layout)| {
                 child.as_widget_mut().on_event(
                     state,
                     event.clone(),
-                    layout,
+                    c_layout.with_virtual_offset(layout.virtual_offset()),
                     cursor,
                     renderer,
                     clipboard,
@@ -342,9 +345,13 @@ where
             .iter()
             .zip(&tree.children)
             .zip(layout.children())
-            .map(|((child, state), layout)| {
+            .map(|((child, state), c_layout)| {
                 child.as_widget().mouse_interaction(
-                    state, layout, cursor, viewport, renderer,
+                    state,
+                    c_layout.with_virtual_offset(layout.virtual_offset()),
+                    cursor,
+                    viewport,
+                    renderer,
                 )
             })
             .max()
@@ -361,15 +368,21 @@ where
         cursor: mouse::Cursor,
         viewport: &Rectangle,
     ) {
-        for ((child, state), layout) in self
+        for ((child, state), c_layout) in self
             .children
             .iter()
             .zip(&tree.children)
             .zip(layout.children())
         {
-            child
-                .as_widget()
-                .draw(state, renderer, theme, style, layout, cursor, viewport);
+            child.as_widget().draw(
+                state,
+                renderer,
+                theme,
+                style,
+                c_layout.with_virtual_offset(layout.virtual_offset()),
+                cursor,
+                viewport,
+            );
         }
     }
 

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -388,8 +388,13 @@ where
                 .iter()
                 .zip(&mut tree.children)
                 .zip(layout.children())
-                .for_each(|(((_pane, content), state), layout)| {
-                    content.operate(state, layout, renderer, operation);
+                .for_each(|(((_pane, content), state), c_layout)| {
+                    content.operate(
+                        state,
+                        c_layout.with_virtual_offset(layout.virtual_offset()),
+                        renderer,
+                        operation,
+                    );
                 });
         });
     }
@@ -581,13 +586,13 @@ where
             .iter_mut()
             .zip(&mut tree.children)
             .zip(layout.children())
-            .map(|(((pane, content), tree), layout)| {
+            .map(|(((pane, content), tree), c_layout)| {
                 let is_picked = picked_pane == Some(pane);
 
                 content.on_event(
                     tree,
                     event.clone(),
-                    layout,
+                    c_layout.with_virtual_offset(layout.virtual_offset()),
                     cursor,
                     renderer,
                     clipboard,
@@ -650,10 +655,10 @@ where
             .iter()
             .zip(&tree.children)
             .zip(layout.children())
-            .map(|(((_pane, content), tree), layout)| {
+            .map(|(((_pane, content), tree), c_layout)| {
                 content.mouse_interaction(
                     tree,
-                    layout,
+                    c_layout.with_virtual_offset(layout.virtual_offset()),
                     cursor,
                     viewport,
                     renderer,
@@ -766,7 +771,8 @@ where
                         renderer,
                         theme,
                         defaults,
-                        pane_layout,
+                        pane_layout
+                            .with_virtual_offset(layout.virtual_offset()),
                         pane_cursor,
                         viewport,
                     );
@@ -797,7 +803,8 @@ where
                         renderer,
                         theme,
                         defaults,
-                        pane_layout,
+                        pane_layout
+                            .with_virtual_offset(layout.virtual_offset()),
                         pane_cursor,
                         viewport,
                     );
@@ -892,8 +899,13 @@ where
             .iter_mut()
             .zip(&mut tree.children)
             .zip(layout.children())
-            .filter_map(|(((_, content), state), layout)| {
-                content.overlay(state, layout, renderer, translation)
+            .filter_map(|(((_, content), state), c_layout)| {
+                content.overlay(
+                    state,
+                    c_layout.with_virtual_offset(layout.virtual_offset()),
+                    renderer,
+                    translation,
+                )
             })
             .collect::<Vec<_>>();
 

--- a/widget/src/pane_grid/title_bar.rs
+++ b/widget/src/pane_grid/title_bar.rs
@@ -191,7 +191,8 @@ where
                             renderer,
                             theme,
                             &inherited_style,
-                            compact_layout,
+                            compact_layout
+                                .with_virtual_offset(layout.virtual_offset()),
                             cursor,
                             viewport,
                         );
@@ -203,7 +204,8 @@ where
                             renderer,
                             theme,
                             &inherited_style,
-                            controls_layout,
+                            controls_layout
+                                .with_virtual_offset(layout.virtual_offset()),
                             cursor,
                             viewport,
                         );
@@ -214,7 +216,8 @@ where
                         renderer,
                         theme,
                         &inherited_style,
-                        controls_layout,
+                        controls_layout
+                            .with_virtual_offset(layout.virtual_offset()),
                         cursor,
                         viewport,
                     );
@@ -228,7 +231,7 @@ where
                 renderer,
                 theme,
                 &inherited_style,
-                title_layout,
+                title_layout.with_virtual_offset(layout.virtual_offset()),
                 cursor,
                 viewport,
             );
@@ -396,7 +399,8 @@ where
 
                     compact.as_widget().operate(
                         &mut tree.children[2],
-                        compact_layout,
+                        compact_layout
+                            .with_virtual_offset(layout.virtual_offset()),
                         renderer,
                         operation,
                     );
@@ -405,7 +409,8 @@ where
 
                     controls.full.as_widget().operate(
                         &mut tree.children[1],
-                        controls_layout,
+                        controls_layout
+                            .with_virtual_offset(layout.virtual_offset()),
                         renderer,
                         operation,
                     );
@@ -413,7 +418,8 @@ where
             } else {
                 controls.full.as_widget().operate(
                     &mut tree.children[1],
-                    controls_layout,
+                    controls_layout
+                        .with_virtual_offset(layout.virtual_offset()),
                     renderer,
                     operation,
                 );
@@ -459,7 +465,8 @@ where
                     compact.as_widget_mut().on_event(
                         &mut tree.children[2],
                         event.clone(),
-                        compact_layout,
+                        compact_layout
+                            .with_virtual_offset(layout.virtual_offset()),
                         cursor,
                         renderer,
                         clipboard,
@@ -472,7 +479,8 @@ where
                     controls.full.as_widget_mut().on_event(
                         &mut tree.children[1],
                         event.clone(),
-                        controls_layout,
+                        controls_layout
+                            .with_virtual_offset(layout.virtual_offset()),
                         cursor,
                         renderer,
                         clipboard,
@@ -484,7 +492,8 @@ where
                 controls.full.as_widget_mut().on_event(
                     &mut tree.children[1],
                     event.clone(),
-                    controls_layout,
+                    controls_layout
+                        .with_virtual_offset(layout.virtual_offset()),
                     cursor,
                     renderer,
                     clipboard,
@@ -500,7 +509,7 @@ where
             self.content.as_widget_mut().on_event(
                 &mut tree.children[0],
                 event,
-                title_layout,
+                title_layout.with_virtual_offset(layout.virtual_offset()),
                 cursor,
                 renderer,
                 clipboard,
@@ -530,7 +539,7 @@ where
 
         let title_interaction = self.content.as_widget().mouse_interaction(
             &tree.children[0],
-            title_layout,
+            title_layout.with_virtual_offset(layout.virtual_offset()),
             cursor,
             viewport,
             renderer,
@@ -541,7 +550,8 @@ where
             let controls_interaction =
                 controls.full.as_widget().mouse_interaction(
                     &tree.children[1],
-                    controls_layout,
+                    controls_layout
+                        .with_virtual_offset(layout.virtual_offset()),
                     cursor,
                     viewport,
                     renderer,
@@ -555,7 +565,8 @@ where
                     let compact_interaction =
                         compact.as_widget().mouse_interaction(
                             &tree.children[2],
-                            compact_layout,
+                            compact_layout
+                                .with_virtual_offset(layout.virtual_offset()),
                             cursor,
                             viewport,
                             renderer,
@@ -611,14 +622,18 @@ where
 
                             compact.as_widget_mut().overlay(
                                 compact_state,
-                                compact_layout,
+                                compact_layout.with_virtual_offset(
+                                    layout.virtual_offset(),
+                                ),
                                 renderer,
                                 translation,
                             )
                         } else {
                             controls.full.as_widget_mut().overlay(
                                 controls_state,
-                                controls_layout,
+                                controls_layout.with_virtual_offset(
+                                    layout.virtual_offset(),
+                                ),
                                 renderer,
                                 translation,
                             )
@@ -626,7 +641,8 @@ where
                     } else {
                         controls.full.as_widget_mut().overlay(
                             controls_state,
-                            controls_layout,
+                            controls_layout
+                                .with_virtual_offset(layout.virtual_offset()),
                             renderer,
                             translation,
                         )

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -246,10 +246,13 @@ where
                 .iter()
                 .zip(&mut tree.children)
                 .zip(layout.children())
-                .for_each(|((child, state), layout)| {
-                    child
-                        .as_widget()
-                        .operate(state, layout, renderer, operation);
+                .for_each(|((child, state), c_layout)| {
+                    child.as_widget().operate(
+                        state,
+                        c_layout.with_virtual_offset(layout.virtual_offset()),
+                        renderer,
+                        operation,
+                    );
                 });
         });
     }
@@ -269,11 +272,11 @@ where
             .iter_mut()
             .zip(&mut tree.children)
             .zip(layout.children())
-            .map(|((child, state), layout)| {
+            .map(|((child, state), c_layout)| {
                 child.as_widget_mut().on_event(
                     state,
                     event.clone(),
-                    layout,
+                    c_layout.with_virtual_offset(layout.virtual_offset()),
                     cursor,
                     renderer,
                     clipboard,
@@ -296,9 +299,13 @@ where
             .iter()
             .zip(&tree.children)
             .zip(layout.children())
-            .map(|((child, state), layout)| {
+            .map(|((child, state), c_layout)| {
                 child.as_widget().mouse_interaction(
-                    state, layout, cursor, viewport, renderer,
+                    state,
+                    c_layout.with_virtual_offset(layout.virtual_offset()),
+                    cursor,
+                    viewport,
+                    renderer,
                 )
             })
             .max()
@@ -322,7 +329,7 @@ where
                 viewport
             };
 
-            for ((child, state), layout) in self
+            for ((child, state), c_layout) in self
                 .children
                 .iter()
                 .zip(&tree.children)
@@ -330,7 +337,13 @@ where
                 .filter(|(_, layout)| layout.bounds().intersects(viewport))
             {
                 child.as_widget().draw(
-                    state, renderer, theme, style, layout, cursor, viewport,
+                    state,
+                    renderer,
+                    theme,
+                    style,
+                    c_layout.with_virtual_offset(layout.virtual_offset()),
+                    cursor,
+                    viewport,
                 );
             }
         }
@@ -367,7 +380,11 @@ where
                 .zip(layout.children())
                 .zip(state.children.iter())
                 .map(|((c, c_layout), state)| {
-                    c.as_widget().a11y_nodes(c_layout, state, cursor)
+                    c.as_widget().a11y_nodes(
+                        c_layout.with_virtual_offset(layout.virtual_offset()),
+                        state,
+                        cursor,
+                    )
                 }),
         )
     }
@@ -379,7 +396,7 @@ where
         renderer: &Renderer,
         dnd_rectangles: &mut crate::core::clipboard::DndDestinationRectangles,
     ) {
-        for ((e, layout), state) in self
+        for ((e, c_layout), state) in self
             .children
             .iter()
             .zip(layout.children())
@@ -387,7 +404,7 @@ where
         {
             e.as_widget().drag_destinations(
                 state,
-                layout,
+                c_layout.with_virtual_offset(layout.virtual_offset()),
                 renderer,
                 dnd_rectangles,
             );


### PR DESCRIPTION
This will probably affect future rebases, but I think something like this must be done for widgets to create popups and sub-surfaces at the correct position using the Layout. This, along with some changes to libcosmic, fixes https://github.com/pop-os/cosmic-settings/issues/1067. 