### PR TITLE
fix(wgpu): avoid llvmpipe fallback on hybrid GPU Wayland setups with stale surfaces

### DIFF
--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -190,30 +190,76 @@ impl Compositor {
         let adapter = match adapter {
             Some(adapter) => adapter,
             None => {
-                // fall back to allowing GL backend if enabled
-                instance = wgpu::util::new_instance_with_webgpu_detection(
-                    &wgpu::InstanceDescriptor {
-                        backends: settings.backends,
-                        flags: if cfg!(feature = "strict-assertions") {
-                            wgpu::InstanceFlags::debugging()
-                        } else {
-                            wgpu::InstanceFlags::empty()
+                let surface_pick =
+                    instance.request_adapter(&adapter_options).await;
+                let is_cpu = surface_pick
+                    .as_ref()
+                    .is_ok_and(|a| a.get_info().device_type == wgpu::DeviceType::Cpu);
+
+                if surface_pick.is_err() || is_cpu {
+                    // Either no adapter was found, or only a CPU software
+                    // rasterizer (e.g. llvmpipe) survived the surface
+                    // compatibility filter.
+                    //
+                    // On Wayland the surface may not be fully committed
+                    // yet (common for layer-shell panel applets), causing
+                    // real GPUs to fail VK_ERROR_SURFACE_LOST_KHR while
+                    // software rasterizers pass.  Retry without the
+                    // surface constraint so a real GPU is preferred.
+                    //
+                    // If the surface-less retry also yields nothing, fall
+                    // back to the GL backend (upstream fallback) or to
+                    // whatever the original attempt returned (possibly
+                    // the CPU adapter) so we are never worse off.
+                    log::warn!(
+                        "adapter selection: surface-compatible pick is \
+                         {pick}; retrying without surface constraint",
+                        pick = match surface_pick.as_ref() {
+                            Ok(a) => a.get_info().name,
+                            Err(e) => format!("Err({e})"),
                         },
-                        ..Default::default()
-                    },
-                )
-                .await;
-                compatible_surface = compatible_window
-                    .and_then(|window| instance.create_surface(window).ok());
-                adapter_options = wgpu::RequestAdapterOptions {
-                    power_preference: wgpu::PowerPreference::from_env()
-                        .unwrap_or(wgpu::PowerPreference::HighPerformance),
-                    compatible_surface: compatible_surface.as_ref(),
-                    force_fallback_adapter: false,
-                };
-                instance.request_adapter(&adapter_options).await.map_err(
-                    |_| Error::NoAdapterFound(format!("{:?}", adapter_options)),
-                )?
+                    );
+                    let fallback_options = wgpu::RequestAdapterOptions {
+                        compatible_surface: None,
+                        ..adapter_options
+                    };
+                    match instance
+                        .request_adapter(&fallback_options)
+                        .await
+                        .or(surface_pick)
+                    {
+                        Ok(a) => a,
+                        Err(_) => {
+                            // Last resort: fall back to allowing GL backend
+                            instance = wgpu::util::new_instance_with_webgpu_detection(
+                                &wgpu::InstanceDescriptor {
+                                    backends: settings.backends,
+                                    flags: if cfg!(feature = "strict-assertions") {
+                                        wgpu::InstanceFlags::debugging()
+                                    } else {
+                                        wgpu::InstanceFlags::empty()
+                                    },
+                                    ..Default::default()
+                                },
+                            )
+                            .await;
+                            compatible_surface = compatible_window
+                                .and_then(|window| instance.create_surface(window).ok());
+                            adapter_options = wgpu::RequestAdapterOptions {
+                                power_preference: wgpu::PowerPreference::from_env()
+                                    .unwrap_or(wgpu::PowerPreference::HighPerformance),
+                                compatible_surface: compatible_surface.as_ref(),
+                                force_fallback_adapter: false,
+                            };
+                            instance.request_adapter(&adapter_options).await.map_err(
+                                |_| Error::NoAdapterFound(format!("{:?}", adapter_options)),
+                            )?
+                        }
+                    }
+                } else {
+                    // A real (non-CPU) GPU was found -- use it.
+                    surface_pick.expect("guaranteed Ok: is_err() was false")
+                }
             }
         };
         log::info!("Selected: {:#?}", adapter.get_info());

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -153,20 +153,21 @@ impl Compositor {
                 not(target_os = "redox")
             ))]
             if let Some((vendor_id, device_id)) = ids {
+                // Trust the compositor's DMA-BUF device preference
+                // without probing the surface.  On Wayland the surface
+                // may not be fully committed at this point, causing
+                // VK_ERROR_SURFACE_LOST_KHR in the capability query
+                // which falsely rejects the correct GPU.  The DMA-BUF
+                // feedback already guarantees this device can render for
+                // the compositor, and the surface will be (re-)created
+                // on the chosen adapter later anyway.
                 adapter = instance
                     .enumerate_adapters(settings.backends)
                     .into_iter()
-                    .filter(|adapter| {
+                    .find(|adapter| {
                         let info = adapter.get_info();
                         info.device == device_id as u32
                             && info.vendor == vendor_id as u32
-                    })
-                    .find(|adapter| {
-                        if let Some(surface) = compatible_surface.as_ref() {
-                            adapter.is_surface_supported(surface)
-                        } else {
-                            true
-                        }
                     });
             }
         } else if let Ok(name) = std::env::var("WGPU_ADAPTER_NAME") {

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -199,30 +199,76 @@ impl Compositor {
         let adapter = match adapter {
             Some(adapter) => adapter,
             None => {
-                // fall back to allowing GL backend if enabled
-                instance = wgpu::util::new_instance_with_webgpu_detection(
-                    &wgpu::InstanceDescriptor {
-                        backends: settings.backends,
-                        flags: if cfg!(feature = "strict-assertions") {
-                            wgpu::InstanceFlags::debugging()
-                        } else {
-                            wgpu::InstanceFlags::empty()
+                let surface_pick =
+                    instance.request_adapter(&adapter_options).await;
+                let is_cpu = surface_pick
+                    .as_ref()
+                    .is_ok_and(|a| a.get_info().device_type == wgpu::DeviceType::Cpu);
+
+                if surface_pick.is_err() || is_cpu {
+                    // Either no adapter was found, or only a CPU software
+                    // rasterizer (e.g. llvmpipe) survived the surface
+                    // compatibility filter.
+                    //
+                    // On Wayland the surface may not be fully committed
+                    // yet (common for layer-shell panel applets), causing
+                    // real GPUs to fail VK_ERROR_SURFACE_LOST_KHR while
+                    // software rasterizers pass.  Retry without the
+                    // surface constraint so a real GPU is preferred.
+                    //
+                    // If the surface-less retry also yields nothing, fall
+                    // back to the GL backend (upstream fallback) or to
+                    // whatever the original attempt returned (possibly
+                    // the CPU adapter) so we are never worse off.
+                    log::warn!(
+                        "adapter selection: surface-compatible pick is \
+                         {pick}; retrying without surface constraint",
+                        pick = match surface_pick.as_ref() {
+                            Ok(a) => a.get_info().name,
+                            Err(e) => format!("Err({e})"),
                         },
-                        ..Default::default()
-                    },
-                )
-                .await;
-                compatible_surface = compatible_window
-                    .and_then(|window| instance.create_surface(window).ok());
-                adapter_options = wgpu::RequestAdapterOptions {
-                    power_preference: wgpu::PowerPreference::from_env()
-                        .unwrap_or(wgpu::PowerPreference::HighPerformance),
-                    compatible_surface: compatible_surface.as_ref(),
-                    force_fallback_adapter: false,
-                };
-                instance.request_adapter(&adapter_options).await.map_err(
-                    |_| Error::NoAdapterFound(format!("{:?}", adapter_options)),
-                )?
+                    );
+                    let fallback_options = wgpu::RequestAdapterOptions {
+                        compatible_surface: None,
+                        ..adapter_options
+                    };
+                    match instance
+                        .request_adapter(&fallback_options)
+                        .await
+                        .or(surface_pick)
+                    {
+                        Ok(a) => a,
+                        Err(_) => {
+                            // Last resort: fall back to allowing GL backend
+                            instance = wgpu::util::new_instance_with_webgpu_detection(
+                                &wgpu::InstanceDescriptor {
+                                    backends: settings.backends,
+                                    flags: if cfg!(feature = "strict-assertions") {
+                                        wgpu::InstanceFlags::debugging()
+                                    } else {
+                                        wgpu::InstanceFlags::empty()
+                                    },
+                                    ..Default::default()
+                                },
+                            )
+                            .await;
+                            compatible_surface = compatible_window
+                                .and_then(|window| instance.create_surface(window).ok());
+                            adapter_options = wgpu::RequestAdapterOptions {
+                                power_preference: wgpu::PowerPreference::from_env()
+                                    .unwrap_or(wgpu::PowerPreference::HighPerformance),
+                                compatible_surface: compatible_surface.as_ref(),
+                                force_fallback_adapter: false,
+                            };
+                            instance.request_adapter(&adapter_options).await.map_err(
+                                |_| Error::NoAdapterFound(format!("{:?}", adapter_options)),
+                            )?
+                        }
+                    }
+                } else {
+                    // A real (non-CPU) GPU was found -- use it.
+                    surface_pick.expect("guaranteed Ok: is_err() was false")
+                }
             }
         };
         log::info!("Selected: {:#?}", adapter.get_info());

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -158,21 +158,22 @@ impl Compositor {
                 not(target_os = "redox")
             ))]
             if let Some((vendor_id, device_id)) = ids {
+                // Trust the compositor's DMA-BUF device preference
+                // without probing the surface.  On Wayland the surface
+                // may not be fully committed at this point, causing
+                // VK_ERROR_SURFACE_LOST_KHR in the capability query
+                // which falsely rejects the correct GPU.  The DMA-BUF
+                // feedback already guarantees this device can render for
+                // the compositor, and the surface will be (re-)created
+                // on the chosen adapter later anyway.
                 adapter = instance
                     .enumerate_adapters(settings.backends)
                     .await
                     .into_iter()
-                    .filter(|adapter| {
+                    .find(|adapter| {
                         let info = adapter.get_info();
                         info.device == device_id as u32
                             && info.vendor == vendor_id as u32
-                    })
-                    .find(|adapter| {
-                        if let Some(surface) = compatible_surface.as_ref() {
-                            adapter.is_surface_supported(surface)
-                        } else {
-                            true
-                        }
                     });
             }
         } else if let Ok(name) = std::env::var("WGPU_ADAPTER_NAME") {

--- a/widget/src/list.rs
+++ b/widget/src/list.rs
@@ -108,7 +108,7 @@ where
 
     fn size(&self) -> Size<Length> {
         Size {
-            width: Length::Shrink,
+            width: Length::Fill,
             height: Length::Shrink,
         }
     }
@@ -344,7 +344,7 @@ where
         );
 
         let size =
-            limits.resolve(Length::Shrink, Length::Shrink, intrinsic_size);
+            limits.resolve(Length::Fill, Length::Shrink, intrinsic_size);
 
         layout::Node::new(size)
     }
@@ -363,10 +363,23 @@ where
         let state = tree.state.downcast_mut::<State>();
         let offset = layout.position() - Point::ORIGIN;
 
+        // Repopulate visible elements after a view() rebuild so that
+        // input events (which arrive before RedrawRequested in winit's
+        // event loop) are not silently lost.
+        if self.visible_elements.is_empty() {
+            self.visible_elements = state
+                .visible_layouts
+                .iter()
+                .map(|(i, _, _)| {
+                    (self.view_item)(*i, &self.content.items[*i])
+                })
+                .collect();
+        }
+
         self.visible_elements
             .iter_mut()
             .zip(&mut state.visible_layouts)
-            .map(|(element, (index, layout, tree))| {
+            .for_each(|(element, (index, layout, tree))| {
                 element.as_widget_mut().update(
                     tree,
                     event,


### PR DESCRIPTION
Problem

On Wayland with hybrid GPU laptops (e.g. NVIDIA + Intel), COSMIC panel applets consistently fall back to **llvmpipe** (CPU software rasterizer) instead of using the real GPU.

The root cause is a race condition during compositor initialization: the Wayland surface is not yet fully committed when wgpu probes adapter compatibility, causing `VK_ERROR_SURFACE_LOST_KHR` in `vkGetPhysicalDeviceSurfaceCapabilitiesKHR`. This falsely rejects real GPU adapters while llvmpipe survives (its Vulkan implementation doesn't perform the same surface validation).

This is particularly common with **layer-shell panel applets**, where the surface lifecycle differs from regular windows.

### Observed behaviour

```
ERROR wgpu_hal::vulkan::adapter: get_physical_device_surface_capabilities: ERROR_SURFACE_LOST_KHR

Selected: AdapterInfo {
    name: "llvmpipe (LLVM 21.1.8, 256 bits)",
    device_type: Cpu,
    ...
}
```

Despite an NVIDIA T550 (discrete) and Intel Iris Xe (integrated) being available.

## Fix

This PR contains two independent, incremental commits:

### Commit 1: Trust DMA-BUF device preference without probing surface

When the Wayland compositor provides DMA-BUF feedback with vendor/device IDs that match an enumerated adapter, select it directly without the redundant `is_surface_supported()` probe. The DMA-BUF feedback already guarantees which device the compositor wants, and the surface will be (re-)created on the chosen adapter later anyway.

### Commit 2: Retry adapter selection without surface when only CPU adapter found

When `request_adapter()` returns only a CPU software rasterizer, assume that real GPUs were falsely rejected by the stale surface and retry without the `compatible_surface` constraint. This lets wgpu's power-preference ranking pick the best real GPU available.

If the surface-less retry also yields nothing, the code falls back to whatever the original surface-constrained attempt returned (possibly the CPU adapter), so **behaviour is never worse than before**.

## Edge cases considered

- **Systems with only a CPU adapter** (e.g. VMs without GPU passthrough): the retry produces the same CPU result and it is used as expected.
- **Systems where DMA-BUF feedback is unavailable** (e.g. layer-shell applets where `get_wayland_device_ids` returns `None`): Commit 1 is skipped, Commit 2 handles the fallback.
- **Systems where the surface is valid**: `request_adapter` returns a real GPU on the first try, the CPU check is `false`, and the existing code path is taken with no behavioural change.

## Testing

Tested on a hybrid GPU laptop (NVIDIA T550 + Intel Iris Xe, driver 580.119.02, Mesa 25.3.5) running COSMIC desktop on Wayland. Before this fix, the applet always selected llvmpipe. After:

```
WARN  iced_wgpu::window::compositor: adapter selection: surface-compatible pick is
      llvmpipe (LLVM 21.1.8, 256 bits); retrying without surface constraint

Selected: AdapterInfo {
    name: "NVIDIA T550 Laptop GPU",
    device_type: DiscreteGpu,
    backend: Vulkan,
    ...
}

---

## Rebase note

Rebased onto current `pop-os/iced` `master`. Besides the two wgpu commits above, this branch also carries a third, independent commit — **`fix(list): repair event dispatch and horizontal sizing in virtual List widget`** — which fixes the virtual `List` silently dropping all child events (lazy `.map()` never consumed; `visible_elements` empty during the pre-`RedrawRequested` input batch) and reporting `Length::Shrink` width instead of `Fill`. Happy to split it into its own PR if preferred.

## Contribution checklist (COSMIC policy)

- [x] **I have disclosed use of any AI generated code in my commit messages.** These commits were developed with AI assistance (Claude, Anthropic), disclosed via an `Assisted-by:` trailer on each commit.
- [x] **I understand these changes in full and will be able to respond to review comments.** The diagnosis, approach, and edge cases are mine; the AI assisted with drafting. I can explain and defend every line and will iterate on review.
- [x] My change is accurately described in the commit messages.
- [x] My contribution is tested and working as described (hybrid NVIDIA + Intel Wayland laptop; virtual List exercised in a COSMIC applet).
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
