### PR TITLE
support CapsLock modifiers on wayland

### DIFF
--- a/core/src/keyboard/modifiers.rs
+++ b/core/src/keyboard/modifiers.rs
@@ -24,6 +24,8 @@ bitflags! {
         const LOGO = 0b100 << 9;
         // const LLOGO = 0b010 << 9;
         // const RLOGO = 0b001 << 9;
+        /// The Caps Lock key
+        const CAPS_LOCK = 0b100 << 12;
     }
 }
 

--- a/winit/src/platform_specific/wayland/conversion.rs
+++ b/winit/src/platform_specific/wayland/conversion.rs
@@ -64,10 +64,10 @@ pub fn modifiers_to_native(mods: Modifiers) -> keyboard::Modifiers {
     if mods.shift {
         native_mods = native_mods.union(keyboard::Modifiers::SHIFT);
     }
+    if mods.caps_lock {
+        native_mods = native_mods.union(keyboard::Modifiers::CAPS_LOCK);
+    }
     // TODO Ashley: missing modifiers as platform specific additions?
-    // if mods.caps_lock {
-    // native_mods = native_mods.union(keyboard::Modifier);
-    // }
     // if mods.num_lock {
     //     native_mods = native_mods.union(keyboard::Modifiers::);
     // }

--- a/winit/src/platform_specific/wayland/subsurface_widget.rs
+++ b/winit/src/platform_specific/wayland/subsurface_widget.rs
@@ -542,7 +542,8 @@ impl SubsurfaceState {
             sorted_subsurfaces.sort_by(|a, b| a.3.cmp(&b.3));
 
             // Attach buffers to subsurfaces, set viewports, and commit.
-            'outer: for (i, subsurface) in sorted_subsurfaces.iter().enumerate() {
+            'outer: for (i, subsurface) in sorted_subsurfaces.iter().enumerate()
+            {
                 for prev in sorted_subsurfaces[0..i].iter().rev() {
                     if prev.0 == subsurface.0 {
                         // Fist surface that has `z` greater than 0, so place above parent,
@@ -753,7 +754,8 @@ pub(crate) fn subsurface_ids(parent: WindowId) -> Vec<WindowId> {
             .borrow_mut()
             .iter()
             .filter_map(|s| {
-                if winit::window::WindowId::from(s.1.id().as_ptr() as u64) == parent
+                if winit::window::WindowId::from(s.1.id().as_ptr() as u64)
+                    == parent
                 {
                     Some(
                         winit::window::WindowId::from(s.4.id().as_ptr() as u64),


### PR DESCRIPTION
This will not track Caps Lock on other platforms but should give cosmic-greeter and the pkexec gui what they need.

Some unrelated code was formatted in another commit.