### PR TITLE
winit/sctk: Update cursor position on touch event

### DIFF
--- a/winit/src/platform_specific/wayland/sctk_event.rs
+++ b/winit/src/platform_specific/wayland/sctk_event.rs
@@ -684,10 +684,23 @@ impl SctkEvent {
                 touch_id: _,
                 seat_id: _,
                 surface,
-            } => events.push((
-                surface_ids.get(&surface.id()).map(|id| id.inner()),
-                iced_runtime::core::Event::Touch(variant),
-            )),
+            } => {
+                let position = match variant {
+                    touch::Event::FingerPressed { position, .. } => position,
+                    touch::Event::FingerMoved { position, .. } => position,
+                    touch::Event::FingerLifted { position, .. } => position,
+                    touch::Event::FingerLost { position, .. } => position,
+                };
+                let id = surface_ids.get(&surface.id()).map(|id| id.inner());
+                if let Some(w) =
+                    id.clone().and_then(|id| window_manager.get_mut(id))
+                {
+                    w.state.set_logical_cursor_pos(
+                        (position.x, position.y).into(),
+                    );
+                }
+                events.push((id, iced_runtime::core::Event::Touch(variant)))
+            }
             SctkEvent::WindowEvent { .. } => {}
             SctkEvent::LayerSurfaceEvent {
                 variant,


### PR DESCRIPTION
Ideally pointer should be seperate from touch, but this should match how Iced handles input in normal winit windows.

https://github.com/iced-rs/iced/blob/d475ae5b454b82cb549d6dd961ae158eb5ac7f19/winit/src/window/state.rs#L165-L170

With this, touch input for applets seems to work as expected in general.
