### PR TITLE
Sort using more deterministic algorithm

### DIFF
--- a/core/src/point.rs
+++ b/core/src/point.rs
@@ -34,6 +34,18 @@ impl<T: Num> Point<T> {
 
         a.hypot(b)
     }
+
+    /// Computes the distance to another [`Point`], using a slower but more deterministic algorithm.
+    /// Useful for sorting algorithms.
+    pub fn distance_slow(&self, to: Self) -> T
+    where
+        T: Float,
+    {
+        let a = self.x - to.x;
+        let b = self.y - to.y;
+
+        (a * a + b * b).sqrt()
+    }
 }
 
 impl<T> From<[T; 2]> for Point<T>

--- a/graphics/src/damage.rs
+++ b/graphics/src/damage.rs
@@ -49,8 +49,8 @@ pub fn group(mut damage: Vec<Rectangle>, bounds: Rectangle) -> Vec<Rectangle> {
 
     damage.sort_by(|a, b| {
         a.center()
-            .distance(Point::ORIGIN)
-            .total_cmp(&b.center().distance(Point::ORIGIN))
+            .distance_slow(Point::ORIGIN)
+            .total_cmp(&b.center().distance_slow(Point::ORIGIN))
     });
 
     let mut output = Vec::new();


### PR DESCRIPTION
adds back #254

`hypot` while useful for most of the cases, may break sorting assumptions like deterministic comparison.
As seen in: https://github.com/pop-os/cosmic-launcher/issues/352

Add and use a new method that trades the performance for more determinism.

The core team is busy and does not have time to mentor nor babysit new contributors. If a member of the core team thinks that reviewing and understanding your work will take more time and effort than writing it from scratch by themselves, your contribution will be dismissed. It is your responsibility to communicate and figure out how to reduce the likelihood of this!

Read the contributing guidelines for more details: https://github.com/iced-rs/iced/blob/master/CONTRIBUTING.md
