### PR TITLE
Revert "subsurface_widget: Handle `viewport` and set source rectangle"

### DIFF
--- a/winit/src/platform_specific/wayland/event_loop/state.rs
+++ b/winit/src/platform_specific/wayland/event_loop/state.rs
@@ -1613,8 +1613,7 @@ impl SctkState {
             wp_fractional_scale,
 
             wl_buffer: None,
-            source: None,
-            destination: Some(bounds),
+            bounds: Some(bounds),
             transform:
                 cctk::wayland_client::protocol::wl_output::Transform::Normal,
             z: settings.z,


### PR DESCRIPTION
This reverts commit 15547dec8f83af1ea6dbed1964302400fc17c257 from https://github.com/pop-os/iced/pull/227.

This is causing issues in `cosmic-workspaces`. It seems I didn't test it properly outside the examples here... and this misinterpreted exactly what the (undocumented) `viewport` argument means (Iced's `image` widget also needed a fix to handle viewports properly since our fork: https://github.com/iced-rs/iced/pull/2752).

It should be possible to fix, but revert for now.