### PR TITLE
fix: Forward wayland IME events in SCTK only when `single-instance` feature enabled

### DIFF
--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -37,6 +37,8 @@ cctk = [
     "xkeysym",
     "dep:cctk",
 ]
+# Prevents multiple separate process instances.
+single-instance = []
 
 
 [dependencies]

--- a/winit/src/platform_specific/wayland/handlers/text_input.rs
+++ b/winit/src/platform_specific/wayland/handlers/text_input.rs
@@ -69,6 +69,10 @@ impl Dispatch<ZwpTextInputV3, (), SctkState> for TextInputManager {
         _conn: &Connection,
         _qhandle: &QueueHandle<SctkState>,
     ) {
+        if cfg!(not(feature = "single-instance")) {
+            return;
+        }
+
         let kbd_focus =
             match state.seats.iter_mut().find_map(|s| s.kbd_focus.clone()) {
                 Some(surface) => surface,


### PR DESCRIPTION
prerequisite change for fix of
- https://github.com/pop-os/libcosmic/issues/1251

Please read dependee PR's description for context

- https://github.com/pop-os/libcosmic/pull/1252

---

The core team is busy and does not have time to mentor nor babysit new contributors. If a member of the core team thinks that reviewing and understanding your work will take more time and effort than writing it from scratch by themselves, your contribution will be dismissed. It is your responsibility to communicate and figure out how to reduce the likelihood of this!

Read the contributing guidelines for more details: https://github.com/iced-rs/iced/blob/master/CONTRIBUTING.md
