### PR TITLE
winit: Set `WindowAttributesWayland` without `cctk` feature

### DIFF
--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -178,7 +178,7 @@ pub fn window_attributes(
                     ),
             ));
         }
-        #[cfg(all(feature = "cctk", target_os = "linux"))]
+        #[cfg(target_os = "linux")]
         {
             use winit::platform::wayland::WindowAttributesWayland;
 


### PR DESCRIPTION
There doesn't seem to be any reason for this to require the `cctk` feature?

Fixes the app ID, and therefore icon, for `cosmic-sync-gui`.