### PR TITLE
wayland: Fix handling of discrete/value120 scroll events

### DIFF
--- a/winit/src/platform_specific/wayland/handlers/seat/pointer.rs
+++ b/winit/src/platform_specific/wayland/handlers/seat/pointer.rs
@@ -128,9 +128,17 @@ impl PointerHandler for SctkState {
                                 horizontal,
                                 vertical,
                                 source,
-                            } => WindowEvent::MouseWheel {
-                                device_id: Default::default(),
-                                delta: if horizontal.discrete > 0 {
+                            } => {
+                                let delta = if horizontal.value120 != 0
+                                    || vertical.value120 != 0
+                                {
+                                    MouseScrollDelta::LineDelta(
+                                        -horizontal.value120 as f32 / 120.,
+                                        -vertical.value120 as f32 / 120.,
+                                    )
+                                } else if horizontal.discrete != 0
+                                    || vertical.discrete != 0
+                                {
                                     MouseScrollDelta::LineDelta(
                                         -horizontal.discrete as f32,
                                         -vertical.discrete as f32,
@@ -142,13 +150,18 @@ impl PointerHandler for SctkState {
                                             -vertical.absolute,
                                         ),
                                     )
-                                },
-                                phase: if horizontal.stop {
-                                    TouchPhase::Ended
-                                } else {
-                                    TouchPhase::Moved
-                                },
-                            },
+                                };
+
+                                WindowEvent::MouseWheel {
+                                    device_id: Default::default(),
+                                    delta,
+                                    phase: if horizontal.stop {
+                                        TouchPhase::Ended
+                                    } else {
+                                        TouchPhase::Moved
+                                    },
+                                }
+                            }
                         },
                     ));
                 }


### PR DESCRIPTION
- Should test `!= 0`, not `> 0`; can scroll in either direction
- Test both vertical and horizontal
- Use `value120` scroll if present (in which case, discrete is 0)

I guess events should really have both line and pixel scroll, since some widgets want to use the pixel scroll values for input devices that have both? But I guess winit and Iced both need to be changed for that...