### PR TITLE
fix: text halign

### DIFF
--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -87,11 +87,7 @@ impl core::text::Paragraph for Paragraph {
             text.content,
             &text::to_attributes(text.font),
             text::to_shaping(text.shaping),
-            Some(match text.horizontal_alignment {
-                alignment::Horizontal::Left => cosmic_text::Align::Left,
-                alignment::Horizontal::Center => cosmic_text::Align::Center,
-                alignment::Horizontal::Right => cosmic_text::Align::Right,
-            }),
+            None,
         );
 
         let min_bounds = text::measure(&buffer);


### PR DESCRIPTION
Iced already offsets the text to match the alignment for each backend, tiny-skia and wgpu. As it is, passing the alignment here seems to just add an extra offset to each glyph of a line, and I'm not sure it does so correctly in the context of iced alignment, because the offset for the alignment seems relative to the width of the text. I'd have to look into it more to switch methods for alignment, but just passing None fixes the text based on my testing.