### PR TITLE
subsurface_widget: Handle `viewport` and set source rectangle

### DIFF
--- a/examples/sctk_subsurface_gst/Cargo.toml
+++ b/examples/sctk_subsurface_gst/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 sctk = { package = "smithay-client-toolkit", git = "https://github.com/smithay/client-toolkit", rev = "828b1eb" }
 iced = { path = "../..", default-features = false, features = [
     "wayland",
+    "winit",
     "debug",
     "a11y",
 ] }

--- a/examples/sctk_subsurface_gst/Cargo.toml
+++ b/examples/sctk_subsurface_gst/Cargo.toml
@@ -15,8 +15,8 @@ iced_runtime = { path = "../../runtime" }
 env_logger = "0.10"
 futures-channel = "0.3.29"
 calloop = "0.12.3"
-gst = { package = "gstreamer", version = "0.21.3" }
-gst-app = { package = "gstreamer-app", version = "0.21.2" }
-gst-video = { package = "gstreamer-video", version = "0.21.2" }
-gst-allocators = { package = "gstreamer-allocators", version = "0.21.2" }
+gst = { package = "gstreamer", version = "0.23.0" }
+gst-app = { package = "gstreamer-app", version = "0.23.0" }
+gst-video = { package = "gstreamer-video", version = "0.23.0" }
+gst-allocators = { package = "gstreamer-allocators", version = "0.23.0" }
 drm-fourcc = "2.2.0"

--- a/examples/sctk_subsurface_gst/src/pipewire.rs
+++ b/examples/sctk_subsurface_gst/src/pipewire.rs
@@ -68,7 +68,7 @@ fn pipewire_thread(
 ) {
     gst::init().unwrap();
 
-    let pipeline = gst::parse_launch(&format!(
+    let pipeline = gst::parse::launch(&format!(
         "filesrc name=filesrc !
          qtdemux !
          h264parse !
@@ -126,7 +126,7 @@ fn pipewire_thread(
                     let planes = (0..meta.n_planes())
                         .map(|plane_idx| {
                             let memory = buffer
-                                .memory(plane_idx)
+                                .memory(plane_idx as usize)
                                 .unwrap()
                                 .downcast_memory::<gst_allocators::DmaBufMemory>()
                                 .unwrap();

--- a/examples/sctk_subsurface_img/Cargo.toml
+++ b/examples/sctk_subsurface_img/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "sctk_subsurface_img"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+iced = { path = "../..", default-features = false, features = [
+    "tokio",
+    "wayland",
+    "winit",
+    "debug",
+    "tiny-skia",
+    "image",
+] }
+iced_runtime = { path = "../../runtime" }
+env_logger = "0.10"
+futures-channel = "0.3.29"
+calloop = "0.13"
+rustix = { version = "0.38.30", features = ["fs", "shm"] }
+cctk.workspace = true
+image = { workspace = true, features = ["png"] }

--- a/examples/sctk_subsurface_img/src/main.rs
+++ b/examples/sctk_subsurface_img/src/main.rs
@@ -1,0 +1,135 @@
+use cctk::sctk::reexports::client::protocol::wl_shm;
+use iced::{
+    platform_specific::shell::subsurface_widget::{
+        self, Shmbuf, SubsurfaceBuffer,
+    },
+    window::{self, Id, Settings},
+    Element, Length, Subscription, Task,
+};
+use image::{ImageReader, Pixel};
+use rustix::{io::Errno, shm::ShmOFlags};
+use std::{
+    env,
+    os::fd::OwnedFd,
+    path::Path,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn main() -> iced::Result {
+    let args = env::args();
+    if args.len() != 2 {
+        eprintln!("usage: sctk_subsurface_img [image path]");
+        return Ok(());
+    }
+    let path = args.skip(1).next().unwrap();
+    if !Path::new(&path).exists() {
+        eprintln!("File `{path}` not found.");
+        return Ok(());
+    }
+
+    iced::daemon(
+        SubsurfaceApp::title,
+        SubsurfaceApp::update,
+        SubsurfaceApp::view,
+    )
+    .subscription(SubsurfaceApp::subscription)
+    .run_with(|| SubsurfaceApp::new(path))
+}
+
+#[derive(Debug, Clone)]
+struct SubsurfaceApp {
+    path: String,
+    buffer: SubsurfaceBuffer,
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    Id(Id),
+}
+
+impl SubsurfaceApp {
+    fn new(path: String) -> (SubsurfaceApp, Task<Message>) {
+        let img = ImageReader::open(&path)
+            .unwrap()
+            .decode()
+            .unwrap()
+            .to_rgba8();
+        let fd = create_memfile().unwrap();
+        for pixel in img.pixels() {
+            let [r, g, b, a] = <[u8; 4]>::try_from(pixel.channels()).unwrap();
+            rustix::io::write(&fd, &[b, g, r, a]).unwrap();
+        }
+        let shmbuf = Shmbuf {
+            fd,
+            offset: 0,
+            width: img.width() as i32,
+            height: img.height() as i32,
+            stride: img.width() as i32 * 4,
+            format: wl_shm::Format::Xrgb8888,
+        };
+        let buffer = SubsurfaceBuffer::new(Arc::new(shmbuf.into())).0;
+
+        (
+            SubsurfaceApp { path, buffer },
+            iced::window::open(Settings {
+                ..Default::default()
+            })
+            .1
+            .map(Message::Id),
+        )
+    }
+
+    fn title(&self, _id: window::Id) -> String {
+        String::from("SubsurfaceApp")
+    }
+
+    fn update(&mut self, message: Message) -> Task<Message> {
+        match message {
+            Message::Id(_) => {}
+        }
+        Task::none()
+    }
+
+    fn view(&self, _id: window::Id) -> Element<Message> {
+        // TODO compare side-by-side with image widget; key bind to toggle?
+        let image = subsurface_widget::Subsurface::new(self.buffer.clone())
+            .content_fit(iced::ContentFit::None);
+        /*
+        let image = iced::widget::image::Image::new(&self.path)
+            .content_fit(iced::ContentFit::None);
+        */
+        iced::widget::scrollable(image).into()
+    }
+
+    fn subscription(&self) -> Subscription<Message> {
+        Subscription::none()
+    }
+}
+
+fn create_memfile() -> rustix::io::Result<OwnedFd> {
+    loop {
+        let flags = ShmOFlags::CREATE | ShmOFlags::EXCL | ShmOFlags::RDWR;
+
+        let time = SystemTime::now();
+        let name = format!(
+            "/iced-sctk-{}",
+            time.duration_since(UNIX_EPOCH).unwrap().subsec_nanos()
+        );
+
+        match rustix::io::retry_on_intr(|| {
+            rustix::shm::shm_open(&name, flags, 0600.into())
+        }) {
+            Ok(fd) => match rustix::shm::shm_unlink(&name) {
+                Ok(_) => return Ok(fd),
+                Err(errno) => {
+                    return Err(errno.into());
+                }
+            },
+            Err(Errno::EXIST) => {
+                continue;
+            }
+            Err(err) => return Err(err.into()),
+        }
+    }
+}

--- a/winit/src/platform_specific/wayland/event_loop/state.rs
+++ b/winit/src/platform_specific/wayland/event_loop/state.rs
@@ -1607,7 +1607,8 @@ impl SctkState {
             wp_fractional_scale,
 
             wl_buffer: None,
-            bounds: Some(bounds),
+            source: None,
+            destination: Some(bounds),
             transform:
                 cctk::wayland_client::protocol::wl_output::Transform::Normal,
             z: settings.z,

--- a/winit/src/platform_specific/wayland/subsurface_widget.rs
+++ b/winit/src/platform_specific/wayland/subsurface_widget.rs
@@ -455,7 +455,8 @@ impl SubsurfaceState {
             wp_viewport,
             wp_alpha_modifier_surface,
             wl_buffer: None,
-            bounds: None,
+            source: None,
+            destination: None,
             wp_fractional_scale: None,
             transform: wl_output::Transform::Normal,
             z: 0,
@@ -542,7 +543,8 @@ impl SubsurfaceState {
             sorted_subsurfaces.sort_by(|a, b| a.3.cmp(&b.3));
 
             // Attach buffers to subsurfaces, set viewports, and commit.
-            'outer: for (i, subsurface) in sorted_subsurfaces.iter().enumerate() {
+            'outer: for (i, subsurface) in sorted_subsurfaces.iter().enumerate()
+            {
                 for prev in sorted_subsurfaces[0..i].iter().rev() {
                     if prev.0 == subsurface.0 {
                         // Fist surface that has `z` greater than 0, so place above parent,
@@ -630,7 +632,8 @@ pub(crate) struct SubsurfaceInstance {
     pub(crate) wp_fractional_scale: Option<WpFractionalScaleV1>,
     pub(crate) wp_alpha_modifier_surface: Option<WpAlphaModifierSurfaceV1>,
     pub(crate) wl_buffer: Option<WlBuffer>,
-    pub(crate) bounds: Option<Rectangle<f32>>,
+    pub(crate) source: Option<Rectangle<f32>>,
+    pub(crate) destination: Option<Rectangle<f32>>,
     pub(crate) transform: wl_output::Transform,
     pub(crate) z: i32,
     pub parent: WlSurface,
@@ -677,14 +680,21 @@ impl SubsurfaceInstance {
         };
 
         // XXX scale factor?
-        let bounds_changed = self.bounds != Some(info.bounds);
+        let source_changed = self.source != Some(info.source);
+        let destination_changed = self.destination != Some(info.destination);
         // wlroots seems to have issues changing buffer without running this
-        if bounds_changed || buffer_changed {
+        if source_changed || destination_changed || buffer_changed {
+            self.wp_viewport.set_source(
+                info.source.x.into(),
+                info.source.y.into(),
+                info.source.width.into(),
+                info.source.height.into(),
+            );
             self.wl_subsurface
-                .set_position(info.bounds.x as i32, info.bounds.y as i32);
+                .set_position(info.destination.x as i32, info.destination.y as i32);
             self.wp_viewport.set_destination(
-                info.bounds.width as i32,
-                info.bounds.height as i32,
+                info.destination.width as i32,
+                info.destination.height as i32,
             );
         }
         let transform_changed = self.transform != info.transform;
@@ -695,7 +705,7 @@ impl SubsurfaceInstance {
             self.wl_surface.attach(Some(&buffer), 0, 0);
             self.wl_surface.damage(0, 0, i32::MAX, i32::MAX);
         }
-        if buffer_changed || bounds_changed || transform_changed {
+        if buffer_changed || source_changed || destination_changed || transform_changed {
             _ = self.wl_surface.frame(&state.qh, self.wl_surface.clone());
             self.wl_surface.commit();
         }
@@ -707,7 +717,8 @@ impl SubsurfaceInstance {
         }
 
         self.wl_buffer = Some(buffer);
-        self.bounds = Some(info.bounds);
+        self.source = Some(info.source);
+        self.destination = Some(info.destination);
         self.transform = info.transform;
         self.z = info.z;
     }
@@ -732,7 +743,8 @@ impl Drop for SubsurfaceInstance {
 #[derive(Debug)]
 pub(crate) struct SubsurfaceInfo {
     pub buffer: SubsurfaceBuffer,
-    pub bounds: Rectangle<f32>,
+    pub source: Rectangle<f32>,
+    pub destination: Rectangle<f32>,
     pub alpha: f32,
     pub transform: wl_output::Transform,
     pub z: i32,
@@ -753,7 +765,8 @@ pub(crate) fn subsurface_ids(parent: WindowId) -> Vec<WindowId> {
             .borrow_mut()
             .iter()
             .filter_map(|s| {
-                if winit::window::WindowId::from(s.1.id().as_ptr() as u64) == parent
+                if winit::window::WindowId::from(s.1.id().as_ptr() as u64)
+                    == parent
                 {
                     Some(
                         winit::window::WindowId::from(s.4.id().as_ptr() as u64),
@@ -838,14 +851,34 @@ where
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
-        _viewport: &Rectangle,
+        viewport: &Rectangle,
     ) {
+        let buffer_size =
+            Size::new(self.buffer.width() as f32, self.buffer.height() as f32);
+        let full_size =
+            self.content_fit.fit(buffer_size, layout.bounds().size());
+
+        let source = Rectangle {
+            x: viewport.x,
+            y: viewport.y,
+            width: viewport.width.min(self.buffer.width() as f32),
+            height: viewport.height.min(self.buffer.height() as f32),
+        };
+
+        let destination = Rectangle {
+            x: layout.bounds().x,
+            y: layout.bounds().y,
+            width: layout.bounds().width.min(viewport.width),
+            height: layout.bounds().height.min(viewport.height),
+        };
+
         // Instead of using renderer, we need to add surface to a list that is
         // read by the iced-sctk shell.
         SUBSURFACES.with(|subsurfaces| {
             subsurfaces.borrow_mut().push(SubsurfaceInfo {
                 buffer: self.buffer.clone(),
-                bounds: layout.bounds(),
+                source,
+                destination,
                 alpha: self.alpha,
                 transform: self.transform,
                 z: self.z,


### PR DESCRIPTION
Scrolling seems to be more or less working... but it doesn't seem to be triggering redraws properly, and scrolling is throttled to 1 fps.

Also the `scrollable` doesn't seem to subtract the scrollbar from the size allocated to its child (this is true of upstream iced). But due to how subsurfaces work, it ends up above the scroll bar instead of the scroll bar drawing above it.