### PR TITLE
wgpu: request devices with `SHADER_F16` feature

### DIFF
--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -294,7 +294,7 @@ impl Compositor {
                     label: Some(
                         "iced_wgpu::window::compositor device descriptor",
                     ),
-                    required_features: wgpu::Features::empty(),
+                    required_features: wgpu::Features::SHADER_F16,
                     required_limits: required_limits.clone(),
                     memory_hints: wgpu::MemoryHints::MemoryUsage,
                     trace: wgpu::Trace::Off,


### PR DESCRIPTION
Picked from https://github.com/iced-rs/iced/pull/3164

Fix for reported wgpu validation error panic on older NVIDIA GPUs.