### PR TITLE
fix(ime): flip the candidate position vertically if the bottom edge overflows bottom screen edge

### DIFF
--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -335,19 +335,9 @@ where
         }
 
         if self.ime_state != Some((cursor, purpose)) {
-            // Specify only the bottom-left position of the cursor on Linux
-            // because fcitx5 doesn't work well with cursor areas of
-            // the top-left position and height.
-            // The candidate window hides the composing text (a.k.a. preedit).
-            let (cursor_y, cursor_height) =
-                if cfg!(not(any(target_os = "windows", target_os = "macos"))) {
-                    (cursor.y + cursor.height, 0.0)
-                } else {
-                    (cursor.y, cursor.height)
-                };
             self.raw.set_ime_cursor_area(
-                LogicalPosition::new(cursor.x, cursor_y).into(),
-                LogicalSize::new(cursor.width, cursor_height).into(),
+                LogicalPosition::new(cursor.x, cursor.y).into(),
+                LogicalSize::new(cursor.width, cursor.height).into(),
             );
             self.raw.set_ime_purpose(conversion::ime_purpose(purpose));
 


### PR DESCRIPTION
Prepares to fix https://github.com/pop-os/cosmic-comp/issues/2284 for COSMIC apps.

This depends on `cosmic-comp` PR:
- https://github.com/pop-os/cosmic-comp/pull/2320

---

Basically https://github.com/pop-os/cosmic-comp/pull/2320 fixes this but we specify the IME cursor rect to 0-height after https://github.com/pop-os/iced/pull/291 for workaround cosmic-comp issue, so flipping at screen bottom edge doesn't work correctly.

As https://github.com/pop-os/cosmic-comp/pull/2320 will fix the root cause of https://github.com/pop-os/iced/pull/291, we can revert this once https://github.com/pop-os/cosmic-comp/pull/2320 merged and released the `cosmic-comp` update to users.

1. before https://github.com/pop-os/cosmic-comp/pull/2320
   - it doesn't flip the popup direction at the bottom of the screen
     <img width="440" height="292" alt="Screenshot_2026-04-25_11-20-44" src="https://github.com/user-attachments/assets/8ffd52fb-1026-45b8-a1d5-0a9b95bd25d6" />
2. after https://github.com/pop-os/cosmic-comp/pull/2320
   - it does flip vertically but doesn't respect the IME cursor area height.
   - this results in hiding the inputting text
     <img width="332" height="334" alt="Screenshot_2026-04-25_11-26-56" src="https://github.com/user-attachments/assets/1ec822aa-8429-4f07-9e12-27be7ebcaa90" />
3. after this PR
   - it filps and respect IME cursor height
     <img width="284" height="230" alt="Screenshot_2026-04-25_11-13-42" src="https://github.com/user-attachments/assets/38445b4f-0804-48f7-b373-15c8f83cb31b" />

---

Revert "fix(ime): the candidate window position of fcitx5 which does't work well with winit's set_ime_cursor_area()"

Reverts pop-os/iced#291
