### PR TITLE
Cache raster uploads by physical draw size

### DIFF
--- a/tiny_skia/src/raster.rs
+++ b/tiny_skia/src/raster.rs
@@ -1,10 +1,14 @@
 use crate::core::image as raster;
 use crate::core::{Rectangle, Size};
 use crate::graphics;
+use crate::graphics::image::image_rs;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
 use std::collections::hash_map;
+use std::ops::Deref;
+
+type SourceImage = image_rs::ImageBuffer<image_rs::Rgba<u8>, raster::Bytes>;
 
 #[derive(Debug)]
 pub struct Pipeline {
@@ -23,7 +27,7 @@ impl Pipeline {
         handle: &raster::Handle,
     ) -> Result<raster::Allocation, raster::Error> {
         let mut cache = self.cache.borrow_mut();
-        let image = cache.allocate(handle)?;
+        let image = cache.source(handle).ok_or(raster::Error::Empty)?;
 
         #[allow(unsafe_code)]
         Ok(unsafe {
@@ -33,7 +37,7 @@ impl Pipeline {
 
     pub fn dimensions(&self, handle: &raster::Handle) -> Option<Size<u32>> {
         let mut cache = self.cache.borrow_mut();
-        let image = cache.allocate(handle).ok()?;
+        let image = cache.source(handle)?;
 
         Some(Size::new(image.width(), image.height()))
     }
@@ -50,8 +54,12 @@ impl Pipeline {
         border_radius: [f32; 4],
     ) {
         let mut cache = self.cache.borrow_mut();
+        let target_size = Size::new(
+            bounds.width.ceil().max(1.0) as u32,
+            bounds.height.ceil().max(1.0) as u32,
+        );
 
-        let Ok(mut image) = cache.allocate(handle) else {
+        let Ok(mut image) = cache.allocate(handle, target_size) else {
             return;
         };
 
@@ -108,51 +116,59 @@ impl Pipeline {
 
 #[derive(Debug, Default)]
 struct Cache {
-    entries: FxHashMap<raster::Id, Option<Entry>>,
-    hits: FxHashSet<raster::Id>,
+    sources: FxHashMap<raster::Id, Option<SourceImage>>,
+    entries: FxHashMap<UploadKey, Option<Entry>>,
+    source_hits: FxHashSet<raster::Id>,
+    entry_hits: FxHashSet<UploadKey>,
 }
 
 impl Cache {
+    pub fn source(&mut self, handle: &raster::Handle) -> Option<&SourceImage> {
+        let id = handle.id();
+
+        if let hash_map::Entry::Vacant(entry) = self.sources.entry(id) {
+            let _ = entry.insert(graphics::image::load(handle).ok());
+        }
+
+        let _ = self.source_hits.insert(id);
+        self.sources.get(&id).and_then(Option::as_ref)
+    }
+
     pub fn allocate(
         &mut self,
         handle: &raster::Handle,
+        target_size: Size<u32>,
     ) -> Result<tiny_skia::PixmapRef<'_>, raster::Error> {
-        let id = handle.id();
+        let key = UploadKey::new(handle.id(), target_size);
+        let _ = self.source_hits.insert(handle.id());
+        let _ = self.entry_hits.insert(key);
 
-        if let hash_map::Entry::Vacant(entry) = self.entries.entry(id) {
-            let image = match graphics::image::load(handle) {
-                Ok(image) => image,
-                Err(error) => {
-                    let _ = entry.insert(None);
-
-                    return Err(error);
-                }
+        if !self.entries.contains_key(&key) {
+            let image = self.source(handle).ok_or(raster::Error::Empty)?;
+            let upload_size = upload_size(image, target_size);
+            let resized = if upload_size.width == image.width()
+                && upload_size.height == image.height()
+            {
+                None
+            } else {
+                Some(image_rs::imageops::resize(
+                    image,
+                    upload_size.width,
+                    upload_size.height,
+                    image_rs::imageops::FilterType::Lanczos3,
+                ))
             };
 
-            if image.width() == 0 || image.height() == 0 {
-                return Err(raster::Error::Empty);
-            }
+            let uploaded = if let Some(resized) = resized.as_ref() {
+                entry_from_image(resized)
+            } else {
+                entry_from_image(image)
+            };
 
-            let mut buffer =
-                vec![0u32; image.width() as usize * image.height() as usize];
-
-            for (i, pixel) in image.pixels().enumerate() {
-                let [r, g, b, a] = pixel.0;
-
-                buffer[i] = bytemuck::cast(
-                    tiny_skia::ColorU8::from_rgba(b, g, r, a).premultiply(),
-                );
-            }
-
-            let _ = entry.insert(Some(Entry {
-                width: image.width(),
-                height: image.height(),
-                pixels: buffer,
-            }));
+            let _ = self.entries.insert(key, uploaded);
         }
 
-        let _ = self.hits.insert(id);
-        let Some(ret) = self.entries.get(&id).unwrap().as_ref().map(|entry| {
+        let Some(ret) = self.entries.get(&key).unwrap().as_ref().map(|entry| {
             tiny_skia::PixmapRef::from_bytes(
                 bytemuck::cast_slice(&entry.pixels),
                 entry.width,
@@ -167,8 +183,10 @@ impl Cache {
     }
 
     fn trim(&mut self) {
-        self.entries.retain(|key, _| self.hits.contains(key));
-        self.hits.clear();
+        self.sources.retain(|key, _| self.source_hits.contains(key));
+        self.entries.retain(|key, _| self.entry_hits.contains(key));
+        self.source_hits.clear();
+        self.entry_hits.clear();
     }
 }
 
@@ -177,6 +195,58 @@ struct Entry {
     width: u32,
     height: u32,
     pixels: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct UploadKey {
+    image_id: raster::Id,
+    width: u32,
+    height: u32,
+}
+
+impl UploadKey {
+    fn new(image_id: raster::Id, target_size: Size<u32>) -> Self {
+        Self {
+            image_id,
+            width: target_size.width.max(1),
+            height: target_size.height.max(1),
+        }
+    }
+}
+
+fn upload_size(image: &SourceImage, target_size: Size<u32>) -> Size<u32> {
+    Size::new(
+        target_size.width.max(1).min(image.width()),
+        target_size.height.max(1).min(image.height()),
+    )
+}
+
+fn entry_from_image<Pixels>(
+    image: &image_rs::ImageBuffer<image_rs::Rgba<u8>, Pixels>,
+) -> Option<Entry>
+where
+    Pixels: Deref<Target = [u8]>,
+{
+    if image.width() == 0 || image.height() == 0 {
+        return None;
+    }
+
+    let mut pixels =
+        vec![0u32; image.width() as usize * image.height() as usize];
+
+    for (i, pixel) in image.pixels().enumerate() {
+        let [r, g, b, a] = pixel.0;
+
+        pixels[i] = bytemuck::cast(
+            tiny_skia::ColorU8::from_rgba(b, g, r, a).premultiply(),
+        );
+    }
+
+    Some(Entry {
+        width: image.width(),
+        height: image.height(),
+        pixels,
+    })
 }
 
 // https://users.rust-lang.org/t/how-to-trim-image-to-circle-image-without-jaggy/70374/2

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -57,30 +57,45 @@ impl Cache {
     ) {
         use crate::image::raster::Memory;
 
+        self.receive();
+
+        if let Some(memory) = self.raster.cache.get_mut(handle) {
+            match memory {
+                Memory::Host(image) => {
+                    let size = Size::new(image.width(), image.height());
+
+                    if let Some(device) =
+                        self.raster.cache.get_entry(handle, size)
+                    {
+                        if let Some(allocation) = device
+                            .allocation
+                            .as_ref()
+                            .and_then(core::image::Allocation::upgrade)
+                        {
+                            callback(Ok(allocation));
+                            return;
+                        }
+
+                        #[allow(unsafe_code)]
+                        let allocation =
+                            unsafe { core::image::allocate(handle, size) };
+
+                        device.allocation = Some(allocation.downgrade());
+                        callback(Ok(allocation));
+                        return;
+                    }
+                }
+                Memory::Error(error) => {
+                    callback(Err(error.clone()));
+                    return;
+                }
+            }
+        }
+
         let callback = Box::new(callback);
 
         if let Some(callbacks) = self.raster.pending.get_mut(&handle.id()) {
             callbacks.push(callback);
-            return;
-        }
-
-        if let Some(Memory::Device {
-            allocation, entry, ..
-        }) = self.raster.cache.get_mut(handle)
-        {
-            if let Some(allocation) = allocation
-                .as_ref()
-                .and_then(core::image::Allocation::upgrade)
-            {
-                callback(Ok(allocation));
-                return;
-            }
-
-            #[allow(unsafe_code)]
-            let new = unsafe { core::image::allocate(handle, entry.size()) };
-            *allocation = Some(new.downgrade());
-            callback(Ok(new));
-
             return;
         }
 
@@ -99,34 +114,61 @@ impl Cache {
     ) -> Result<core::image::Allocation, core::image::Error> {
         use crate::image::raster::Memory;
 
+        self.receive();
+
         if !self.raster.cache.contains(handle) {
             self.raster.cache.insert(handle, Memory::load(handle));
         }
 
         match self.raster.cache.get_mut(handle).unwrap() {
             Memory::Host(image) => {
+                let size = Size::new(image.width(), image.height());
+
+                if let Some(device_entry) =
+                    self.raster.cache.get_entry(handle, size)
+                {
+                    if let Some(allocation) = device_entry
+                        .allocation
+                        .as_ref()
+                        .and_then(core::image::Allocation::upgrade)
+                    {
+                        return Ok(allocation);
+                    }
+
+                    #[allow(unsafe_code)]
+                    let allocation =
+                        unsafe { core::image::allocate(handle, size) };
+
+                    device_entry.allocation = Some(allocation.downgrade());
+
+                    return Ok(allocation);
+                }
+
                 let mut encoder = device.create_command_encoder(
                     &wgpu::CommandEncoderDescriptor {
                         label: Some("raster image upload"),
                     },
                 );
 
-                let entry = self.atlas.upload(
-                    device,
-                    &mut encoder,
-                    &mut self.raster.belt,
-                    image.width(),
-                    image.height(),
-                    image,
-                );
+                if self
+                    .raster
+                    .cache
+                    .upload(
+                        device,
+                        &mut encoder,
+                        &mut self.raster.belt,
+                        handle,
+                        size,
+                        &mut self.atlas,
+                    )
+                    .is_none()
+                {
+                    return Err(core::image::Error::OutOfMemory);
+                }
 
                 self.raster.belt.finish();
                 let submission = queue.submit([encoder.finish()]);
                 self.raster.belt.recall();
-
-                let Some(entry) = entry else {
-                    return Err(core::image::Error::OutOfMemory);
-                };
 
                 let _ = device.poll(wgpu::PollType::Wait {
                     submission_index: Some(submission),
@@ -134,41 +176,15 @@ impl Cache {
                 });
 
                 #[allow(unsafe_code)]
-                let allocation = unsafe {
-                    core::image::allocate(
-                        handle,
-                        Size::new(image.width(), image.height()),
-                    )
-                };
+                let allocation = unsafe { core::image::allocate(handle, size) };
 
-                self.raster.cache.insert(
-                    handle,
-                    Memory::Device {
-                        entry,
-                        bind_group: None,
-                        allocation: Some(allocation.downgrade()),
-                    },
-                );
-
-                Ok(allocation)
-            }
-            Memory::Device {
-                entry, allocation, ..
-            } => {
-                if let Some(allocation) = allocation
-                    .as_ref()
-                    .and_then(core::image::Allocation::upgrade)
+                if let Some(device_entry) =
+                    self.raster.cache.get_entry(handle, size)
                 {
-                    return Ok(allocation);
+                    device_entry.allocation = Some(allocation.downgrade());
                 }
 
-                #[allow(unsafe_code)]
-                let new =
-                    unsafe { core::image::allocate(handle, entry.size()) };
-
-                *allocation = Some(new.downgrade());
-
-                Ok(new)
+                Ok(allocation)
             }
             Memory::Error(error) => Err(error.clone()),
         }
@@ -206,12 +222,11 @@ impl Cache {
         encoder: &mut wgpu::CommandEncoder,
         belt: &mut wgpu::util::StagingBelt,
         handle: &core::image::Handle,
+        target_size: Size<u32>,
     ) -> Option<(&atlas::Entry, &Arc<wgpu::BindGroup>)> {
-        use crate::image::raster::Memory;
-
         self.receive();
 
-        let memory = load_image(
+        load_image(
             &mut self.raster.cache,
             &mut self.raster.pending,
             #[cfg(not(target_arch = "wasm32"))]
@@ -220,50 +235,22 @@ impl Cache {
             None,
         )?;
 
-        if let Memory::Device {
-            entry, bind_group, ..
-        } = memory
+        if let Some(device_entry) =
+            self.raster.cache.get_entry(handle, target_size)
         {
             return Some((
-                entry,
-                bind_group.as_ref().unwrap_or(self.atlas.bind_group()),
+                &device_entry.entry,
+                device_entry
+                    .bind_group
+                    .as_ref()
+                    .unwrap_or(self.atlas.bind_group()),
             ));
         }
 
-        let image = memory.host()?;
-
-        const MAX_SYNC_SIZE: usize = 2 * 1024 * 1024;
-
-        // TODO: Concurrent Wasm support
-        if image.len() < MAX_SYNC_SIZE || cfg!(target_arch = "wasm32") {
-            let entry = self.atlas.upload(
-                device,
-                encoder,
-                belt,
-                image.width(),
-                image.height(),
-                &image,
-            )?;
-
-            *memory = Memory::Device {
-                entry,
-                bind_group: None,
-                allocation: None,
-            };
-
-            if let Memory::Device { entry, .. } = memory {
-                return Some((entry, self.atlas.bind_group()));
-            }
-        }
-
-        if !self.raster.pending.contains_key(&handle.id()) {
-            let _ = self.raster.pending.insert(handle.id(), Vec::new());
-
-            #[cfg(not(target_arch = "wasm32"))]
-            self.worker.upload(handle, image);
-        }
-
-        None
+        self.raster
+            .cache
+            .upload(device, encoder, belt, handle, target_size, &mut self.atlas)
+            .map(|device_entry| (&device_entry.entry, self.atlas.bind_group()))
     }
 
     #[cfg(feature = "svg")]
@@ -310,21 +297,22 @@ impl Cache {
     fn receive(&mut self) {
         #[cfg(not(target_arch = "wasm32"))]
         while let Ok(work) = self.worker.try_recv() {
-            use crate::image::raster::Memory;
+            use crate::image::raster::{Device, Memory};
 
             match work {
                 worker::Work::Upload {
                     handle,
+                    image,
                     entry,
                     bind_group,
                 } => {
                     let callbacks = self.raster.pending.remove(&handle.id());
+                    let size = Size::new(image.width(), image.height());
 
                     let allocation = if let Some(callbacks) = callbacks {
                         #[allow(unsafe_code)]
-                        let allocation = unsafe {
-                            core::image::allocate(&handle, entry.size())
-                        };
+                        let allocation =
+                            unsafe { core::image::allocate(&handle, size) };
 
                         let reference = allocation.downgrade();
 
@@ -337,9 +325,11 @@ impl Cache {
                         None
                     };
 
-                    self.raster.cache.insert(
+                    self.raster.cache.insert(&handle, Memory::Host(image));
+                    self.raster.cache.insert_entry(
                         &handle,
-                        Memory::Device {
+                        size,
+                        Device {
                             entry,
                             bind_group: Some(bind_group),
                             allocation,
@@ -517,6 +507,7 @@ mod worker {
     pub enum Work {
         Upload {
             handle: image::Handle,
+            image: raster::Image,
             entry: atlas::Entry,
             bind_group: Arc<wgpu::BindGroup>,
         },
@@ -540,13 +531,20 @@ mod worker {
                 match job {
                     Job::Load(handle) => {
                         match crate::graphics::image::load(&handle) {
-                            Ok(image) => self.upload(
-                                handle,
-                                image.width(),
-                                image.height(),
-                                image.into_raw(),
-                                Shell::invalidate_layout,
-                            ),
+                            Ok(image) => {
+                                let width = image.width();
+                                let height = image.height();
+                                let rgba = image.clone().into_raw();
+
+                                self.upload(
+                                    handle,
+                                    image,
+                                    width,
+                                    height,
+                                    rgba,
+                                    Shell::invalidate_layout,
+                                )
+                            }
                             Err(error) => {
                                 let _ = self
                                     .output
@@ -579,6 +577,7 @@ mod worker {
         fn upload(
             &mut self,
             handle: image::Handle,
+            image: raster::Image,
             width: u32,
             height: u32,
             rgba: Bytes,
@@ -620,6 +619,7 @@ mod worker {
             self.queue.on_submitted_work_done(move || {
                 let _ = output.send(Work::Upload {
                     handle,
+                    image,
                     entry,
                     bind_group,
                 });

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -266,8 +266,19 @@ impl State {
                     bounds,
                     clip_bounds,
                 } => {
+                    let target_size = Size::new(
+                        (bounds.width * scale).ceil().max(1.0) as u32,
+                        (bounds.height * scale).ceil().max(1.0) as u32,
+                    );
+
                     if let Some((atlas_entry, bind_group)) = cache
-                        .upload_raster(device, encoder, belt, &image.handle)
+                        .upload_raster(
+                            device,
+                            encoder,
+                            belt,
+                            &image.handle,
+                            target_size,
+                        )
                     {
                         match atlas.as_mut() {
                             None => {

--- a/wgpu/src/image/raster.rs
+++ b/wgpu/src/image/raster.rs
@@ -13,12 +13,6 @@ pub type Image = graphics::image::Buffer;
 pub enum Memory {
     /// Image data on host
     Host(Image),
-    /// Storage entry
-    Device {
-        entry: atlas::Entry,
-        bind_group: Option<Arc<wgpu::BindGroup>>,
-        allocation: Option<Weak<image::Memory>>,
-    },
     Error(image::Error),
 }
 
@@ -37,42 +31,109 @@ impl Memory {
 
                 Size::new(width, height)
             }
-            Memory::Device { entry, .. } => entry.size(),
             Memory::Error(_) => Size::new(1, 1),
-        }
-    }
-
-    pub fn host(&self) -> Option<Image> {
-        match self {
-            Memory::Host(image) => Some(image.clone()),
-            Memory::Device { .. } | Memory::Error(_) => None,
         }
     }
 }
 
 #[derive(Debug, Default)]
 pub struct Cache {
-    map: FxHashMap<image::Id, Memory>,
-    hits: FxHashSet<image::Id>,
+    images: FxHashMap<image::Id, Memory>,
+    entries: FxHashMap<UploadKey, Device>,
+    image_hits: FxHashSet<image::Id>,
+    entry_hits: FxHashSet<UploadKey>,
     should_trim: bool,
 }
 
 impl Cache {
     pub fn get_mut(&mut self, handle: &image::Handle) -> Option<&mut Memory> {
-        let _ = self.hits.insert(handle.id());
+        let _ = self.image_hits.insert(handle.id());
 
-        self.map.get_mut(&handle.id())
+        self.images.get_mut(&handle.id())
     }
 
     pub fn insert(&mut self, handle: &image::Handle, memory: Memory) {
-        let _ = self.map.insert(handle.id(), memory);
-        let _ = self.hits.insert(handle.id());
+        let _ = self.images.insert(handle.id(), memory);
+        let _ = self.image_hits.insert(handle.id());
 
         self.should_trim = true;
     }
 
     pub fn contains(&self, handle: &image::Handle) -> bool {
-        self.map.contains_key(&handle.id())
+        self.images.contains_key(&handle.id())
+    }
+
+    pub fn get_entry(
+        &mut self,
+        handle: &image::Handle,
+        target_size: Size<u32>,
+    ) -> Option<&mut Device> {
+        let key = UploadKey::new(handle.id(), target_size);
+        let _ = self.image_hits.insert(handle.id());
+        let _ = self.entry_hits.insert(key);
+
+        self.entries.get_mut(&key)
+    }
+
+    pub fn insert_entry(
+        &mut self,
+        handle: &image::Handle,
+        target_size: Size<u32>,
+        device: Device,
+    ) {
+        let key = UploadKey::new(handle.id(), target_size);
+        let _ = self.image_hits.insert(handle.id());
+        let _ = self.entry_hits.insert(key);
+        let _ = self.entries.insert(key, device);
+
+        self.should_trim = true;
+    }
+
+    pub fn upload(
+        &mut self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
+        handle: &image::Handle,
+        target_size: Size<u32>,
+        atlas: &mut Atlas,
+    ) -> Option<&Device> {
+        let key = UploadKey::new(handle.id(), target_size);
+        let _ = self.image_hits.insert(handle.id());
+        let _ = self.entry_hits.insert(key);
+
+        if self.entries.contains_key(&key) {
+            return self.entries.get(&key);
+        }
+
+        let memory = self.get_mut(handle)?;
+        let Memory::Host(image) = memory else {
+            return None;
+        };
+
+        let upload_size = upload_size(image, target_size);
+        let entry = atlas.upload(
+            device,
+            encoder,
+            belt,
+            upload_size.width,
+            upload_size.height,
+            resized_bytes(image, upload_size)
+                .as_deref()
+                .unwrap_or(image),
+        )?;
+
+        self.insert_entry(
+            handle,
+            upload_size,
+            Device {
+                entry,
+                bind_group: None,
+                allocation: None,
+            },
+        );
+
+        self.entries.get(&key)
     }
 
     pub fn trim(
@@ -85,39 +146,86 @@ impl Cache {
             return;
         }
 
-        let hits = &self.hits;
+        let image_hits = &self.image_hits;
+        let entry_hits = &self.entry_hits;
 
-        self.map.retain(|id, memory| {
-            // Retain active allocations
-            if let Memory::Device { allocation, .. } = memory
-                && allocation
-                    .as_ref()
-                    .is_some_and(|allocation| allocation.strong_count() > 0)
+        self.images.retain(|id, _| image_hits.contains(id));
+
+        self.entries.retain(|key, device| {
+            if device
+                .allocation
+                .as_ref()
+                .is_some_and(|allocation| allocation.strong_count() > 0)
             {
                 return true;
             }
 
-            let retain = hits.contains(id);
+            let retain = entry_hits.contains(key);
 
             if !retain {
-                log::debug!("Dropping image allocation: {id:?}");
+                log::debug!("Dropping image allocation: {key:?}");
 
-                if let Memory::Device {
-                    entry, bind_group, ..
-                } = memory
-                {
-                    if let Some(bind_group) = bind_group.take() {
-                        on_drop(bind_group);
-                    } else {
-                        atlas.remove(entry);
-                    }
+                if let Some(bind_group) = device.bind_group.take() {
+                    on_drop(bind_group);
+                } else {
+                    atlas.remove(&device.entry);
                 }
             }
 
             retain
         });
 
-        self.hits.clear();
+        self.image_hits.clear();
+        self.entry_hits.clear();
         self.should_trim = false;
     }
+}
+
+#[derive(Debug)]
+pub struct Device {
+    pub entry: atlas::Entry,
+    pub bind_group: Option<Arc<wgpu::BindGroup>>,
+    pub allocation: Option<Weak<image::Memory>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct UploadKey {
+    image_id: image::Id,
+    width: u32,
+    height: u32,
+}
+
+impl UploadKey {
+    fn new(image_id: image::Id, target_size: Size<u32>) -> Self {
+        Self {
+            image_id,
+            width: target_size.width.max(1),
+            height: target_size.height.max(1),
+        }
+    }
+}
+
+fn upload_size(image: &Image, target_size: Size<u32>) -> Size<u32> {
+    Size::new(
+        target_size.width.max(1).min(image.width()),
+        target_size.height.max(1).min(image.height()),
+    )
+}
+
+fn resized_bytes(image: &Image, target_size: Size<u32>) -> Option<Vec<u8>> {
+    if target_size.width == image.width()
+        && target_size.height == image.height()
+    {
+        return None;
+    }
+
+    Some(
+        graphics::image::imageops::resize(
+            image,
+            target_size.width,
+            target_size.height,
+            graphics::image::imageops::FilterType::Lanczos3,
+        )
+        .into_raw(),
+    )
 }


### PR DESCRIPTION
## Summary

Follow-up to pop-os/libcosmic#1218.

That PR was correctly called out as the wrong layer. This moves the raster fix into the `iced` renderer, as requested in the review feedback there.

The change keeps decoded raster images in the renderer cache and keys atlas uploads by the physical draw size. Small surfaces can then reuse a downsampled upload that matches the actual target size instead of always sampling from the original source image.

## Why

Third-party app icons in small COSMIC surfaces, especially the dock, can look rough when the renderer only reuses a single upload at the source image size.

Caching raster uploads by physical size lets the renderer prefilter the image once with `Lanczos3` and then reuse that result across frames.

## What changed

- keep decoded raster images available in the `wgpu` raster cache
- cache `wgpu` atlas uploads by `(image id, physical width, physical height)`
- apply the same size-aware raster caching in `tiny-skia`
- leave the SVG path unchanged

## Validation

- `cargo check -p iced_wgpu -p iced_tiny_skia`
- live COSMIC dock validation against the applet-pinned `iced` snapshot using the same renderer-side size-aware cache approach

The current stock applet workspace still pins an older `iced` snapshot, so the live system verification was done against the equivalent renderer patch on that pinned tree before forward-porting it here.
