### PR TITLE
fix: load image synchronously if no callback is set

### DIFF
--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -398,10 +398,16 @@ fn load_image<'a>(
             // Load RGBA handles synchronously, since it's very cheap
             cache.insert(handle, Memory::load(handle));
         } else if !pending.contains_key(&handle.id()) {
-            let _ = pending.insert(handle.id(), Vec::from_iter(callback));
+            if callback.is_some() {
+                let _ = pending.insert(handle.id(), Vec::from_iter(callback));
 
-            #[cfg(not(target_arch = "wasm32"))]
-            worker.load(handle);
+                #[cfg(not(target_arch = "wasm32"))]
+                worker.load(handle);
+            } else {
+                // Synchronous fallback when no callback is provided,
+                // needed for one-shot renders like drag icon screenshots
+                cache.insert(handle, Memory::load(handle));
+            }
         }
     }
 


### PR DESCRIPTION
I noticed this when running cosmic-app-library with wgpu feature enabled.

"ProtonVPN" is svg and is OK. But "Signal" is a PNG icon and is invisible.


https://github.com/user-attachments/assets/563e6cb6-78d3-4dfd-a2f5-adfc548c8d53

