### PR TITLE
wayland: Set cusor position on `Enter` events

### DIFF
--- a/winit/src/platform_specific/wayland/handlers/seat/pointer.rs
+++ b/winit/src/platform_specific/wayland/handlers/seat/pointer.rs
@@ -63,6 +63,18 @@ impl PointerHandler for SctkState {
                     *entry = FrameStatus::Ready;
                 }
 
+                if let PointerEventKind::Enter { .. } = &e.kind {
+                    self.sctk_events.push(SctkEvent::PointerEvent {
+                        variant: PointerEvent {
+                            surface: e.surface.clone(),
+                            position: e.position,
+                            kind: e.kind.clone(),
+                        },
+                        ptr_id: pointer.clone(),
+                        seat_id: my_seat.seat.clone(),
+                    });
+                }
+
                 if let PointerEventKind::Motion { time } = &e.kind {
                     self.sctk_events.push(SctkEvent::PointerEvent {
                         variant: PointerEvent {

--- a/winit/src/platform_specific/wayland/sctk_event.rs
+++ b/winit/src/platform_specific/wayland/sctk_event.rs
@@ -369,14 +369,16 @@ impl SctkEvent {
             SctkEvent::SeatEvent { .. } => Default::default(),
             SctkEvent::PointerEvent { variant, .. } => match variant.kind {
                 PointerEventKind::Enter { .. } => {
-                    events.push((
-                        surface_ids
-                            .get(&variant.surface.id())
-                            .map(|id| id.inner()),
-                        iced_runtime::core::Event::Mouse(
-                            mouse::Event::CursorEntered,
-                        ),
-                    ));
+                    let id = surface_ids
+                        .get(&variant.surface.id())
+                        .map(|id| id.inner());
+                    if let Some(w) =
+                        id.clone().and_then(|id| window_manager.get_mut(id))
+                    {
+                        w.state.set_logical_cursor_pos(
+                            (variant.position.0, variant.position.1).into(),
+                        )
+                    }
                 }
                 PointerEventKind::Leave { .. } => events.push((
                     surface_ids.get(&variant.surface.id()).map(|id| id.inner()),


### PR DESCRIPTION
Fixes https://github.com/pop-os/cosmic-workspaces-epoch/issues/143.

The way some events are converted to `WindowEvent`s in `pointer_frame` but motion is handled in `SctkEvent::process` seems a little cluttered at the moment, I guess from how this code was ported to be part of iced-winit instead of separate. But as I understand, the code handling `PointerEventKind::Enter` in `SctkEvent::enter` wasn't being called, so that can be replaced with the new code here that sets the logical cursor position.
