### PR TITLE
Sort using more deterministic algorithm

### DIFF
--- a/core/src/point.rs
+++ b/core/src/point.rs
@@ -34,6 +34,18 @@ impl<T: Num> Point<T> {
 
         a.hypot(b)
     }
+
+    /// Computes the distance to another [`Point`], using a slower but more deterministic algorithm.
+    /// Useful for sorting algorithms.
+    pub fn distance_slow(&self, to: Self) -> T
+    where
+        T: Float,
+    {
+        let a = self.x - to.x;
+        let b = self.y - to.y;
+
+        (a * a + b * b).sqrt()
+    }
 }
 
 impl<T> From<[T; 2]> for Point<T>

--- a/graphics/src/damage.rs
+++ b/graphics/src/damage.rs
@@ -51,8 +51,8 @@ pub fn group(mut damage: Vec<Rectangle>, bounds: Rectangle) -> Vec<Rectangle> {
 
     damage.sort_by(|a, b| {
         a.center()
-            .distance(Point::ORIGIN)
-            .total_cmp(&b.center().distance(Point::ORIGIN))
+            .distance_slow(Point::ORIGIN)
+            .total_cmp(&b.center().distance_slow(Point::ORIGIN))
     });
 
     let mut output = Vec::new();

--- a/graphics/src/damage.rs
+++ b/graphics/src/damage.rs
@@ -49,9 +49,7 @@ pub fn group(mut damage: Vec<Rectangle>, bounds: Rectangle) -> Vec<Rectangle> {
 
     const AREA_THRESHOLD: f32 = 20_000.0;
 
-    // Keep unstable sort here because `distance` uses `hypot` which has
-    // non-deterministic precision.
-    damage.sort_unstable_by(|a, b| {
+    damage.sort_by(|a, b| {
         a.center()
             .distance(Point::ORIGIN)
             .total_cmp(&b.center().distance(Point::ORIGIN))


### PR DESCRIPTION
Replaces https://github.com/pop-os/iced/pull/253 which turned out to be insufficient. I cannot promise this fixes the issue for good, as alterations of the source code and build options can mask it sometimes. Although, I've been using cosmic-launcher with this modification yesterday and today and haven't seen any crash yet.

`hypot` while useful for most of the cases, may break sorting assumptions like deterministic comparison.
As seen in: https://github.com/pop-os/cosmic-launcher/issues/352

Add and use a new method that trades the performance for more determinism.

Upstream companion PR: https://github.com/iced-rs/iced/pull/3196