### PR TITLE
fix: just use 0 for position of blur rectangle

### DIFF
--- a/winit/src/platform_specific/wayland/winit_window.rs
+++ b/winit/src/platform_specific/wayland/winit_window.rs
@@ -292,8 +292,8 @@ impl winit::window::Window for SctkWinitWindow {
                 self.id.inner(),
                 if blur {
                     Some(vec![iced_runtime::core::Rectangle {
-                        x: f32::MIN,
-                        y: f32::MIN,
+                        x: 0.,
+                        y: 0.,
                         width: f32::MAX,
                         height: f32::MAX,
                     }])


### PR DESCRIPTION
Blur works in the launcher and for popups after this change
