### PR TITLE
Use `request_ime_update()` instead of `set_ime_*()` for further surrounding text support in IME

### DIFF
--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -2,6 +2,9 @@ mod state;
 
 use state::State;
 use winit::dpi::PhysicalPosition;
+use winit::window::{
+    ImeCapabilities, ImeEnableRequest, ImeHint, ImeRequest, ImeRequestData,
+};
 
 pub use crate::core::window::{Event, Id, RedrawRequest, Settings};
 
@@ -317,10 +320,6 @@ where
         cursor: Rectangle,
         purpose: input_method::Purpose,
     ) {
-        if self.ime_state.is_none() {
-            self.raw.set_ime_allowed(true);
-        }
-
         if self.ime_state != Some((cursor, purpose)) {
             // Specify only the bottom-left position of the cursor on Linux
             // because fcitx5 doesn't work well with cursor areas of
@@ -332,11 +331,29 @@ where
                 } else {
                     (cursor.y, cursor.height)
                 };
-            self.raw.set_ime_cursor_area(
-                LogicalPosition::new(cursor.x, cursor_y).into(),
-                LogicalSize::new(cursor.width, cursor_height).into(),
-            );
-            self.raw.set_ime_purpose(conversion::ime_purpose(purpose));
+            let request_data = ImeRequestData::default()
+                .with_cursor_area(
+                    LogicalPosition::new(cursor.x, cursor_y).into(),
+                    LogicalSize::new(cursor.width, cursor_height).into(),
+                )
+                .with_hint_and_purpose(
+                    ImeHint::NONE,
+                    conversion::ime_purpose(purpose),
+                );
+
+            let request = if self.ime_state.is_none() {
+                let caps = ImeCapabilities::new()
+                    .with_cursor_area()
+                    .with_hint_and_purpose();
+                ImeRequest::Enable(
+                    ImeEnableRequest::new(caps, request_data).unwrap(),
+                )
+            } else {
+                ImeRequest::Update(request_data)
+            };
+            self.raw
+                .request_ime_update(request)
+                .expect("Enabling may fail if IME is not supported");
 
             self.ime_state = Some((cursor, purpose));
         }
@@ -344,7 +361,9 @@ where
 
     fn disable_ime(&mut self) {
         if self.ime_state.is_some() {
-            self.raw.set_ime_allowed(false);
+            self.raw
+                .request_ime_update(ImeRequest::Disable)
+                .expect("Disable cannot fail");
             self.ime_state = None;
         }
 

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -320,43 +320,45 @@ where
         cursor: Rectangle,
         purpose: input_method::Purpose,
     ) {
-        if self.ime_state != Some((cursor, purpose)) {
-            // Specify only the bottom-left position of the cursor on Linux
-            // because fcitx5 doesn't work well with cursor areas of
-            // the top-left position and height.
-            // The candidate window hides the composing text (a.k.a. preedit).
-            let (cursor_y, cursor_height) =
-                if cfg!(not(any(target_os = "windows", target_os = "macos"))) {
-                    (cursor.y + cursor.height, 0.0)
-                } else {
-                    (cursor.y, cursor.height)
-                };
-            let request_data = ImeRequestData::default()
-                .with_cursor_area(
-                    LogicalPosition::new(cursor.x, cursor_y).into(),
-                    LogicalSize::new(cursor.width, cursor_height).into(),
-                )
-                .with_hint_and_purpose(
-                    ImeHint::NONE,
-                    conversion::ime_purpose(purpose),
-                );
-
-            let request = if self.ime_state.is_none() {
-                let caps = ImeCapabilities::new()
-                    .with_cursor_area()
-                    .with_hint_and_purpose();
-                ImeRequest::Enable(
-                    ImeEnableRequest::new(caps, request_data).unwrap(),
-                )
-            } else {
-                ImeRequest::Update(request_data)
-            };
-            self.raw
-                .request_ime_update(request)
-                .expect("Enabling may fail if IME is not supported");
-
-            self.ime_state = Some((cursor, purpose));
+        if self.ime_state == Some((cursor, purpose)) {
+            return;
         }
+
+        // Specify only the bottom-left position of the cursor on Linux
+        // because fcitx5 doesn't work well with cursor areas of
+        // the top-left position and height.
+        // The candidate window hides the composing text (a.k.a. preedit).
+        let (cursor_y, cursor_height) =
+            if cfg!(not(any(target_os = "windows", target_os = "macos"))) {
+                (cursor.y + cursor.height, 0.0)
+            } else {
+                (cursor.y, cursor.height)
+            };
+        let request_data = ImeRequestData::default()
+            .with_cursor_area(
+                LogicalPosition::new(cursor.x, cursor_y).into(),
+                LogicalSize::new(cursor.width, cursor_height).into(),
+            )
+            .with_hint_and_purpose(
+                ImeHint::NONE,
+                conversion::ime_purpose(purpose),
+            );
+
+        let request = if self.ime_state.is_none() {
+            let caps = ImeCapabilities::new()
+                .with_cursor_area()
+                .with_hint_and_purpose();
+            ImeRequest::Enable(
+                ImeEnableRequest::new(caps, request_data).unwrap(),
+            )
+        } else {
+            ImeRequest::Update(request_data)
+        };
+        self.raw
+            .request_ime_update(request)
+            .expect("Enabling may fail if IME is not supported");
+
+        self.ime_state = Some((cursor, purpose));
     }
 
     fn disable_ime(&mut self) {

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -4,6 +4,7 @@ use state::State;
 use winit::dpi::PhysicalPosition;
 use winit::window::{
     ImeCapabilities, ImeEnableRequest, ImeHint, ImeRequest, ImeRequestData,
+    ImeRequestError,
 };
 
 pub use crate::core::window::{Event, Id, RedrawRequest, Settings};
@@ -97,6 +98,7 @@ where
                 redraw_at: None,
                 preedit: None,
                 ime_state: None,
+                ime_not_supported: false,
                 prev_dnd_destination_rectangles_count: 0,
                 viewport_version: 0,
                 redraw_requested: false,
@@ -206,6 +208,7 @@ where
     pub redraw_at: Option<Instant>,
     preedit: Option<Preedit<P::Renderer>>,
     ime_state: Option<(Rectangle, input_method::Purpose)>,
+    ime_not_supported: bool,
     pub(crate) redraw_requested: bool,
     pub resize_enabled: bool,
 }
@@ -251,6 +254,10 @@ where
     }
 
     pub fn request_input_method(&mut self, input_method: InputMethod) {
+        if self.ime_not_supported {
+            return; // no-op if not supported
+        }
+
         match input_method {
             InputMethod::Disabled => {
                 self.disable_ime();
@@ -259,29 +266,35 @@ where
                 cursor,
                 purpose,
                 preedit,
-            } => {
-                self.enable_ime(cursor, purpose);
+            } => match self.enable_ime(cursor, purpose) {
+                Ok(_) => {
+                    if let Some(preedit) = preedit {
+                        if preedit.content.is_empty() {
+                            self.preedit = None;
+                        } else {
+                            let mut overlay = self
+                                .preedit
+                                .take()
+                                .unwrap_or_else(Preedit::new);
 
-                if let Some(preedit) = preedit {
-                    if preedit.content.is_empty() {
-                        self.preedit = None;
+                            overlay.update(
+                                cursor,
+                                &preedit,
+                                self.state.background_color(),
+                                &self.renderer,
+                            );
+
+                            self.preedit = Some(overlay);
+                        }
                     } else {
-                        let mut overlay =
-                            self.preedit.take().unwrap_or_else(Preedit::new);
-
-                        overlay.update(
-                            cursor,
-                            &preedit,
-                            self.state.background_color(),
-                            &self.renderer,
-                        );
-
-                        self.preedit = Some(overlay);
+                        self.preedit = None;
                     }
-                } else {
-                    self.preedit = None;
                 }
-            }
+                Err(_) => {
+                    // may be failed if the system doesn't support IMEs.
+                    self.ime_not_supported = true;
+                }
+            },
         }
     }
 
@@ -319,9 +332,9 @@ where
         &mut self,
         cursor: Rectangle,
         purpose: input_method::Purpose,
-    ) {
+    ) -> Result<(), ImeRequestError> {
         if self.ime_state == Some((cursor, purpose)) {
-            return;
+            return Ok(());
         }
 
         // Specify only the bottom-left position of the cursor on Linux
@@ -354,11 +367,9 @@ where
         } else {
             ImeRequest::Update(request_data)
         };
-        self.raw
-            .request_ime_update(request)
-            .expect("Enabling may fail if IME is not supported");
-
+        self.raw.request_ime_update(request)?;
         self.ime_state = Some((cursor, purpose));
+        Ok(())
     }
 
     fn disable_ime(&mut self) {


### PR DESCRIPTION
Context: https://github.com/pop-os/iced/pull/292#issuecomment-4147509077

If we want to support the IME surrounding text handling earlier than upstream iced, we need to make use of a new and richer IME API of newer winit version in advance.

https://docs.rs/winit/0.31.0-beta.2/winit/window/trait.Window.html#tymethod.request_ime_update

This is a refactor PR of doing that.