### PR TITLE
Regression fix for bounds check bug where images > 2048px could have data missing from the bottom right corner

### DIFF
--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -347,7 +347,15 @@ impl Atlas {
         let stride = PIXEL * w;
 
         // bounds check for source pixels to fragment
-        if pixels.len() < offset + PIXEL * image_width as usize * h {
+        // The upload loop accesses rows 0..h; the last row starts at
+        // `offset + (h-1) * PIXEL * image_width` and reads `stride` bytes.
+        // Using `h` instead of `h-1` over-estimates by one full image_width
+        // row, causing false positives for bottom-right fragments whose
+        // x-offset is non-zero and whose bottom edge reaches the image edge.
+        if h > 0
+            && pixels.len()
+                < offset + (h - 1) * PIXEL * image_width as usize + stride
+        {
             return;
         }
 


### PR DESCRIPTION
After updating yesterday to the latest libcosmic widgets for an app I'm working on that deals with photos, I saw that some of my larger photos were missing info from their bottom right corner.  Smaller images were all fine, as were thumbnails that I created from the larger images, which was puzzling, because I'd originally thought it was an image decoding problem.  

I traced it back to this bounds check that was added in the pop os fork of iced with #296, which it looks like doesn't account for fragments that started on the last row, basically.  The change in this patch fixes it for me locally.