### PR TITLE
Update to wgpu 28 and pin cosmic-text 0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,8 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "cosmic-text"
-version = "0.18.2"
-source = "git+https://github.com/pop-os/cosmic-text.git#4d74f795cc771fdcc7ea0f9cacba63fcf036fad6"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be17b688510d934ce13f48a2beba700e11583e281e0fda99c22bb256a14eda73"
 dependencies = [
  "bitflags 2.11.0",
  "fontdb",
@@ -1439,7 +1446,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "cryoglyph"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/glyphon.git?tag=cosmic-0.14#c49de15bce4d8254ac136d1be9911960cc85ce12"
+source = "git+https://github.com/iced-rs/cryoglyph.git?rev=e429a025df36ab8145708acb309080ae3deec17a#e429a025df36ab8145708acb309080ae3deec17a"
 dependencies = [
  "cosmic-text",
  "etagere",
@@ -1561,7 +1568,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1789,7 +1796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2292,7 +2299,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2404,34 +2411,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.11.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "gpu-allocator"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
 dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
  "log",
  "presser",
- "thiserror 1.0.69",
- "windows 0.58.0",
+ "thiserror 2.0.18",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -2699,6 +2689,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -3478,7 +3470,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3536,7 +3528,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4045,9 +4037,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
+checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
 dependencies = [
  "bitflags 2.11.0",
  "block",
@@ -4193,9 +4185,9 @@ checksum = "13d2233c9842d08cfe13f9eac96e207ca6a2ea10b80259ebe8ad0268be27d2af"
 
 [[package]]
 name = "naga"
-version = "27.0.3"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
+checksum = "618f667225063219ddfc61251087db8a9aec3c3f0950c916b614e403486f1135"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -4300,7 +4292,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5706,7 +5698,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5719,7 +5711,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6334,7 +6326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6628,7 +6620,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7167,7 +7159,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7823,12 +7815,13 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "27.0.1"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
+checksum = "f9cb534d5ffd109c7d1135f34cdae29e60eab94855a625dcfe1705f8bc7ad79f"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.0",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "document-features",
@@ -7852,9 +7845,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "27.0.3"
+version = "28.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
+checksum = "d23f4642f53f666adcfd2d3218ab174d1e6681101aef18696b90cbe64d1c10f9"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -7885,45 +7878,45 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
+checksum = "87b7b696b918f337c486bf93142454080a32a37832ba8a31e4f48221890047da"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
+checksum = "34b251c331f84feac147de3c4aa3aa45112622a95dd7ee1b74384fa0458dbd79"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-wasm"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1027dcf3b027a877e44819df7ceb0e2e98578830f8cd34cd6c3c7c2a7a50b7"
+checksum = "12a2cf578ce8d7d50d0e63ddc2345c7dcb599f6eb90b888813406ea78b9b7010"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
+checksum = "68ca976e72b2c9964eb243e281f6ce7f14a514e409920920dcda12ae40febaae"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "27.0.4"
+version = "28.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
+checksum = "44d6cb474beb218824dcc9e1ce679d973f719262789bfb27407da560cac20eeb"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -7937,7 +7930,6 @@ dependencies = [
  "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
- "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
  "hashbrown 0.16.1",
@@ -7964,21 +7956,20 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "27.0.1"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
+checksum = "e18308757e594ed2cd27dddbb16a139c42a683819d32a2e0b1b0167552f5840c"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
  "js-sys",
  "log",
- "thiserror 2.0.18",
  "web-sys",
 ]
 
@@ -8004,7 +7995,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8035,16 +8026,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -8100,19 +8081,6 @@ dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
  "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -8177,17 +8145,6 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
@@ -8202,17 +8159,6 @@ name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8284,15 +8230,6 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -8307,16 +8244,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ repository = "https://github.com/iced-rs/iced"
 homepage = "https://iced.rs"
 categories = ["gui"]
 keywords = ["gui", "ui", "graphics", "interface", "widgets"]
-rust-version = "1.89"
+rust-version = "1.92"
 
 [workspace.dependencies]
 iced = { version = "0.14.0", path = "." }
@@ -238,10 +238,9 @@ async-std = "1.0"
 bitflags = "2.5"
 bytemuck = { version = "1.0", features = ["derive"] }
 bytes = "1.6"
-cosmic-text = { git = "https://github.com/pop-os/cosmic-text.git" }
-# cosmic-text = "0.10"
+cosmic-text = "0.19"
+cryoglyph = { git = "https://github.com/iced-rs/cryoglyph.git", rev = "e429a025df36ab8145708acb309080ae3deec17a" }
 dark-light = "1.0"
-cryoglyph = { package = "cryoglyph", git = "https://github.com/pop-os/glyphon.git", tag = "cosmic-0.14" }
 resvg = "0.45"
 web-sys = "0.3.69"
 guillotiere = "0.6"
@@ -288,7 +287,7 @@ url = "2.5"
 wasm-bindgen-futures = "0.4"
 wasmtimer = "0.4.2"
 web-time = "1.1"
-wgpu = { version = "27.0", default-features = false, features = [
+wgpu = { version = "28.0", default-features = false, features = [
     "std",
     "wgsl",
 ] }

--- a/examples/custom_shader/src/scene/pipeline.rs
+++ b/examples/custom_shader/src/scene/pipeline.rs
@@ -140,7 +140,7 @@ impl Pipeline {
             address_mode_w: wgpu::AddressMode::ClampToEdge,
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::MipmapFilterMode::Linear,
             ..Default::default()
         });
 
@@ -223,7 +223,7 @@ impl Pipeline {
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("cubes pipeline layout"),
                 bind_group_layouts: &[&uniform_bind_group_layout],
-                push_constant_ranges: &[],
+                immediate_size: 0,
             });
 
         let shader =
@@ -280,7 +280,7 @@ impl Pipeline {
                     compilation_options:
                         wgpu::PipelineCompilationOptions::default(),
                 }),
-                multiview: None,
+                multiview_mask: None,
                 cache: None,
             });
 
@@ -388,6 +388,7 @@ impl Pipeline {
                     ),
                     timestamp_writes: None,
                     occlusion_query_set: None,
+                    multiview_mask: None,
                 });
 
             pass.set_viewport(
@@ -478,7 +479,7 @@ impl DepthPipeline {
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("cubes.depth_pipeline.layout"),
                 bind_group_layouts: &[&bind_group_layout],
-                push_constant_ranges: &[],
+                immediate_size: 0,
             });
 
         let shader =
@@ -520,7 +521,7 @@ impl DepthPipeline {
                     compilation_options:
                         wgpu::PipelineCompilationOptions::default(),
                 }),
-                multiview: None,
+                multiview_mask: None,
                 cache: None,
             });
 
@@ -586,6 +587,7 @@ impl DepthPipeline {
             ),
             timestamp_writes: None,
             occlusion_query_set: None,
+            multiview_mask: None,
         });
 
         pass.set_viewport(

--- a/examples/integration/src/scene.rs
+++ b/examples/integration/src/scene.rs
@@ -43,6 +43,7 @@ impl Scene {
             depth_stencil_attachment: None,
             timestamp_writes: None,
             occlusion_query_set: None,
+            multiview_mask: None,
         })
     }
 
@@ -64,8 +65,8 @@ fn build_pipeline(
     let pipeline_layout =
         device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: None,
-            push_constant_ranges: &[],
             bind_group_layouts: &[],
+            immediate_size: 0,
         });
 
     device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -101,7 +102,7 @@ fn build_pipeline(
             mask: !0,
             alpha_to_coverage_enabled: false,
         },
-        multiview: None,
+        multiview_mask: None,
         cache: None,
     })
 }

--- a/wgpu/src/buffer.rs
+++ b/wgpu/src/buffer.rs
@@ -63,7 +63,6 @@ impl<T: bytemuck::Pod> Buffer<T> {
     /// Returns the size of the written bytes.
     pub fn write(
         &mut self,
-        device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
         belt: &mut wgpu::util::StagingBelt,
         offset: usize,
@@ -79,7 +78,6 @@ impl<T: bytemuck::Pod> Buffer<T> {
                 &self.raw,
                 (offset + bytes_written) as u64,
                 MAX_WRITE_SIZE_U64,
-                device,
             )
             .copy_from_slice(
                 &bytes[bytes_written..bytes_written + MAX_WRITE_SIZE],
@@ -100,7 +98,6 @@ impl<T: bytemuck::Pod> Buffer<T> {
             &self.raw,
             (offset + bytes_written) as u64,
             bytes_left,
-            device,
         )
         .copy_from_slice(&bytes[bytes_written..]);
 

--- a/wgpu/src/color.rs
+++ b/wgpu/src/color.rs
@@ -99,7 +99,7 @@ pub fn convert(
         device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("iced_wgpu.offscreen.blit.pipeline_layout"),
             bind_group_layouts: &[&constant_layout, &texture_layout],
-            push_constant_ranges: &[],
+            immediate_size: 0,
         });
 
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
@@ -149,7 +149,7 @@ pub fn convert(
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState::default(),
-            multiview: None,
+            multiview_mask: None,
             cache: None,
         });
 
@@ -194,6 +194,7 @@ pub fn convert(
         depth_stencil_attachment: None,
         timestamp_writes: None,
         occlusion_query_set: None,
+        multiview_mask: None,
     });
 
     pass.set_pipeline(&pipeline);

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -132,7 +132,7 @@ impl Atlas {
         match &entry {
             Entry::Contiguous(allocation) => {
                 self.upload_allocation(
-                    pixels, width, 0, allocation, device, encoder, belt,
+                    pixels, width, 0, allocation, encoder, belt,
                 );
             }
             Entry::Fragmented { fragments, .. } => {
@@ -145,7 +145,6 @@ impl Atlas {
                         width,
                         offset,
                         &fragment.allocation,
-                        device,
                         encoder,
                         belt,
                     );
@@ -312,7 +311,6 @@ impl Atlas {
         image_width: u32,
         offset: usize,
         allocation: &Allocation,
-        device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
         belt: &mut wgpu::util::StagingBelt,
     ) {
@@ -334,7 +332,6 @@ impl Atlas {
         let buffer_slice = belt.allocate(
             wgpu::BufferSize::new(total_bytes as u64).unwrap(),
             wgpu::BufferSize::new(8 * 4).unwrap(),
-            device,
         );
 
         const PIXEL: usize = 4;

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -38,7 +38,10 @@ impl Cache {
             raster: Raster {
                 cache: crate::image::raster::Cache::default(),
                 pending: HashMap::new(),
-                belt: wgpu::util::StagingBelt::new(2 * 1024 * 1024),
+                belt: wgpu::util::StagingBelt::new(
+                    device.clone(),
+                    2 * 1024 * 1024,
+                ),
             },
             #[cfg(feature = "svg")]
             vector: crate::image::vector::Cache::default(),
@@ -451,7 +454,10 @@ mod worker {
                 backend,
                 texture_layout,
                 shell: shell.clone(),
-                belt: wgpu::util::StagingBelt::new(4 * 1024 * 1024),
+                belt: wgpu::util::StagingBelt::new(
+                    device.clone(),
+                    4 * 1024 * 1024,
+                ),
                 jobs: jobs_receiver,
                 output: work_sender,
                 quit: quit_receiver,

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -45,7 +45,7 @@ impl Pipeline {
             address_mode_w: wgpu::AddressMode::ClampToEdge,
             min_filter: wgpu::FilterMode::Nearest,
             mag_filter: wgpu::FilterMode::Nearest,
-            mipmap_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
             ..Default::default()
         });
 
@@ -55,7 +55,7 @@ impl Pipeline {
             address_mode_w: wgpu::AddressMode::ClampToEdge,
             min_filter: wgpu::FilterMode::Linear,
             mag_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::MipmapFilterMode::Linear,
             ..Default::default()
         });
 
@@ -106,8 +106,8 @@ impl Pipeline {
         let layout =
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("iced_wgpu::image pipeline layout"),
-                push_constant_ranges: &[],
                 bind_group_layouts: &[&constant_layout, &texture_layout],
+                immediate_size: 0,
             });
 
         let shader =
@@ -191,7 +191,7 @@ impl Pipeline {
                     mask: !0,
                     alpha_to_coverage_enabled: false,
                 },
-                multiview: None,
+                multiview_mask: None,
                 cache: None,
             });
 
@@ -528,7 +528,6 @@ impl Layer {
             &self.uniforms,
             0,
             (bytes.len() as u64).try_into().expect("Sized uniforms"),
-            device,
         )
         .copy_from_slice(bytes);
 
@@ -539,11 +538,11 @@ impl Layer {
         let mut offset = 0;
 
         if !nearest.is_empty() {
-            offset += self.instances.write(device, encoder, belt, 0, nearest);
+            offset += self.instances.write(encoder, belt, 0, nearest);
         }
 
         if !linear.is_empty() {
-            let _ = self.instances.write(device, encoder, belt, offset, linear);
+            let _ = self.instances.write(encoder, belt, offset, linear);
         }
     }
 

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -126,6 +126,7 @@ impl Renderer {
             // It would be great if the `StagingBelt` API exposed methods
             // for introspection to detect when a resize may be worth it.
             staging_belt: wgpu::util::StagingBelt::new(
+                engine.device.clone(),
                 buffer::MAX_WRITE_SIZE as u64,
             ),
 
@@ -454,6 +455,7 @@ impl Renderer {
                 depth_stencil_attachment: None,
                 timestamp_writes: None,
                 occlusion_query_set: None,
+                multiview_mask: None,
             },
         ));
 
@@ -528,6 +530,7 @@ impl Renderer {
                         depth_stencil_attachment: None,
                         timestamp_writes: None,
                         occlusion_query_set: None,
+                        multiview_mask: None,
                     },
                 ));
             }
@@ -621,6 +624,7 @@ impl Renderer {
                             depth_stencil_attachment: None,
                             timestamp_writes: None,
                             occlusion_query_set: None,
+                            multiview_mask: None,
                         },
                     ));
                 }

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -209,7 +209,7 @@ impl Layer {
         transformation: Transformation,
         scale: f32,
     ) {
-        self.update(device, encoder, belt, transformation, scale);
+        self.update(encoder, belt, transformation, scale);
 
         if !quads.solids.is_empty() {
             self.solid.prepare(device, encoder, belt, &quads.solids);
@@ -223,7 +223,6 @@ impl Layer {
 
     pub fn update(
         &mut self,
-        device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
         belt: &mut wgpu::util::StagingBelt,
         transformation: Transformation,
@@ -237,7 +236,6 @@ impl Layer {
             &self.constants_buffer,
             0,
             (bytes.len() as u64).try_into().expect("Sized uniforms"),
-            device,
         )
         .copy_from_slice(bytes);
     }

--- a/wgpu/src/quad/gradient.rs
+++ b/wgpu/src/quad/gradient.rs
@@ -51,7 +51,7 @@ impl Layer {
         instances: &[Gradient],
     ) {
         let _ = self.instances.resize(device, instances.len());
-        let _ = self.instances.write(device, encoder, belt, 0, instances);
+        let _ = self.instances.write(encoder, belt, 0, instances);
 
         self.instance_count = instances.len();
     }
@@ -75,8 +75,8 @@ impl Pipeline {
             let layout = device.create_pipeline_layout(
                 &wgpu::PipelineLayoutDescriptor {
                     label: Some("iced_wgpu.quad.gradient.pipeline"),
-                    push_constant_ranges: &[],
                     bind_group_layouts: &[constants_layout],
+                    immediate_size: 0,
                 },
             );
 
@@ -155,7 +155,7 @@ impl Pipeline {
                         mask: !0,
                         alpha_to_coverage_enabled: false,
                     },
-                    multiview: None,
+                    multiview_mask: None,
                     cache: None,
                 },
             );

--- a/wgpu/src/quad/solid.rs
+++ b/wgpu/src/quad/solid.rs
@@ -45,7 +45,7 @@ impl Layer {
         instances: &[Solid],
     ) {
         let _ = self.instances.resize(device, instances.len());
-        let _ = self.instances.write(device, encoder, belt, 0, instances);
+        let _ = self.instances.write(encoder, belt, 0, instances);
 
         self.instance_count = instances.len();
     }
@@ -65,8 +65,8 @@ impl Pipeline {
         let layout =
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("iced_wgpu.quad.solid.pipeline"),
-                push_constant_ranges: &[],
                 bind_group_layouts: &[constants_layout],
+                immediate_size: 0,
             });
 
         let shader =
@@ -139,7 +139,7 @@ impl Pipeline {
                     mask: !0,
                     alpha_to_coverage_enabled: false,
                 },
-                multiview: None,
+                multiview_mask: None,
                 cache: None,
             });
 

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -619,7 +619,7 @@ fn prepare(
             )?;
 
             Some(cryoglyph::TextArea {
-                buffer,
+                text: buffer.layout_runs(),
                 left: position.x,
                 top: position.y,
                 scale: transformation.scale_factor()

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -313,6 +313,7 @@ fn render<'a>(
                 depth_stencil_attachment: None,
                 timestamp_writes: None,
                 occlusion_query_set: None,
+                multiview_mask: None,
             })
         };
 
@@ -425,18 +426,13 @@ impl Layer {
 
             let indices = mesh.indices();
 
-            index_offset += self.index_buffer.write(
-                device,
-                encoder,
-                belt,
-                index_offset,
-                indices,
-            );
+            index_offset +=
+                self.index_buffer
+                    .write(encoder, belt, index_offset, indices);
 
             match mesh {
                 Mesh::Solid { buffers, .. } => {
                     solid_vertex_offset += self.solid.vertices.write(
-                        device,
                         encoder,
                         belt,
                         solid_vertex_offset,
@@ -444,16 +440,14 @@ impl Layer {
                     );
 
                     solid_uniform_offset += self.solid.uniforms.write(
-                        device,
                         encoder,
                         belt,
                         solid_uniform_offset,
                         &[uniforms],
-                    );
+                    )
                 }
                 Mesh::Gradient { buffers, .. } => {
                     gradient_vertex_offset += self.gradient.vertices.write(
-                        device,
                         encoder,
                         belt,
                         gradient_vertex_offset,
@@ -461,7 +455,6 @@ impl Layer {
                     );
 
                     gradient_uniform_offset += self.gradient.uniforms.write(
-                        device,
                         encoder,
                         belt,
                         gradient_uniform_offset,
@@ -731,7 +724,7 @@ mod solid {
                 &wgpu::PipelineLayoutDescriptor {
                     label: Some("iced_wgpu.triangle.solid.pipeline_layout"),
                     bind_group_layouts: &[&constants_layout],
-                    push_constant_ranges: &[],
+                    immediate_size: 0,
                 },
             );
 
@@ -784,7 +777,7 @@ mod solid {
                         primitive: triangle::primitive_state(),
                         depth_stencil: None,
                         multisample: triangle::multisample_state(antialiasing),
-                        multiview: None,
+                        multiview_mask: None,
                         cache: None,
                     },
                 );
@@ -886,7 +879,7 @@ mod gradient {
                 &wgpu::PipelineLayoutDescriptor {
                     label: Some("iced_wgpu.triangle.gradient.pipeline_layout"),
                     bind_group_layouts: &[&constants_layout],
-                    push_constant_ranges: &[],
+                    immediate_size: 0,
                 },
             );
 
@@ -949,7 +942,7 @@ mod gradient {
                     primitive: triangle::primitive_state(),
                     depth_stencil: None,
                     multisample: triangle::multisample_state(antialiasing),
-                    multiview: None,
+                    multiview_mask: None,
                     cache: None,
                 },
             );

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -69,8 +69,8 @@ impl Pipeline {
         let layout =
             device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("iced_wgpu::triangle::msaa pipeline layout"),
-                push_constant_ranges: &[],
                 bind_group_layouts: &[&constant_layout, &texture_layout],
+                immediate_size: 0,
             });
 
         let shader =
@@ -116,7 +116,7 @@ impl Pipeline {
                     mask: !0,
                     alpha_to_coverage_enabled: false,
                 },
-                multiview: None,
+                multiview_mask: None,
                 cache: None,
             });
 
@@ -177,6 +177,7 @@ impl Pipeline {
             depth_stencil_attachment: None,
             timestamp_writes: None,
             occlusion_query_set: None,
+            multiview_mask: None,
         })
     }
 }
@@ -320,7 +321,6 @@ impl State {
                 0,
                 NonZeroU64::new(std::mem::size_of::<Ratio>() as u64)
                     .expect("non-empty ratio"),
-                device,
             )
             .copy_from_slice(bytemuck::bytes_of(&ratio));
 
@@ -351,6 +351,7 @@ impl State {
                 depth_stencil_attachment: None,
                 timestamp_writes: None,
                 occlusion_query_set: None,
+                multiview_mask: None,
             });
 
         render_pass.set_pipeline(&pipeline.raw);

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -126,6 +126,7 @@ impl Compositor {
         // if log::max_level() >= log::LevelFilter::Info {
         //     let available_adapters: Vec<_> = instance
         //         .enumerate_adapters(settings.backends)
+        //         .await
         //         .iter()
         //         .map(wgpu::Adapter::get_info)
         //         .collect();
@@ -155,6 +156,7 @@ impl Compositor {
             if let Some((vendor_id, device_id)) = ids {
                 adapter = instance
                     .enumerate_adapters(settings.backends)
+                    .await
                     .into_iter()
                     .filter(|adapter| {
                         let info = adapter.get_info();
@@ -172,6 +174,7 @@ impl Compositor {
         } else if let Ok(name) = std::env::var("WGPU_ADAPTER_NAME") {
             adapter = instance
                 .enumerate_adapters(settings.backends)
+                .await
                 .into_iter()
                 .filter(|adapter| {
                     let info = adapter.get_info();


### PR DESCRIPTION
Update to wgpu 28.
Update to rust 1.92.
Switch to upstream cryoglyph.
Pin cosmic-text to v0.19.

The update to wgpu 28 is based on https://github.com/iced-rs/iced/commit/312842ca02bcbe9ed97f97bd7ce58a5cc9eae389.
