### PR TITLE
subsurface_widget: Fix use of `place_above`, allow negative `z` to place below parent surface

### DIFF
--- a/runtime/src/platform_specific/wayland/subsurface.rs
+++ b/runtime/src/platform_specific/wayland/subsurface.rs
@@ -23,7 +23,7 @@ pub struct SctkSubsurfaceSettings {
     pub size: Option<Size>,
     // pub subsurface_view: Option<Arc<dyn Any + Send + Sync>>,
     /// Z
-    pub z: u32,
+    pub z: i32,
     /// Steal Keyboard focus from parent while open.
     /// Will not work on a regular window.
     pub steal_keyboard_focus: bool,

--- a/winit/src/platform_specific/wayland/event_loop/mod.rs
+++ b/winit/src/platform_specific/wayland/event_loop/mod.rs
@@ -134,7 +134,7 @@ impl SctkEventLoop {
                                         .enumerate()
                                         .filter_map(|(i, s)| {
                                             (winit::window::WindowId::from(
-                                                s.instance.parent.as_ptr()
+                                                s.instance.parent.id().as_ptr()
                                                     as u64,
                                             ) == w.window.id())
                                             .then_some(i)

--- a/winit/src/platform_specific/wayland/event_loop/state.rs
+++ b/winit/src/platform_specific/wayland/event_loop/state.rs
@@ -1017,7 +1017,7 @@ impl SctkState {
                                     .subsurfaces
                                     .drain(..)
                                     .partition(|s| {
-                                        s.instance.parent == l.surface.wl_surface().id()
+                                        s.instance.parent == *l.surface.wl_surface()
                                     });
 
                                 self.subsurfaces = remaining;
@@ -1245,7 +1245,7 @@ impl SctkState {
                             .subsurfaces
                             .drain(..)
                             .partition(|s| {
-                                s.instance.parent == popup.popup.wl_surface().id()
+                                s.instance.parent == *popup.popup.wl_surface()
                             });
 
                         self.subsurfaces = remaining;
@@ -1366,7 +1366,7 @@ impl SctkState {
                             .subsurfaces
                             .drain(..)
                             .partition(|s| {
-                                s.instance.parent == surface.session_lock_surface.wl_surface().id()
+                                s.instance.parent == *surface.session_lock_surface.wl_surface()
                             });
 
                         self.subsurfaces = remaining;
@@ -1444,7 +1444,7 @@ impl SctkState {
                     for (destroyed, parent) in destroyed {
                         if let Some((wl_surface, f)) = self.seats.iter_mut().find(|f| {
                             f.kbd_focus.as_ref().is_some_and(|f| *f == destroyed)
-                        }).and_then(|f| WlSurface::from_id(&self.connection, parent).ok().map(|wl| (wl, &mut f.kbd_focus))) {
+                        }).and_then(|f| Some((parent, &mut f.kbd_focus))) {
                             *f = Some(wl_surface);
                         }
                     }
@@ -1611,7 +1611,7 @@ impl SctkState {
             transform:
                 cctk::wayland_client::protocol::wl_output::Transform::Normal,
             z: settings.z,
-            parent: parent_wl_surface.id(),
+            parent: parent_wl_surface.clone(),
         };
         common.wp_viewport = Some(wp_viewport);
         let common = Arc::new(Mutex::new(common));

--- a/winit/src/platform_specific/wayland/handlers/seat/keyboard.rs
+++ b/winit/src/platform_specific/wayland/handlers/seat/keyboard.rs
@@ -34,7 +34,7 @@ impl KeyboardHandler for SctkState {
 
             let surface = if let Some(subsurface) =
                 self.subsurfaces.iter().find(|s| {
-                    s.steals_keyboard_focus && s.instance.parent == surface.id()
+                    s.steals_keyboard_focus && s.instance.parent == *surface
                 }) {
                 &subsurface.instance.wl_surface
             } else {
@@ -53,7 +53,7 @@ impl KeyboardHandler for SctkState {
         self.request_redraw(&surface);
 
         let surfaces = self.subsurfaces.iter().filter_map(|s| {
-            (s.instance.parent == surface.id()).then(|| &s.instance.wl_surface)
+            (s.instance.parent == *surface).then(|| &s.instance.wl_surface)
         });
         for surface in surfaces.chain(std::iter::once(surface)) {
             if is_active {
@@ -103,7 +103,7 @@ impl KeyboardHandler for SctkState {
             (is_active, seat, kbd)
         };
         let surfaces = self.subsurfaces.iter().filter_map(|s| {
-            (s.instance.parent == surface.id()).then(|| &s.instance.wl_surface)
+            (s.instance.parent == *surface).then(|| &s.instance.wl_surface)
         });
         for surface in surfaces.chain(std::iter::once(surface)) {
             if is_active {
@@ -168,7 +168,7 @@ impl KeyboardHandler for SctkState {
             if let Some(surface) = my_seat.kbd_focus.clone() {
                 self.request_redraw(&surface);
                 let surfaces = self.subsurfaces.iter().filter_map(|s| {
-                    (s.instance.parent == surface.id())
+                    (s.instance.parent == surface)
                         .then(|| &s.instance.wl_surface)
                 });
                 for surface in surfaces.chain(std::iter::once(&surface)) {
@@ -209,7 +209,7 @@ impl KeyboardHandler for SctkState {
             if let Some(surface) = my_seat.kbd_focus.clone() {
                 self.request_redraw(&surface);
                 let surfaces = self.subsurfaces.iter().filter_map(|s| {
-                    (s.instance.parent == surface.id())
+                    (s.instance.parent == surface)
                         .then(|| &s.instance.wl_surface)
                 });
                 for surface in surfaces.chain(std::iter::once(&surface)) {
@@ -251,7 +251,7 @@ impl KeyboardHandler for SctkState {
             if let Some(surface) = my_seat.kbd_focus.clone() {
                 self.request_redraw(&surface);
                 let surfaces = self.subsurfaces.iter().filter_map(|s| {
-                    (s.instance.parent == surface.id())
+                    (s.instance.parent == surface)
                         .then(|| &s.instance.wl_surface)
                 });
                 for surface in surfaces.chain(std::iter::once(&surface)) {

--- a/winit/src/platform_specific/wayland/sctk_event.rs
+++ b/winit/src/platform_specific/wayland/sctk_event.rs
@@ -293,7 +293,7 @@ pub enum SubsurfaceEventVariant {
         surface_id: SurfaceId,
         common: Arc<Mutex<Common>>,
         display: WlDisplay,
-        z: u32,
+        z: i32,
     },
     /// Destroyed
     Destroyed(SubsurfaceInstance),

--- a/winit/src/platform_specific/wayland/sctk_event.rs
+++ b/winit/src/platform_specific/wayland/sctk_event.rs
@@ -1450,7 +1450,7 @@ impl SctkEvent {
                     if let Some(subsurface_state) = subsurface_state.as_mut() {
                         subsurface_state.new_iced_subsurfaces.push((
                             parent_id,
-                            parent.id(),
+                            parent,
                             surface_id,
                             wl_subsurface.clone(),
                             wl_surface.clone(),

--- a/winit/src/platform_specific/wayland/subsurface_widget.rs
+++ b/winit/src/platform_specific/wayland/subsurface_widget.rs
@@ -513,12 +513,14 @@ impl SubsurfaceState {
             let mut sorted_subsurfaces: Vec<_> = view_subsurfaces
                 .iter()
                 .zip(subsurfaces.iter_mut())
-                .map(|(_, instance)| {
+                .map(|(subsurface_info, instance)| {
                     (
                         instance.parent.clone(),
                         instance.wl_subsurface.clone(),
                         instance.wl_surface.clone(),
-                        instance.z,
+                        // Use from `view_subsurfaces`; not updated in `subsurfaces`
+                        // until `attach_and_commit`
+                        subsurface_info.z,
                     )
                 })
                 .chain(self.new_iced_subsurfaces.clone().into_iter().map(
@@ -545,10 +547,10 @@ impl SubsurfaceState {
                 let prev = &sorted_subsurfaces[0..i];
                 let subsurface = &sorted_subsurfaces[i];
                 for prev in prev.iter().rev() {
-                    if prev.0 != subsurface.0 {
-                        continue;
+                    if prev.0 == subsurface.0 {
+                        subsurface.1.place_above(&prev.2);
+                        break;
                     }
-                    subsurface.1.place_above(&prev.2);
                 }
             }
         }


### PR DESCRIPTION
In the protocol specification for `wl_subsurface::place_above` :

> This sub-surface is taken from the stack, and put back just above the reference surface, changing the z-order of the sub-surfaces. T

So we don't need to place above all previous subsurfaces; in fact, this can mess up the order when there are more than two subsurfaces.

Looks like the place this is called also needs a fix; `attach_and_commit` is where `z` is set for new surfaces, so we need to make sure that `z` value is used when updating the order (though it should also be before the `.commit()`.

I think we should also have a way to place subsurfaces *behind* the parent surfaces. Probably making `z` and i32, and placing subsurfaces with negative indices behind the parent surface would work.