### PR TITLE
feat(wayland): shortcut inhibit

### DIFF
--- a/core/src/event/wayland/mod.rs
+++ b/core/src/event/wayland/mod.rs
@@ -44,4 +44,6 @@ pub enum Event {
     RequestResize,
     /// Subsurface
     Subsurface(SubsurfaceEvent),
+    /// Keyboard inhibit shortcuts
+    ShortcutsInhibited(bool),
 }

--- a/runtime/src/platform_specific/wayland/mod.rs
+++ b/runtime/src/platform_specific/wayland/mod.rs
@@ -31,6 +31,8 @@ pub enum Action {
     OverlapNotify(Id, bool),
     /// Subsurfaces
     Subsurface(subsurface::Action),
+    /// Keyboard inhibit shortcuts
+    InhibitShortcuts(bool),
 }
 
 impl Debug for Action {
@@ -51,6 +53,9 @@ impl Debug for Action {
             }
             Action::Subsurface(action) => {
                 f.debug_tuple("Subsurface").field(action).finish()
+            }
+            Action::InhibitShortcuts(v) => {
+                f.debug_tuple("InhibitShortcuts").field(v).finish()
             }
         }
     }

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -11,7 +11,6 @@ use crate::core::mouse;
 use crate::core::touch;
 use crate::core::window;
 use crate::core::{Event, Point, Size};
-use iced_futures::core::event::PlatformSpecific;
 
 /// Converts some [`window::Settings`] into some `WindowAttributes` from `winit`.
 pub fn window_attributes(
@@ -312,9 +311,9 @@ pub fn window_event(
                 Size::new(size.width, size.height)
             });
 
-            Some(Event::PlatformSpecific(PlatformSpecific::Wayland(
+            Some(Event::PlatformSpecific(iced_futures::core::event::PlatformSpecific::Wayland(
                 iced_runtime::core::event::wayland::Event::Window(
-                    iced_runtime::core::event::wayland::WindowEvent::SuggestedBounds(size),
+                    iced_runtime::core::event::wayland::WindowEvent::SuggestedBounds(size)
                 ),
             )))
         }
@@ -1120,6 +1119,254 @@ pub fn key_code(
         KeyCode::F35 => keyboard::key::Code::F35,
         _ => None?,
     })
+}
+
+pub fn winit_key_code(
+    key_code: keyboard::key::Code,
+) -> Option<winit::keyboard::KeyCode> {
+    use winit::keyboard::KeyCode;
+
+    Some(match key_code {
+        keyboard::key::Code::Backquote => KeyCode::Backquote,
+        keyboard::key::Code::Backslash => KeyCode::Backslash,
+        keyboard::key::Code::BracketLeft => KeyCode::BracketLeft,
+        keyboard::key::Code::BracketRight => KeyCode::BracketRight,
+        keyboard::key::Code::Comma => KeyCode::Comma,
+        keyboard::key::Code::Digit0 => KeyCode::Digit0,
+        keyboard::key::Code::Digit1 => KeyCode::Digit1,
+        keyboard::key::Code::Digit2 => KeyCode::Digit2,
+        keyboard::key::Code::Digit3 => KeyCode::Digit3,
+        keyboard::key::Code::Digit4 => KeyCode::Digit4,
+        keyboard::key::Code::Digit5 => KeyCode::Digit5,
+        keyboard::key::Code::Digit6 => KeyCode::Digit6,
+        keyboard::key::Code::Digit7 => KeyCode::Digit7,
+        keyboard::key::Code::Digit8 => KeyCode::Digit8,
+        keyboard::key::Code::Digit9 => KeyCode::Digit9,
+        keyboard::key::Code::Equal => KeyCode::Equal,
+        keyboard::key::Code::IntlBackslash => KeyCode::IntlBackslash,
+        keyboard::key::Code::IntlRo => KeyCode::IntlRo,
+        keyboard::key::Code::IntlYen => KeyCode::IntlYen,
+        keyboard::key::Code::KeyA => KeyCode::KeyA,
+        keyboard::key::Code::KeyB => KeyCode::KeyB,
+        keyboard::key::Code::KeyC => KeyCode::KeyC,
+        keyboard::key::Code::KeyD => KeyCode::KeyD,
+        keyboard::key::Code::KeyE => KeyCode::KeyE,
+        keyboard::key::Code::KeyF => KeyCode::KeyF,
+        keyboard::key::Code::KeyG => KeyCode::KeyG,
+        keyboard::key::Code::KeyH => KeyCode::KeyH,
+        keyboard::key::Code::KeyI => KeyCode::KeyI,
+        keyboard::key::Code::KeyJ => KeyCode::KeyJ,
+        keyboard::key::Code::KeyK => KeyCode::KeyK,
+        keyboard::key::Code::KeyL => KeyCode::KeyL,
+        keyboard::key::Code::KeyM => KeyCode::KeyM,
+        keyboard::key::Code::KeyN => KeyCode::KeyN,
+        keyboard::key::Code::KeyO => KeyCode::KeyO,
+        keyboard::key::Code::KeyP => KeyCode::KeyP,
+        keyboard::key::Code::KeyQ => KeyCode::KeyQ,
+        keyboard::key::Code::KeyR => KeyCode::KeyR,
+        keyboard::key::Code::KeyS => KeyCode::KeyS,
+        keyboard::key::Code::KeyT => KeyCode::KeyT,
+        keyboard::key::Code::KeyU => KeyCode::KeyU,
+        keyboard::key::Code::KeyV => KeyCode::KeyV,
+        keyboard::key::Code::KeyW => KeyCode::KeyW,
+        keyboard::key::Code::KeyX => KeyCode::KeyX,
+        keyboard::key::Code::KeyY => KeyCode::KeyY,
+        keyboard::key::Code::KeyZ => KeyCode::KeyZ,
+        keyboard::key::Code::Minus => KeyCode::Minus,
+        keyboard::key::Code::Period => KeyCode::Period,
+        keyboard::key::Code::Quote => KeyCode::Quote,
+        keyboard::key::Code::Semicolon => KeyCode::Semicolon,
+        keyboard::key::Code::Slash => KeyCode::Slash,
+        keyboard::key::Code::AltLeft => KeyCode::AltLeft,
+        keyboard::key::Code::AltRight => KeyCode::AltRight,
+        keyboard::key::Code::Backspace => KeyCode::Backspace,
+        keyboard::key::Code::CapsLock => KeyCode::CapsLock,
+        keyboard::key::Code::ContextMenu => KeyCode::ContextMenu,
+        keyboard::key::Code::ControlLeft => KeyCode::ControlLeft,
+        keyboard::key::Code::ControlRight => KeyCode::ControlRight,
+        keyboard::key::Code::Enter => KeyCode::Enter,
+        keyboard::key::Code::SuperLeft => KeyCode::SuperLeft,
+        keyboard::key::Code::SuperRight => KeyCode::SuperRight,
+        keyboard::key::Code::ShiftLeft => KeyCode::ShiftLeft,
+        keyboard::key::Code::ShiftRight => KeyCode::ShiftRight,
+        keyboard::key::Code::Space => KeyCode::Space,
+        keyboard::key::Code::Tab => KeyCode::Tab,
+        keyboard::key::Code::Convert => KeyCode::Convert,
+        keyboard::key::Code::KanaMode => KeyCode::KanaMode,
+        keyboard::key::Code::Lang1 => KeyCode::Lang1,
+        keyboard::key::Code::Lang2 => KeyCode::Lang2,
+        keyboard::key::Code::Lang3 => KeyCode::Lang3,
+        keyboard::key::Code::Lang4 => KeyCode::Lang4,
+        keyboard::key::Code::Lang5 => KeyCode::Lang5,
+        keyboard::key::Code::NonConvert => KeyCode::NonConvert,
+        keyboard::key::Code::Delete => KeyCode::Delete,
+        keyboard::key::Code::End => KeyCode::End,
+        keyboard::key::Code::Help => KeyCode::Help,
+        keyboard::key::Code::Home => KeyCode::Home,
+        keyboard::key::Code::Insert => KeyCode::Insert,
+        keyboard::key::Code::PageDown => KeyCode::PageDown,
+        keyboard::key::Code::PageUp => KeyCode::PageUp,
+        keyboard::key::Code::ArrowDown => KeyCode::ArrowDown,
+        keyboard::key::Code::ArrowLeft => KeyCode::ArrowLeft,
+        keyboard::key::Code::ArrowRight => KeyCode::ArrowRight,
+        keyboard::key::Code::ArrowUp => KeyCode::ArrowUp,
+        keyboard::key::Code::NumLock => KeyCode::NumLock,
+        keyboard::key::Code::Numpad0 => KeyCode::Numpad0,
+        keyboard::key::Code::Numpad1 => KeyCode::Numpad1,
+        keyboard::key::Code::Numpad2 => KeyCode::Numpad2,
+        keyboard::key::Code::Numpad3 => KeyCode::Numpad3,
+        keyboard::key::Code::Numpad4 => KeyCode::Numpad4,
+        keyboard::key::Code::Numpad5 => KeyCode::Numpad5,
+        keyboard::key::Code::Numpad6 => KeyCode::Numpad6,
+        keyboard::key::Code::Numpad7 => KeyCode::Numpad7,
+        keyboard::key::Code::Numpad8 => KeyCode::Numpad8,
+        keyboard::key::Code::Numpad9 => KeyCode::Numpad9,
+        keyboard::key::Code::NumpadAdd => KeyCode::NumpadAdd,
+        keyboard::key::Code::NumpadBackspace => KeyCode::NumpadBackspace,
+        keyboard::key::Code::NumpadClear => KeyCode::NumpadClear,
+        keyboard::key::Code::NumpadClearEntry => KeyCode::NumpadClearEntry,
+        keyboard::key::Code::NumpadComma => KeyCode::NumpadComma,
+        keyboard::key::Code::NumpadDecimal => KeyCode::NumpadDecimal,
+        keyboard::key::Code::NumpadDivide => KeyCode::NumpadDivide,
+        keyboard::key::Code::NumpadEnter => KeyCode::NumpadEnter,
+        keyboard::key::Code::NumpadEqual => KeyCode::NumpadEqual,
+        keyboard::key::Code::NumpadHash => KeyCode::NumpadHash,
+        keyboard::key::Code::NumpadMemoryAdd => KeyCode::NumpadMemoryAdd,
+        keyboard::key::Code::NumpadMemoryClear => KeyCode::NumpadMemoryClear,
+        keyboard::key::Code::NumpadMemoryRecall => KeyCode::NumpadMemoryRecall,
+        keyboard::key::Code::NumpadMemoryStore => KeyCode::NumpadMemoryStore,
+        keyboard::key::Code::NumpadMemorySubtract => {
+            KeyCode::NumpadMemorySubtract
+        }
+        keyboard::key::Code::NumpadMultiply => KeyCode::NumpadMultiply,
+        keyboard::key::Code::NumpadParenLeft => KeyCode::NumpadParenLeft,
+        keyboard::key::Code::NumpadParenRight => KeyCode::NumpadParenRight,
+        keyboard::key::Code::NumpadStar => KeyCode::NumpadStar,
+        keyboard::key::Code::NumpadSubtract => KeyCode::NumpadSubtract,
+        keyboard::key::Code::Escape => KeyCode::Escape,
+        keyboard::key::Code::Fn => KeyCode::Fn,
+        keyboard::key::Code::FnLock => KeyCode::FnLock,
+        keyboard::key::Code::PrintScreen => KeyCode::PrintScreen,
+        keyboard::key::Code::ScrollLock => KeyCode::ScrollLock,
+        keyboard::key::Code::Pause => KeyCode::Pause,
+        keyboard::key::Code::BrowserBack => KeyCode::BrowserBack,
+        keyboard::key::Code::BrowserFavorites => KeyCode::BrowserFavorites,
+        keyboard::key::Code::BrowserForward => KeyCode::BrowserForward,
+        keyboard::key::Code::BrowserHome => KeyCode::BrowserHome,
+        keyboard::key::Code::BrowserRefresh => KeyCode::BrowserRefresh,
+        keyboard::key::Code::BrowserSearch => KeyCode::BrowserSearch,
+        keyboard::key::Code::BrowserStop => KeyCode::BrowserStop,
+        keyboard::key::Code::Eject => KeyCode::Eject,
+        keyboard::key::Code::LaunchApp1 => KeyCode::LaunchApp1,
+        keyboard::key::Code::LaunchApp2 => KeyCode::LaunchApp2,
+        keyboard::key::Code::LaunchMail => KeyCode::LaunchMail,
+        keyboard::key::Code::MediaPlayPause => KeyCode::MediaPlayPause,
+        keyboard::key::Code::MediaSelect => KeyCode::MediaSelect,
+        keyboard::key::Code::MediaStop => KeyCode::MediaStop,
+        keyboard::key::Code::MediaTrackNext => KeyCode::MediaTrackNext,
+        keyboard::key::Code::MediaTrackPrevious => KeyCode::MediaTrackPrevious,
+        keyboard::key::Code::Power => KeyCode::Power,
+        keyboard::key::Code::Sleep => KeyCode::Sleep,
+        keyboard::key::Code::AudioVolumeDown => KeyCode::AudioVolumeDown,
+        keyboard::key::Code::AudioVolumeMute => KeyCode::AudioVolumeMute,
+        keyboard::key::Code::AudioVolumeUp => KeyCode::AudioVolumeUp,
+        keyboard::key::Code::WakeUp => KeyCode::WakeUp,
+        keyboard::key::Code::Meta => KeyCode::Meta,
+        keyboard::key::Code::Hyper => KeyCode::Hyper,
+        keyboard::key::Code::Turbo => KeyCode::Turbo,
+        keyboard::key::Code::Abort => KeyCode::Abort,
+        keyboard::key::Code::Resume => KeyCode::Resume,
+        keyboard::key::Code::Suspend => KeyCode::Suspend,
+        keyboard::key::Code::Again => KeyCode::Again,
+        keyboard::key::Code::Copy => KeyCode::Copy,
+        keyboard::key::Code::Cut => KeyCode::Cut,
+        keyboard::key::Code::Find => KeyCode::Find,
+        keyboard::key::Code::Open => KeyCode::Open,
+        keyboard::key::Code::Paste => KeyCode::Paste,
+        keyboard::key::Code::Props => KeyCode::Props,
+        keyboard::key::Code::Select => KeyCode::Select,
+        keyboard::key::Code::Undo => KeyCode::Undo,
+        keyboard::key::Code::Hiragana => KeyCode::Hiragana,
+        keyboard::key::Code::Katakana => KeyCode::Katakana,
+        keyboard::key::Code::F1 => KeyCode::F1,
+        keyboard::key::Code::F2 => KeyCode::F2,
+        keyboard::key::Code::F3 => KeyCode::F3,
+        keyboard::key::Code::F4 => KeyCode::F4,
+        keyboard::key::Code::F5 => KeyCode::F5,
+        keyboard::key::Code::F6 => KeyCode::F6,
+        keyboard::key::Code::F7 => KeyCode::F7,
+        keyboard::key::Code::F8 => KeyCode::F8,
+        keyboard::key::Code::F9 => KeyCode::F9,
+        keyboard::key::Code::F10 => KeyCode::F10,
+        keyboard::key::Code::F11 => KeyCode::F11,
+        keyboard::key::Code::F12 => KeyCode::F12,
+        keyboard::key::Code::F13 => KeyCode::F13,
+        keyboard::key::Code::F14 => KeyCode::F14,
+        keyboard::key::Code::F15 => KeyCode::F15,
+        keyboard::key::Code::F16 => KeyCode::F16,
+        keyboard::key::Code::F17 => KeyCode::F17,
+        keyboard::key::Code::F18 => KeyCode::F18,
+        keyboard::key::Code::F19 => KeyCode::F19,
+        keyboard::key::Code::F20 => KeyCode::F20,
+        keyboard::key::Code::F21 => KeyCode::F21,
+        keyboard::key::Code::F22 => KeyCode::F22,
+        keyboard::key::Code::F23 => KeyCode::F23,
+        keyboard::key::Code::F24 => KeyCode::F24,
+        keyboard::key::Code::F25 => KeyCode::F25,
+        keyboard::key::Code::F26 => KeyCode::F26,
+        keyboard::key::Code::F27 => KeyCode::F27,
+        keyboard::key::Code::F28 => KeyCode::F28,
+        keyboard::key::Code::F29 => KeyCode::F29,
+        keyboard::key::Code::F30 => KeyCode::F30,
+        keyboard::key::Code::F31 => KeyCode::F31,
+        keyboard::key::Code::F32 => KeyCode::F32,
+        keyboard::key::Code::F33 => KeyCode::F33,
+        keyboard::key::Code::F34 => KeyCode::F34,
+        keyboard::key::Code::F35 => KeyCode::F35,
+        _ => None?,
+    })
+}
+
+#[cfg(feature = "wayland")]
+fn winit_native_key_code(
+    keycode: keyboard::key::NativeCode,
+) -> winit::keyboard::NativeKeyCode {
+    match keycode {
+        keyboard::key::NativeCode::Unidentified => {
+            winit::keyboard::NativeKeyCode::Unidentified
+        }
+        keyboard::key::NativeCode::Android(k) => {
+            winit::keyboard::NativeKeyCode::Android(k)
+        }
+        keyboard::key::NativeCode::MacOS(k) => {
+            winit::keyboard::NativeKeyCode::MacOS(k)
+        }
+        keyboard::key::NativeCode::Windows(k) => {
+            winit::keyboard::NativeKeyCode::Windows(k)
+        }
+        keyboard::key::NativeCode::Xkb(k) => {
+            winit::keyboard::NativeKeyCode::Xkb(k)
+        }
+    }
+}
+
+/// Reconstruct the raw keycode
+#[cfg(feature = "wayland")]
+pub fn physical_to_scancode(physical: keyboard::key::Physical) -> Option<u32> {
+    let Some(physical_key) = (match physical {
+        keyboard::key::Physical::Code(code) => {
+            winit_key_code(code).map(|k| winit::keyboard::PhysicalKey::Code(k))
+        }
+        keyboard::key::Physical::Unidentified(native_code) => {
+            Some(winit::keyboard::PhysicalKey::Unidentified(
+                winit_native_key_code(native_code),
+            ))
+        }
+    }) else {
+        return None;
+    };
+
+    crate::keymap::physicalkey_to_scancode(physical_key)
 }
 
 /// Converts a `NativeKeyCode` from [`winit`] to an [`iced`] native key code.

--- a/winit/src/platform_specific/wayland/commands/keyboard_shortcuts_inhibit.rs
+++ b/winit/src/platform_specific/wayland/commands/keyboard_shortcuts_inhibit.rs
@@ -1,0 +1,13 @@
+use iced_runtime::{
+    self,
+    platform_specific::{self, wayland},
+    task, Action, Task,
+};
+
+pub fn inhibit_shortcuts(inhibit: bool) -> Task<()> {
+    task::oneshot(|_| {
+        Action::PlatformSpecific(platform_specific::Action::Wayland(
+            wayland::Action::InhibitShortcuts(inhibit),
+        ))
+    })
+}

--- a/winit/src/platform_specific/wayland/commands/mod.rs
+++ b/winit/src/platform_specific/wayland/commands/mod.rs
@@ -1,6 +1,7 @@
 //! Interact with the wayland objects of your application.
 
 pub mod activation;
+pub mod keyboard_shortcuts_inhibit;
 pub mod layer_surface;
 pub mod overlap_notify;
 pub mod popup;

--- a/winit/src/platform_specific/wayland/event_loop/mod.rs
+++ b/winit/src/platform_specific/wayland/event_loop/mod.rs
@@ -44,8 +44,6 @@ use cctk::{
 };
 use raw_window_handle::HasDisplayHandle;
 use state::{send_event, FrameStatus, SctkWindow};
-#[cfg(feature = "a11y")]
-use std::sync::{Arc, Mutex};
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
@@ -53,6 +51,7 @@ use std::{
 use tracing::error;
 use wayland_backend::client::Backend;
 use wayland_client::globals::GlobalError;
+use wayland_protocols::wp::keyboard_shortcuts_inhibit::zv1::client::zwp_keyboard_shortcuts_inhibit_manager_v1;
 use winit::{dpi::LogicalSize, event_loop::OwnedDisplayHandle};
 
 use self::state::SctkState;
@@ -306,6 +305,14 @@ impl SctkEventLoop {
                         &registry_state,
                         &qh,
                     ),
+                    inhibitor_manager: registry_state.bind_one::<zwp_keyboard_shortcuts_inhibit_manager_v1::ZwpKeyboardShortcutsInhibitManagerV1, _, _>(
+                        &qh,
+                        1..=1,
+                        (),
+                    ).ok(),
+                    inhibitor: None,
+                    inhibited: false,
+
                     registry_state,
 
                     queue_handle: qh,
@@ -320,7 +327,6 @@ impl SctkEventLoop {
                     popups: Vec::new(),
                     lock_surfaces: Vec::new(),
                     subsurfaces: Vec::new(),
-                    _kbd_focus: None,
                     touch_points: HashMap::new(),
                     sctk_events: Vec::new(),
                     frame_status: HashMap::new(),

--- a/winit/src/platform_specific/wayland/event_loop/state.rs
+++ b/winit/src/platform_specific/wayland/event_loop/state.rs
@@ -95,8 +95,7 @@ use iced_runtime::{
 };
 use wayland_protocols::{
     wp::{
-        fractional_scale::v1::client::wp_fractional_scale_v1::WpFractionalScaleV1,
-        viewporter::client::wp_viewport::WpViewport,
+        fractional_scale::v1::client::wp_fractional_scale_v1::WpFractionalScaleV1, keyboard_shortcuts_inhibit::zv1::client::{zwp_keyboard_shortcuts_inhibit_manager_v1, zwp_keyboard_shortcuts_inhibitor_v1}, viewporter::client::wp_viewport::WpViewport
     },
     xdg::shell::client::xdg_surface::XdgSurface,
 };
@@ -389,7 +388,6 @@ pub struct SctkState {
     pub(crate) popups: Vec<SctkPopup>,
     pub(crate) subsurfaces: Vec<SctkSubsurface>,
     pub(crate) lock_surfaces: Vec<SctkLockSurface>,
-    pub(crate) _kbd_focus: Option<WlSurface>,
     pub(crate) touch_points: HashMap<touch::Finger, (WlSurface, Point)>,
 
     /// Window updates, which are coming from SCTK or the compositor, which require
@@ -435,6 +433,10 @@ pub struct SctkState {
 
     pub(crate) activation_token_ctr: u32,
     pub(crate) token_senders: HashMap<u32, oneshot::Sender<Option<String>>>,
+
+    pub(crate) inhibitor: Option<zwp_keyboard_shortcuts_inhibitor_v1::ZwpKeyboardShortcutsInhibitorV1>,
+    pub(crate) inhibited: bool,
+    pub(crate) inhibitor_manager: Option<zwp_keyboard_shortcuts_inhibit_manager_v1::ZwpKeyboardShortcutsInhibitManagerV1>,
 }
 
 /// An error that occurred while running an application.
@@ -1464,6 +1466,17 @@ impl SctkState {
                     }
                 },
             },
+            Action::InhibitShortcuts(v) => {
+                if let Some(manager) = self.inhibitor_manager.as_ref() {
+                    if let Some(inhibit) = self.inhibitor.take() {
+                            inhibit.destroy();
+                    }
+                    if v {
+                        self.inhibitor = self.seats.iter().next()
+                        .and_then(|s| s.kbd_focus.as_ref().map(|surface| manager.inhibit_shortcuts(surface, &s.seat, &self.queue_handle, ())));
+                    }
+                }
+            }
         };
         Ok(())
     }

--- a/winit/src/platform_specific/wayland/handlers/seat/keyboard_shortcuts_inhibit.rs
+++ b/winit/src/platform_specific/wayland/handlers/seat/keyboard_shortcuts_inhibit.rs
@@ -1,0 +1,52 @@
+use cctk::sctk;
+use sctk::reexports::{
+    client::{Connection, Dispatch, Proxy},
+    protocols::wp::keyboard_shortcuts_inhibit::{
+        self, zv1::client::zwp_keyboard_shortcuts_inhibitor_v1,
+    },
+};
+
+use crate::event_loop::state::SctkState;
+use crate::platform_specific::wayland::SctkEvent;
+
+impl Dispatch<keyboard_shortcuts_inhibit::zv1::client::zwp_keyboard_shortcuts_inhibit_manager_v1::ZwpKeyboardShortcutsInhibitManagerV1, ()> for SctkState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &keyboard_shortcuts_inhibit::zv1::client::zwp_keyboard_shortcuts_inhibit_manager_v1::ZwpKeyboardShortcutsInhibitManagerV1,
+        _event: <keyboard_shortcuts_inhibit::zv1::client::zwp_keyboard_shortcuts_inhibit_manager_v1::ZwpKeyboardShortcutsInhibitManagerV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qhandle: &sctk::reexports::client::QueueHandle<Self>,
+    ) {}
+}
+
+impl
+    Dispatch<
+        zwp_keyboard_shortcuts_inhibitor_v1::ZwpKeyboardShortcutsInhibitorV1,
+        (),
+    > for SctkState
+{
+    fn event(
+        state: &mut Self,
+        _proxy: &zwp_keyboard_shortcuts_inhibitor_v1::ZwpKeyboardShortcutsInhibitorV1,
+        event: <zwp_keyboard_shortcuts_inhibitor_v1::ZwpKeyboardShortcutsInhibitorV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qhandle: &sctk::reexports::client::QueueHandle<Self>,
+    ) {
+        match event {
+            zwp_keyboard_shortcuts_inhibitor_v1::Event::Active => {
+                state.sctk_events.push(SctkEvent::ShortcutsInhibited(true));
+                state.inhibited = true;
+            }
+            zwp_keyboard_shortcuts_inhibitor_v1::Event::Inactive => {
+                state.sctk_events.push(SctkEvent::ShortcutsInhibited(false));
+                state.inhibited = false;
+                if let Some(inhibitor) = state.inhibitor.take() {
+                    inhibitor.destroy();
+                }
+            }
+            _ => unimplemented!(),
+        }
+    }
+}

--- a/winit/src/platform_specific/wayland/handlers/seat/mod.rs
+++ b/winit/src/platform_specific/wayland/handlers/seat/mod.rs
@@ -1,5 +1,6 @@
 // TODO support multi-seat handling
 pub mod keyboard;
+pub mod keyboard_shortcuts_inhibit;
 pub mod pointer;
 pub mod seat;
 pub mod touch;

--- a/winit/src/platform_specific/wayland/keymap.rs
+++ b/winit/src/platform_specific/wayland/keymap.rs
@@ -1,5 +1,7 @@
 // Borrowed from winit
+use iced_runtime::keyboard::{key::Named, Key, Location};
 use winit::keyboard::{KeyCode, NativeKeyCode, PhysicalKey};
+
 /// Map the raw X11-style keycode to the `KeyCode` enum.
 ///
 /// X11-style keycodes are offset by 8 from the keycodes the Linux kernel uses.
@@ -838,7 +840,197 @@ pub fn keysym_to_key(keysym: u32) -> Key {
     })
 }
 
-use iced_runtime::keyboard::{key::Named, Key, Location};
+pub fn key_to_keysym(
+    unmodified_key: Key,
+    location: Location,
+) -> Option<xkeysym::Keysym> {
+    use xkbcommon_dl::keysyms;
+
+    let raw = match unmodified_key {
+        Key::Named(named) => Some(match (named, location) {
+            (Named::Escape, _) => keysyms::Escape,
+            (Named::Backspace, _) => keysyms::BackSpace,
+            (Named::Tab, _) => keysyms::Tab,
+            (Named::Enter, _) => keysyms::Return,
+
+            (Named::Compose, _) => keysyms::Multi_key,
+
+            (Named::KanjiMode, _) => keysyms::Kanji,
+            (Named::Eisu, _) => keysyms::Eisu_toggle,
+            (Named::NonConvert, _) => keysyms::Muhenkan,
+            (Named::Convert, _) => keysyms::Henkan_Mode,
+            (Named::Romaji, _) => keysyms::Romaji,
+            (Named::Hiragana, _) => keysyms::Hiragana,
+            (Named::Katakana, _) => keysyms::Katakana,
+            (Named::HiraganaKatakana, _) => keysyms::Hiragana_Katakana,
+            (Named::Zenkaku, _) => keysyms::Zenkaku,
+            (Named::Hankaku, _) => keysyms::Hankaku,
+            (Named::ZenkakuHankaku, _) => keysyms::Zenkaku_Hankaku,
+            (Named::KanaMode, _) => keysyms::Kana_Lock,
+            (Named::Alphanumeric, _) => keysyms::Eisu_toggle,
+            (Named::CodeInput, _) => keysyms::Codeinput,
+            (Named::AllCandidates, _) => keysyms::MultipleCandidate,
+            (Named::PreviousCandidate, _) => keysyms::PreviousCandidate,
+            (Named::SingleCandidate, _) => keysyms::SingleCandidate,
+
+            (Named::ArrowUp, _) => keysyms::Up,
+            (Named::ArrowDown, _) => keysyms::Down,
+            (Named::ArrowLeft, _) => keysyms::Left,
+            (Named::ArrowRight, _) => keysyms::Right,
+            (Named::PageUp, _) => keysyms::Page_Up,
+            (Named::PageDown, _) => keysyms::Page_Down,
+            (Named::Home, _) => keysyms::Home,
+            (Named::End, _) => keysyms::End,
+            (Named::Insert, _) => keysyms::Insert,
+            (Named::Delete, _) => keysyms::Delete,
+
+            (Named::Undo, _) => keysyms::Undo,
+            (Named::Redo, _) => keysyms::Redo,
+            (Named::ContextMenu, _) => keysyms::Menu,
+            (Named::Find, _) => keysyms::Find,
+            (Named::Cancel, _) => keysyms::Cancel,
+            (Named::Help, _) => keysyms::Help,
+            (Named::Pause, _) => keysyms::Break,
+            (Named::ModeChange, _) => keysyms::Mode_switch,
+            (Named::NumLock, _) => keysyms::Num_Lock,
+            (Named::CapsLock, _) => keysyms::Caps_Lock,
+            (Named::ScrollLock, _) => keysyms::Scroll_Lock,
+            (Named::PrintScreen, _) => keysyms::Print,
+
+            (Named::F1, _) => keysyms::F1,
+            (Named::F2, _) => keysyms::F2,
+            (Named::F3, _) => keysyms::F3,
+            (Named::F4, _) => keysyms::F4,
+            (Named::F5, _) => keysyms::F5,
+            (Named::F6, _) => keysyms::F6,
+            (Named::F7, _) => keysyms::F7,
+            (Named::F8, _) => keysyms::F8,
+            (Named::F9, _) => keysyms::F9,
+            (Named::F10, _) => keysyms::F10,
+            (Named::F11, _) => keysyms::F11,
+            (Named::F12, _) => keysyms::F12,
+            (Named::F13, _) => keysyms::F13,
+            (Named::F14, _) => keysyms::F14,
+            (Named::F15, _) => keysyms::F15,
+            (Named::F16, _) => keysyms::F16,
+            (Named::F17, _) => keysyms::F17,
+            (Named::F18, _) => keysyms::F18,
+            (Named::F19, _) => keysyms::F19,
+            (Named::F20, _) => keysyms::F20,
+
+            (Named::Shift, _) => keysyms::Shift_L,
+            (Named::Control, _) => keysyms::Control_L,
+            (Named::Alt, _) => keysyms::Alt_L,
+            (Named::Super, _) => keysyms::Super_L,
+            (Named::Hyper, _) => keysyms::Hyper_L,
+            (Named::Meta, _) => keysyms::Meta_L,
+
+            (Named::AltGraph, _) => keysyms::ISO_Level3_Shift,
+            (Named::GroupNext, _) => keysyms::ISO_Next_Group,
+            (Named::GroupPrevious, _) => keysyms::ISO_Prev_Group,
+            (Named::GroupFirst, _) => keysyms::ISO_First_Group,
+            (Named::GroupLast, _) => keysyms::ISO_Last_Group,
+
+            (Named::EraseEof, _) => keysyms::_3270_EraseEOF,
+            (Named::Attn, _) => keysyms::_3270_Attn,
+            (Named::Play, _) => keysyms::_3270_Play,
+            (Named::ExSel, _) => keysyms::_3270_ExSelect,
+            (Named::CrSel, _) => keysyms::_3270_CursorSelect,
+
+            (Named::Space, _) => keysyms::space,
+
+            // XF86 multimedia / internet / power keys (subset shown)
+            (Named::BrightnessUp, _) => keysyms::XF86_MonBrightnessUp,
+            (Named::BrightnessDown, _) => keysyms::XF86_MonBrightnessDown,
+            (Named::Standby, _) => keysyms::XF86_Standby,
+            (Named::AudioVolumeDown, _) => keysyms::XF86_AudioLowerVolume,
+            (Named::AudioVolumeUp, _) => keysyms::XF86_AudioRaiseVolume,
+            (Named::MediaPlay, _) => keysyms::XF86_AudioPlay,
+            (Named::MediaStop, _) => keysyms::XF86_AudioStop,
+            (Named::MediaTrackPrevious, _) => keysyms::XF86_AudioPrev,
+            (Named::MediaTrackNext, _) => keysyms::XF86_AudioNext,
+            (Named::BrowserHome, _) => keysyms::XF86_HomePage,
+            (Named::LaunchMail, _) => keysyms::XF86_Mail,
+            (Named::BrowserSearch, _) => keysyms::XF86_Search,
+            (Named::MediaRecord, _) => keysyms::XF86_AudioRecord,
+            (Named::LaunchApplication2, _) => keysyms::XF86_Calculator,
+            (Named::LaunchCalendar, _) => keysyms::XF86_Calendar,
+            (Named::Power, _) => keysyms::XF86_PowerDown,
+            (Named::BrowserBack, _) => keysyms::XF86_Back,
+            (Named::BrowserForward, _) => keysyms::XF86_Forward,
+            (Named::BrowserRefresh, _) => keysyms::XF86_Refresh,
+            (Named::WakeUp, _) => keysyms::XF86_WakeUp,
+            (Named::Eject, _) => keysyms::XF86_Eject,
+            (Named::LaunchScreenSaver, _) => keysyms::XF86_ScreenSaver,
+            (Named::LaunchWebBrowser, _) => keysyms::XF86_WWW,
+            (Named::BrowserFavorites, _) => keysyms::XF86_Favorites,
+            (Named::MediaPause, _) => keysyms::XF86_AudioPause,
+            (Named::LaunchApplication1, _) => keysyms::XF86_MyComputer,
+            (Named::Close, _) => keysyms::XF86_Close,
+            (Named::Copy, _) => keysyms::XF86_Copy,
+            (Named::Cut, _) => keysyms::XF86_Cut,
+            (Named::LaunchSpreadsheet, _) => keysyms::XF86_Excel,
+            (Named::LogOff, _) => keysyms::XF86_LogOff,
+            (Named::New, _) => keysyms::XF86_New,
+            (Named::Open, _) => keysyms::XF86_Open,
+            (Named::Paste, _) => keysyms::XF86_Paste,
+            (Named::LaunchPhone, _) => keysyms::XF86_Phone,
+            (Named::MailReply, _) => keysyms::XF86_Reply,
+            (Named::Save, _) => keysyms::XF86_Save,
+            (Named::MailSend, _) => keysyms::XF86_Send,
+            (Named::SpellCheck, _) => keysyms::XF86_Spell,
+            (Named::SplitScreenToggle, _) => keysyms::XF86_SplitScreen,
+            (Named::LaunchMediaPlayer, _) => keysyms::XF86_Video,
+            (Named::LaunchWordProcessor, _) => keysyms::XF86_Word,
+            (Named::ZoomIn, _) => keysyms::XF86_ZoomIn,
+            (Named::ZoomOut, _) => keysyms::XF86_ZoomOut,
+            (Named::LaunchWebCam, _) => keysyms::XF86_WebCam,
+            (Named::MailForward, _) => keysyms::XF86_MailForward,
+            (Named::LaunchMusicPlayer, _) => keysyms::XF86_Music,
+            (Named::MediaFastForward, _) => keysyms::XF86_AudioForward,
+            (Named::RandomToggle, _) => keysyms::XF86_AudioRandomPlay,
+            (Named::Subtitle, _) => keysyms::XF86_Subtitle,
+            (Named::MediaAudioTrack, _) => keysyms::XF86_AudioCycleTrack,
+            (Named::Hibernate, _) => keysyms::XF86_Hibernate,
+            (Named::AudioVolumeMute, _) => keysyms::XF86_AudioMute,
+            (Named::VideoModeNext, _) => keysyms::XF86_Next_VMode,
+
+            _ => return None,
+        }),
+        Key::Character(c) if c.chars().count() == 1 => {
+            Some(match (c.chars().next(), location) {
+                (Some('0'), Location::Numpad) => keysyms::KP_0,
+                (Some('1'), Location::Numpad) => keysyms::KP_1,
+                (Some('2'), Location::Numpad) => keysyms::KP_2,
+                (Some('3'), Location::Numpad) => keysyms::KP_3,
+                (Some('4'), Location::Numpad) => keysyms::KP_4,
+                (Some('5'), Location::Numpad) => keysyms::KP_5,
+                (Some('6'), Location::Numpad) => keysyms::KP_6,
+                (Some('7'), Location::Numpad) => keysyms::KP_7,
+                (Some('8'), Location::Numpad) => keysyms::KP_8,
+                (Some('9'), Location::Numpad) => keysyms::KP_9,
+                (Some('.'), Location::Numpad) => keysyms::KP_Decimal,
+                (Some('+'), Location::Numpad) => keysyms::KP_Add,
+                (Some('-'), Location::Numpad) => keysyms::KP_Subtract,
+                (Some('*'), Location::Numpad) => keysyms::KP_Multiply,
+                (Some('/'), Location::Numpad) => keysyms::KP_Divide,
+                (Some('='), Location::Numpad) => keysyms::KP_Equal,
+
+                (Some(c), _) => unsafe {
+                    let keysym =
+                        xkbcommon::xkb::ffi::xkb_utf32_to_keysym(c as u32);
+                    if keysym == keysyms::NoSymbol {
+                        return None;
+                    }
+                    keysym
+                },
+                _ => return None,
+            })
+        }
+        _ => None,
+    };
+    raw.map(|k| xkeysym::Keysym::new(k))
+}
 
 pub fn keysym_location(keysym: u32) -> Location {
     use xkbcommon_dl::keysyms;

--- a/winit/src/platform_specific/wayland/sctk_event.rs
+++ b/winit/src/platform_specific/wayland/sctk_event.rs
@@ -211,6 +211,7 @@ pub enum SctkEvent {
     SurfaceScaleFactorChanged(f64, WlSurface, window::Id),
     Winit(WindowId, WindowEvent),
     Subcompositor(SubsurfaceState),
+    ShortcutsInhibited(bool),
 }
 
 #[cfg(feature = "a11y")]
@@ -1683,6 +1684,14 @@ impl SctkEvent {
                     }
                 }
             },
+            SctkEvent::ShortcutsInhibited(v) => events.push((
+                None,
+                iced_runtime::core::Event::PlatformSpecific(
+                    PlatformSpecific::Wayland(
+                        wayland::Event::ShortcutsInhibited(v),
+                    ),
+                ),
+            )),
         }
     }
 }


### PR DESCRIPTION
I'm not really sure of a better way to reconstruct the keysym from the iced Key. This does drop a few keysyms, like the SUN variants, and a few 3270 and ISO, but I'm hoping that they won't be an issue. 

This also adds helpers for getting the raw keycode, which isn't really used by settings at the moment, but I believe we want to in the future.