### PR TITLE
Remove `max_width` limit for `rustfmt`

### DIFF
--- a/accessibility/src/a11y_tree.rs
+++ b/accessibility/src/a11y_tree.rs
@@ -25,9 +25,7 @@ impl A11yTree {
 
     /// Helper for creating an A11y tree with a single root node and some children
     pub fn node_with_child_tree(mut root: A11yNode, child_tree: Self) -> Self {
-        root.add_children(
-            child_tree.root.iter().map(|n| n.id()).cloned().collect(),
-        );
+        root.add_children(child_tree.root.iter().map(|n| n.id()).cloned().collect());
         Self {
             root: vec![root],
             children: child_tree

--- a/accessibility/src/id.rs
+++ b/accessibility/src/id.rs
@@ -36,9 +36,7 @@ impl From<Id> for A11yId {
 impl IdEq for A11yId {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (A11yId::Widget(self_), A11yId::Widget(other)) => {
-                IdEq::eq(self_, other)
-            }
+            (A11yId::Widget(self_), A11yId::Widget(other)) => IdEq::eq(self_, other),
             _ => self == other,
         }
     }
@@ -150,8 +148,7 @@ impl std::fmt::Display for Id {
 // XXX WIndow IDs are made unique by adding u32::MAX to them
 /// get window node id that won't conflict with other node ids for the duration of the program
 pub fn window_node_id() -> u64 {
-    u32::MAX as u64
-        + NEXT_WINDOW_ID.fetch_add(1, atomic::Ordering::Relaxed) as u64
+    u32::MAX as u64 + NEXT_WINDOW_ID.fetch_add(1, atomic::Ordering::Relaxed) as u64
 }
 
 // TODO refactor to make panic impossible?
@@ -189,17 +186,14 @@ impl IdEq for Internal {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Unique(l0), Self::Unique(r0)) => l0 == r0,
-            (Self::Custom(l0, l1), Self::Custom(r0, r1)) => {
-                l0 == r0 || l1 == r1
-            }
+            (Self::Custom(l0, l1), Self::Custom(r0, r1)) => l0 == r0 || l1 == r1,
             // allow custom ids to be equal to unique ids
-            (Self::Unique(l0), Self::Custom(r0, _))
-            | (Self::Custom(l0, _), Self::Unique(r0)) => l0 == r0,
+            (Self::Unique(l0), Self::Custom(r0, _)) | (Self::Custom(l0, _), Self::Unique(r0)) => {
+                l0 == r0
+            }
             (Self::Set(l0), Self::Set(r0)) => l0 == r0,
             // allow set ids to just be equal to any of their members
-            (Self::Set(l0), r) | (r, Self::Set(l0)) => {
-                l0.iter().any(|l| l == r)
-            }
+            (Self::Set(l0), r) | (r, Self::Set(l0)) => l0.iter().any(|l| l == r),
         }
     }
 }

--- a/accessibility/src/node.rs
+++ b/accessibility/src/node.rs
@@ -27,8 +27,7 @@ impl A11yNode {
     }
 
     pub fn add_children(&mut self, children: Vec<A11yId>) {
-        let mut children =
-            children.into_iter().map(|id| id.into()).collect::<Vec<_>>();
+        let mut children = children.into_iter().map(|id| id.into()).collect::<Vec<_>>();
         children.extend_from_slice(self.node.children());
         self.node.set_children(children);
     }

--- a/beacon/src/client.rs
+++ b/beacon/src/client.rs
@@ -119,8 +119,7 @@ async fn run(
     is_connected: Arc<AtomicBool>,
     mut receiver: mpsc::Receiver<Action>,
 ) {
-    let version = semver::Version::parse(env!("CARGO_PKG_VERSION"))
-        .expect("Parse package version");
+    let version = semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("Parse package version");
 
     let command_sender = {
         // Discard by default
@@ -158,8 +157,7 @@ async fn run(
                             match receive(&mut reader, &mut buffer).await {
                                 Ok(command) => {
                                     match command {
-                                        Command::RewindTo { .. }
-                                        | Command::GoLive
+                                        Command::RewindTo { .. } | Command::GoLive
                                             if !metadata.can_time_travel =>
                                         {
                                             continue;
@@ -191,17 +189,11 @@ async fn run(
                             match send(&mut writer, message).await {
                                 Ok(()) => {}
                                 Err(error) => {
-                                    if error.kind() != io::ErrorKind::BrokenPipe
-                                    {
-                                        log::warn!(
-                                            "Error sending message to server: {error}"
-                                        );
+                                    if error.kind() != io::ErrorKind::BrokenPipe {
+                                        log::warn!("Error sending message to server: {error}");
                                     }
 
-                                    is_connected.store(
-                                        false,
-                                        atomic::Ordering::Relaxed,
-                                    );
+                                    is_connected.store(false, atomic::Ordering::Relaxed);
                                     break;
                                 }
                             }
@@ -229,8 +221,7 @@ async fn run(
 pub fn server_address_from_env() -> String {
     const DEFAULT_ADDRESS: &str = "127.0.0.1:9167";
 
-    std::env::var("ICED_BEACON_SERVER_ADDRESS")
-        .unwrap_or_else(|_| String::from(DEFAULT_ADDRESS))
+    std::env::var("ICED_BEACON_SERVER_ADDRESS").unwrap_or_else(|_| String::from(DEFAULT_ADDRESS))
 }
 
 async fn _connect() -> Result<net::TcpStream, io::Error> {
@@ -243,10 +234,7 @@ async fn _connect() -> Result<net::TcpStream, io::Error> {
     Ok(stream)
 }
 
-async fn send(
-    stream: &mut net::tcp::OwnedWriteHalf,
-    message: Message,
-) -> Result<(), io::Error> {
+async fn send(stream: &mut net::tcp::OwnedWriteHalf, message: Message) -> Result<(), io::Error> {
     let bytes = bincode::serialize(&message).expect("Encode input message");
     let size = bytes.len() as u64;
 

--- a/beacon/src/span.rs
+++ b/beacon/src/span.rs
@@ -34,9 +34,7 @@ pub enum Span {
     },
 }
 
-#[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum Stage {
     Boot,
     Update,
@@ -81,18 +79,7 @@ pub mod present {
         pub images: Duration,
     }
 
-    #[derive(
-        Debug,
-        Clone,
-        Copy,
-        PartialEq,
-        Eq,
-        PartialOrd,
-        Ord,
-        Hash,
-        Serialize,
-        Deserialize,
-    )]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
     pub enum Primitive {
         Quad,
         Triangle,

--- a/benches/wgpu.rs
+++ b/benches/wgpu.rs
@@ -4,9 +4,7 @@ use criterion::{Bencher, Criterion, criterion_group, criterion_main};
 use iced::alignment;
 use iced::mouse;
 use iced::widget::{canvas, scrollable, stack, text};
-use iced::{
-    Color, Element, Font, Length, Pixels, Point, Rectangle, Size, Theme,
-};
+use iced::{Color, Element, Font, Length, Pixels, Point, Rectangle, Size, Theme};
 use iced_wgpu::Renderer;
 use iced_wgpu::wgpu;
 
@@ -23,25 +21,22 @@ pub fn wgpu_benchmark(c: &mut Criterion) {
         ..Default::default()
     });
 
-    let adapter = executor::block_on(instance.request_adapter(
-        &wgpu::RequestAdapterOptions {
-            power_preference: wgpu::PowerPreference::HighPerformance,
-            compatible_surface: None,
-            force_fallback_adapter: false,
-        },
-    ))
+    let adapter = executor::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        compatible_surface: None,
+        force_fallback_adapter: false,
+    }))
     .expect("request adapter");
 
-    let (device, queue) =
-        executor::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-            label: None,
-            required_features: wgpu::Features::empty(),
-            required_limits: wgpu::Limits::default(),
-            memory_hints: wgpu::MemoryHints::MemoryUsage,
-            trace: wgpu::Trace::Off,
-            experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        }))
-        .expect("request device");
+    let (device, queue) = executor::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: None,
+        required_features: wgpu::Features::empty(),
+        required_limits: wgpu::Limits::default(),
+        memory_hints: wgpu::MemoryHints::MemoryUsage,
+        trace: wgpu::Trace::Off,
+        experimental_features: wgpu::ExperimentalFeatures::disabled(),
+    }))
+    .expect("request device");
 
     c.bench_function("wgpu — canvas (light)", |b| {
         benchmark(b, &adapter, &device, &queue, |_| scene(10));
@@ -100,8 +95,7 @@ fn benchmark<'a>(
 
     let mut renderer = Renderer::new(engine, Font::DEFAULT, Pixels::from(16));
 
-    let viewport =
-        graphics::Viewport::with_physical_size(Size::new(3840, 2160), 2.0);
+    let viewport = graphics::Viewport::with_physical_size(Size::new(3840, 2160), 2.0);
 
     let texture = device.create_texture(&wgpu::TextureDescriptor {
         label: None,
@@ -118,8 +112,7 @@ fn benchmark<'a>(
         view_formats: &[],
     });
 
-    let texture_view =
-        texture.create_view(&wgpu::TextureViewDescriptor::default());
+    let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 
     let mut i = 0;
     let mut cache = Some(runtime::user_interface::Cache::default());
@@ -143,12 +136,7 @@ fn benchmark<'a>(
 
         cache = Some(user_interface.into_cache());
 
-        let submission = renderer.present(
-            Some(Color::BLACK),
-            format,
-            &texture_view,
-            &viewport,
-        );
+        let submission = renderer.present(Some(Color::BLACK), format, &texture_view, &viewport);
 
         let _ = device.poll(wgpu::PollType::Wait {
             submission_index: Some(submission),
@@ -208,19 +196,14 @@ fn scene<'a, Message: 'a>(n: usize) -> Element<'a, Message, Theme, Renderer> {
         .into()
 }
 
-fn layered_text<'a, Message: 'a>(
-    n: usize,
-) -> Element<'a, Message, Theme, Renderer> {
+fn layered_text<'a, Message: 'a>(n: usize) -> Element<'a, Message, Theme, Renderer> {
     stack((0..n).map(|i| text!("I am paragraph {i}!").into()))
         .width(Length::Fill)
         .height(Length::Fill)
         .into()
 }
 
-fn dynamic_text<'a, Message: 'a>(
-    n: usize,
-    i: usize,
-) -> Element<'a, Message, Theme, Renderer> {
+fn dynamic_text<'a, Message: 'a>(n: usize, i: usize) -> Element<'a, Message, Theme, Renderer> {
     const LOREM_IPSUM: &str = include_str!("ipsum.txt");
 
     scrollable(
@@ -236,10 +219,7 @@ fn dynamic_text<'a, Message: 'a>(
     .into()
 }
 
-fn advanced_shaping<'a, Message: 'a>(
-    n: usize,
-    i: usize,
-) -> Element<'a, Message, Theme, Renderer> {
+fn advanced_shaping<'a, Message: 'a>(n: usize, i: usize) -> Element<'a, Message, Theme, Renderer> {
     const LOREM_IPSUM: &str = include_str!("ipsum.txt");
 
     scrollable(

--- a/core/src/animation.rs
+++ b/core/src/animation.rs
@@ -141,10 +141,6 @@ impl Animation<bool> {
 
     /// Returns the remaining [`Duration`] of the [`Animation`].
     pub fn remaining(&self, at: Instant) -> Duration {
-        Duration::from_secs_f32(self.interpolate(
-            self.duration.as_secs_f32(),
-            0.0,
-            at,
-        ))
+        Duration::from_secs_f32(self.interpolate(self.duration.as_secs_f32(), 0.0, at))
     }
 }

--- a/core/src/background.rs
+++ b/core/src/background.rs
@@ -17,9 +17,7 @@ impl Background {
     pub fn scale_alpha(self, factor: f32) -> Self {
         match self {
             Self::Color(color) => Self::Color(color.scale_alpha(factor)),
-            Self::Gradient(gradient) => {
-                Self::Gradient(gradient.scale_alpha(factor))
-            }
+            Self::Gradient(gradient) => Self::Gradient(gradient.scale_alpha(factor)),
         }
     }
 }

--- a/core/src/clipboard.rs
+++ b/core/src/clipboard.rs
@@ -17,11 +17,7 @@ pub struct IconSurface<E> {
 pub type DynIconSurface = IconSurface<Box<dyn Any>>;
 
 impl<T: 'static, R: 'static> IconSurface<Element<'static, (), T, R>> {
-    pub fn new(
-        element: Element<'static, (), T, R>,
-        state: State,
-        offset: Vector,
-    ) -> Self {
+    pub fn new(element: Element<'static, (), T, R>, state: State, offset: Vector) -> Self {
         Self {
             element,
             state,
@@ -42,9 +38,7 @@ impl DynIconSurface {
     /// Downcast `element` to concrete type `Element<(), T, R>`
     ///
     /// Panics if type doesn't match
-    pub fn downcast<T: 'static, R: 'static>(
-        self,
-    ) -> IconSurface<Element<'static, (), T, R>> {
+    pub fn downcast<T: 'static, R: 'static>(self) -> IconSurface<Element<'static, (), T, R>> {
         IconSurface {
             element: *self
                 .element
@@ -67,11 +61,7 @@ pub trait Clipboard {
 
     /// Consider using [`read_data`] instead
     /// Reads the current content of the [`Clipboard`] as text.
-    fn read_data(
-        &self,
-        _kind: Kind,
-        _mimes: Vec<String>,
-    ) -> Option<(Vec<u8>, String)> {
+    fn read_data(&self, _kind: Kind, _mimes: Vec<String>) -> Option<(Vec<u8>, String)> {
         None
     }
 
@@ -79,9 +69,7 @@ pub trait Clipboard {
     fn write_data(
         &mut self,
         _kind: Kind,
-        _contents: ClipboardStoreData<
-            Box<dyn Send + Sync + 'static + mime::AsMimeTypes>,
-        >,
+        _contents: ClipboardStoreData<Box<dyn Send + Sync + 'static + mime::AsMimeTypes>>,
     ) {
     }
 
@@ -165,18 +153,14 @@ impl Clipboard for Null {
 }
 
 /// Reads the current content of the [`Clipboard`].
-pub fn read_data<T: AllowedMimeTypes>(
-    clipboard: &mut dyn Clipboard,
-) -> Option<T> {
+pub fn read_data<T: AllowedMimeTypes>(clipboard: &mut dyn Clipboard) -> Option<T> {
     clipboard
         .read_data(Kind::Standard, T::allowed().into())
         .and_then(|data| T::try_from(data).ok())
 }
 
 /// Reads the current content of the primary [`Clipboard`].
-pub fn read_primary_data<T: AllowedMimeTypes>(
-    clipboard: &mut dyn Clipboard,
-) -> Option<T> {
+pub fn read_primary_data<T: AllowedMimeTypes>(clipboard: &mut dyn Clipboard) -> Option<T> {
     clipboard
         .read_data(Kind::Primary, T::allowed().into())
         .and_then(|data| T::try_from(data).ok())

--- a/core/src/color.rs
+++ b/core/src/color.rs
@@ -206,9 +206,7 @@ pub enum ParseError {
     #[error(transparent)]
     ParseIntError(#[from] std::num::ParseIntError),
     /// The string is of invalid length.
-    #[error(
-        "expected hex string of length 3, 4, 6 or 8 excluding optional prefix '#', found {0}"
-    )]
+    #[error("expected hex string of length 3, 4, 6 or 8 excluding optional prefix '#', found {0}")]
     InvalidLength(usize),
 }
 
@@ -218,14 +216,12 @@ impl std::str::FromStr for Color {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let hex = s.strip_prefix('#').unwrap_or(s);
 
-        let parse_channel =
-            |from: usize, to: usize| -> Result<f32, std::num::ParseIntError> {
-                let num =
-                    usize::from_str_radix(&hex[from..=to], 16)? as f32 / 255.0;
+        let parse_channel = |from: usize, to: usize| -> Result<f32, std::num::ParseIntError> {
+            let num = usize::from_str_radix(&hex[from..=to], 16)? as f32 / 255.0;
 
-                // If we only got half a byte (one letter), expand it into a full byte (two letters)
-                Ok(if from == to { num + num * 16.0 } else { num })
-            };
+            // If we only got half a byte (one letter), expand it into a full byte (two letters)
+            Ok(if from == to { num + num * 16.0 } else { num })
+        };
 
         let val = match hex.len() {
             3 => Color::from_rgb(

--- a/core/src/element.rs
+++ b/core/src/element.rs
@@ -6,10 +6,7 @@ use crate::overlay;
 use crate::renderer;
 use crate::widget;
 use crate::widget::tree::{self, Tree};
-use crate::{
-    Border, Clipboard, Color, Layout, Length, Rectangle, Shell, Size, Vector,
-    Widget,
-};
+use crate::{Border, Clipboard, Color, Layout, Length, Rectangle, Shell, Size, Vector, Widget};
 
 use std::borrow::{Borrow, BorrowMut};
 
@@ -43,9 +40,7 @@ impl<'a, Message, Theme, Renderer> Element<'a, Message, Theme, Renderer> {
     }
 
     /// Returns a mutable reference to the [`Widget`] of the [`Element`],
-    pub fn as_widget_mut(
-        &mut self,
-    ) -> &mut dyn Widget<Message, Theme, Renderer> {
+    pub fn as_widget_mut(&mut self) -> &mut dyn Widget<Message, Theme, Renderer> {
         self.widget.as_mut()
     }
 
@@ -188,10 +183,7 @@ impl<'a, Message, Theme, Renderer> Element<'a, Message, Theme, Renderer> {
     ///     }
     /// }
     /// ```
-    pub fn map<B>(
-        self,
-        f: impl Fn(Message) -> B + 'a,
-    ) -> Element<'a, B, Theme, Renderer>
+    pub fn map<B>(self, f: impl Fn(Message) -> B + 'a) -> Element<'a, B, Theme, Renderer>
     where
         Message: 'a,
         Theme: 'a,
@@ -207,10 +199,7 @@ impl<'a, Message, Theme, Renderer> Element<'a, Message, Theme, Renderer> {
     /// This can be very useful for debugging your layout!
     ///
     /// [`Renderer`]: crate::Renderer
-    pub fn explain<C: Into<Color>>(
-        self,
-        color: C,
-    ) -> Element<'a, Message, Theme, Renderer>
+    pub fn explain<C: Into<Color>>(self, color: C) -> Element<'a, Message, Theme, Renderer>
     where
         Message: 'a,
         Theme: 'a,
@@ -222,8 +211,7 @@ impl<'a, Message, Theme, Renderer> Element<'a, Message, Theme, Renderer> {
     }
 }
 
-impl<'a, Message, Theme, Renderer>
-    Borrow<dyn Widget<Message, Theme, Renderer> + 'a>
+impl<'a, Message, Theme, Renderer> Borrow<dyn Widget<Message, Theme, Renderer> + 'a>
     for Element<'a, Message, Theme, Renderer>
 {
     fn borrow(&self) -> &(dyn Widget<Message, Theme, Renderer> + 'a) {
@@ -231,8 +219,7 @@ impl<'a, Message, Theme, Renderer>
     }
 }
 
-impl<'a, Message, Theme, Renderer>
-    Borrow<dyn Widget<Message, Theme, Renderer> + 'a>
+impl<'a, Message, Theme, Renderer> Borrow<dyn Widget<Message, Theme, Renderer> + 'a>
     for &Element<'a, Message, Theme, Renderer>
 {
     fn borrow(&self) -> &(dyn Widget<Message, Theme, Renderer> + 'a) {
@@ -240,8 +227,7 @@ impl<'a, Message, Theme, Renderer>
     }
 }
 
-impl<'a, Message, Theme, Renderer>
-    Borrow<dyn Widget<Message, Theme, Renderer> + 'a>
+impl<'a, Message, Theme, Renderer> Borrow<dyn Widget<Message, Theme, Renderer> + 'a>
     for &mut Element<'a, Message, Theme, Renderer>
 {
     fn borrow(&self) -> &(dyn Widget<Message, Theme, Renderer> + 'a) {
@@ -249,24 +235,18 @@ impl<'a, Message, Theme, Renderer>
     }
 }
 
-impl<'a, Message, Theme, Renderer>
-    BorrowMut<dyn Widget<Message, Theme, Renderer> + 'a>
+impl<'a, Message, Theme, Renderer> BorrowMut<dyn Widget<Message, Theme, Renderer> + 'a>
     for &mut Element<'a, Message, Theme, Renderer>
 {
-    fn borrow_mut(
-        &mut self,
-    ) -> &mut (dyn Widget<Message, Theme, Renderer> + 'a) {
+    fn borrow_mut(&mut self) -> &mut (dyn Widget<Message, Theme, Renderer> + 'a) {
         self.widget.borrow_mut()
     }
 }
 
-impl<'a, Message, Theme, Renderer>
-    BorrowMut<dyn Widget<Message, Theme, Renderer> + 'a>
+impl<'a, Message, Theme, Renderer> BorrowMut<dyn Widget<Message, Theme, Renderer> + 'a>
     for Element<'a, Message, Theme, Renderer>
 {
-    fn borrow_mut(
-        &mut self,
-    ) -> &mut (dyn Widget<Message, Theme, Renderer> + 'a) {
+    fn borrow_mut(&mut self) -> &mut (dyn Widget<Message, Theme, Renderer> + 'a) {
         self.widget.borrow_mut()
     }
 }
@@ -291,8 +271,7 @@ impl<'a, A, B, Theme, Renderer> Map<'a, A, B, Theme, Renderer> {
     }
 }
 
-impl<'a, A, B, Theme, Renderer> Widget<B, Theme, Renderer>
-    for Map<'a, A, B, Theme, Renderer>
+impl<'a, A, B, Theme, Renderer> Widget<B, Theme, Renderer> for Map<'a, A, B, Theme, Renderer>
 where
     Renderer: crate::Renderer + 'a,
     A: 'a,
@@ -449,10 +428,7 @@ impl<'a, Message, Theme, Renderer> Explain<'a, Message, Theme, Renderer>
 where
     Renderer: crate::Renderer,
 {
-    fn new(
-        element: Element<'a, Message, Theme, Renderer>,
-        color: Color,
-    ) -> Self {
+    fn new(element: Element<'a, Message, Theme, Renderer>, color: Color) -> Self {
         Explain { element, color }
     }
 }
@@ -586,13 +562,9 @@ where
         viewport: &Rectangle,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
-        self.element.widget.overlay(
-            tree,
-            layout,
-            renderer,
-            viewport,
-            translation,
-        )
+        self.element
+            .widget
+            .overlay(tree, layout, renderer, viewport, translation)
     }
 
     fn id(&self) -> Option<Id> {
@@ -610,17 +582,13 @@ where
         renderer: &Renderer,
         dnd_rectangles: &mut crate::clipboard::DndDestinationRectangles,
     ) {
-        self.element.widget.drag_destinations(
-            state,
-            layout,
-            renderer,
-            dnd_rectangles,
-        );
+        self.element
+            .widget
+            .drag_destinations(state, layout, renderer, dnd_rectangles);
     }
     // TODO maybe a11y_nodes
 }
-impl<'a, T, Message, Theme, Renderer> From<Option<T>>
-    for Element<'a, Message, Theme, Renderer>
+impl<'a, T, Message, Theme, Renderer> From<Option<T>> for Element<'a, Message, Theme, Renderer>
 where
     T: Into<Self>,
     Renderer: crate::Renderer,

--- a/core/src/event/wayland/output.rs
+++ b/core/src/event/wayland/output.rs
@@ -26,9 +26,7 @@ impl PartialEq for OutputEvent {
             (Self::InfoUpdate(l0), Self::InfoUpdate(r0)) => {
                 l0.id == r0.id && l0.make == r0.make && l0.model == r0.model
             }
-            _ => {
-                core::mem::discriminant(self) == core::mem::discriminant(other)
-            }
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }
     }
 }

--- a/core/src/event/wayland/overlap_notify.rs
+++ b/core/src/event/wayland/overlap_notify.rs
@@ -1,4 +1,7 @@
-use cctk::{sctk::shell::wlr_layer::Layer, wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1};
+use cctk::{
+    sctk::shell::wlr_layer::Layer,
+    wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum OverlapNotifyEvent {

--- a/core/src/gradient.rs
+++ b/core/src/gradient.rs
@@ -15,9 +15,7 @@ impl Gradient {
     /// Scales the alpha channel of the [`Gradient`] by the given factor.
     pub fn scale_alpha(self, factor: f32) -> Self {
         match self {
-            Gradient::Linear(linear) => {
-                Gradient::Linear(linear.scale_alpha(factor))
-            }
+            Gradient::Linear(linear) => Gradient::Linear(linear.scale_alpha(factor)),
         }
     }
 }
@@ -67,11 +65,10 @@ impl Linear {
     /// Any stop added after the 8th will be silently ignored.
     pub fn add_stop(mut self, offset: f32, color: Color) -> Self {
         if offset.is_finite() && (0.0..=1.0).contains(&offset) {
-            let (Ok(index) | Err(index)) =
-                self.stops.binary_search_by(|stop| match stop {
-                    None => Ordering::Greater,
-                    Some(stop) => stop.offset.total_cmp(&offset),
-                });
+            let (Ok(index) | Err(index)) = self.stops.binary_search_by(|stop| match stop {
+                None => Ordering::Greater,
+                Some(stop) => stop.offset.total_cmp(&offset),
+            });
 
             if index < 8 {
                 self.stops[index] = Some(ColorStop { offset, color });
@@ -86,10 +83,7 @@ impl Linear {
     /// Adds multiple [`ColorStop`]s to the gradient.
     ///
     /// Any stop added after the 8th will be silently ignored.
-    pub fn add_stops(
-        mut self,
-        stops: impl IntoIterator<Item = ColorStop>,
-    ) -> Self {
+    pub fn add_stops(mut self, stops: impl IntoIterator<Item = ColorStop>) -> Self {
         for stop in stops {
             self = self.add_stop(stop.offset, stop.color);
         }

--- a/core/src/id.rs
+++ b/core/src/id.rs
@@ -63,9 +63,7 @@ impl From<Id> for NonZeroU128 {
     fn from(id: Id) -> NonZeroU128 {
         match &id.0 {
             Internal::Unique(id) => NonZeroU128::try_from(*id as u128).unwrap(),
-            Internal::Custom(id, _) => {
-                NonZeroU128::try_from(*id as u128).unwrap()
-            }
+            Internal::Custom(id, _) => NonZeroU128::try_from(*id as u128).unwrap(),
             // this is a set id, which is not a valid id and will not ever be converted to a NonZeroU128
             // so we panic
             Internal::Set(_) => {
@@ -89,8 +87,7 @@ impl std::fmt::Display for Id {
 /// get window node id that won't conflict with other node ids for the duration of the program
 pub fn window_node_id() -> NonZeroU128 {
     std::num::NonZeroU128::try_from(
-        u64::MAX as u128
-            + NEXT_WINDOW_ID.fetch_add(1, atomic::Ordering::Relaxed) as u128,
+        u64::MAX as u128 + NEXT_WINDOW_ID.fetch_add(1, atomic::Ordering::Relaxed) as u128,
     )
     .unwrap()
 }
@@ -131,17 +128,14 @@ impl IdEq for Internal {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Unique(l0), Self::Unique(r0)) => l0 == r0,
-            (Self::Custom(l0, l1), Self::Custom(r0, r1)) => {
-                l0 == r0 || l1 == r1
-            }
+            (Self::Custom(l0, l1), Self::Custom(r0, r1)) => l0 == r0 || l1 == r1,
             // allow custom ids to be equal to unique ids
-            (Self::Unique(l0), Self::Custom(r0, _))
-            | (Self::Custom(l0, _), Self::Unique(r0)) => l0 == r0,
+            (Self::Unique(l0), Self::Custom(r0, _)) | (Self::Custom(l0, _), Self::Unique(r0)) => {
+                l0 == r0
+            }
             (Self::Set(l0), Self::Set(r0)) => l0 == r0,
             // allow set ids to just be equal to any of their members
-            (Self::Set(l0), r) | (r, Self::Set(l0)) => {
-                l0.iter().any(|l| l == r)
-            }
+            (Self::Set(l0), r) | (r, Self::Set(l0)) => l0.iter().any(|l| l == r),
         }
     }
 }

--- a/core/src/image.rs
+++ b/core/src/image.rs
@@ -145,11 +145,7 @@ impl Handle {
     /// `width * height * 4`.
     ///
     /// This is useful if you have already decoded your image.
-    pub fn from_rgba(
-        width: u32,
-        height: u32,
-        pixels: impl Into<Bytes>,
-    ) -> Handle {
+    pub fn from_rgba(width: u32, height: u32, pixels: impl Into<Bytes>) -> Handle {
         Self::Rgba {
             id: Id::unique(),
             width,
@@ -161,9 +157,7 @@ impl Handle {
     /// Returns the unique identifier of the [`Handle`].
     pub fn id(&self) -> Id {
         match self {
-            Handle::Path(id, _)
-            | Handle::Bytes(id, _)
-            | Handle::Rgba { id, .. } => *id,
+            Handle::Path(id, _) | Handle::Bytes(id, _) | Handle::Rgba { id, .. } => *id,
         }
     }
 }
@@ -329,12 +323,7 @@ pub trait Renderer: crate::Renderer {
     ///
     /// If you need to draw an image right away, consider using [`Renderer::load_image`]
     /// and hold on to an [`Allocation`] first.
-    fn draw_image(
-        &mut self,
-        image: Image<Self::Handle>,
-        bounds: Rectangle,
-        clip_bounds: Rectangle,
-    );
+    fn draw_image(&mut self, image: Image<Self::Handle>, bounds: Rectangle, clip_bounds: Rectangle);
 }
 
 /// An image loading error.

--- a/core/src/layout.rs
+++ b/core/src/layout.rs
@@ -70,14 +70,9 @@ impl<'a> Layout<'a> {
     }
 
     /// Returns an iterator over the children of this [`Layout`].
-    pub fn children(
-        self,
-    ) -> impl DoubleEndedIterator<Item = Layout<'a>> + ExactSizeIterator {
+    pub fn children(self) -> impl DoubleEndedIterator<Item = Layout<'a>> + ExactSizeIterator {
         self.node.children().iter().map(move |node| {
-            Layout::with_offset(
-                Vector::new(self.position.x, self.position.y),
-                node,
-            )
+            Layout::with_offset(Vector::new(self.position.x, self.position.y), node)
         })
     }
 
@@ -130,11 +125,7 @@ pub fn next_to_each_other(
 
 /// Computes the resulting [`Node`] that fits the [`Limits`] given
 /// some width and height requirements and no intrinsic size.
-pub fn atomic(
-    limits: &Limits,
-    width: impl Into<Length>,
-    height: impl Into<Length>,
-) -> Node {
+pub fn atomic(limits: &Limits, width: impl Into<Length>, height: impl Into<Length>) -> Node {
     let width = width.into();
     let height = height.into();
 
@@ -174,10 +165,7 @@ pub fn contained(
     let limits = limits.width(width).height(height);
     let content = f(&limits);
 
-    Node::with_children(
-        limits.resolve(width, height, content.size()),
-        vec![content],
-    )
+    Node::with_children(limits.resolve(width, height, content.size()), vec![content])
 }
 
 /// Computes the [`Node`] that fits the [`Limits`] given some width, height, and

--- a/core/src/layout/flex.rs
+++ b/core/src/layout/flex.rs
@@ -100,17 +100,14 @@ where
     // We lay out non-fluid elements in the main axis.
     // If we need to compress the cross axis, then we skip any of these elements
     // that are also fluid in the cross axis.
-    for (i, (child, tree)) in items.iter_mut().zip(trees.iter_mut()).enumerate()
-    {
+    for (i, (child, tree)) in items.iter_mut().zip(trees.iter_mut()).enumerate() {
         let (fill_main_factor, fill_cross_factor) = {
             let size = child.as_widget().size();
 
             axis.pack(size.width.fill_factor(), size.height.fill_factor())
         };
 
-        if (main_compress || fill_main_factor == 0)
-            && (!cross_compress || fill_cross_factor == 0)
-        {
+        if (main_compress || fill_main_factor == 0) && (!cross_compress || fill_cross_factor == 0) {
             let (max_width, max_height) = axis.pack(
                 available,
                 if fill_cross_factor == 0 {
@@ -120,14 +117,10 @@ where
                 },
             );
 
-            let child_limits = Limits::with_compression(
-                Size::ZERO,
-                Size::new(max_width, max_height),
-                compression,
-            );
+            let child_limits =
+                Limits::with_compression(Size::ZERO, Size::new(max_width, max_height), compression);
 
-            let layout =
-                child.as_widget_mut().layout(tree, renderer, &child_limits);
+            let layout = child.as_widget_mut().layout(tree, renderer, &child_limits);
             let size = layout.size();
 
             available -= axis.main(size);
@@ -151,18 +144,14 @@ where
     // We can defer the layout of any elements that have a fixed size in the main axis,
     // allowing them to use the cross calculations of the next pass.
     if cross_compress && some_fill_cross {
-        for (i, (child, tree)) in
-            items.iter_mut().zip(trees.iter_mut()).enumerate()
-        {
+        for (i, (child, tree)) in items.iter_mut().zip(trees.iter_mut()).enumerate() {
             let (main_size, cross_size) = {
                 let size = child.as_widget().size();
 
                 axis.pack(size.width, size.height)
             };
 
-            if (main_compress || main_size.fill_factor() == 0)
-                && cross_size.fill_factor() != 0
-            {
+            if (main_compress || main_size.fill_factor() == 0) && cross_size.fill_factor() != 0 {
                 if let Length::Fixed(main) = main_size {
                     available -= main;
                     continue;
@@ -176,8 +165,7 @@ where
                     compression,
                 );
 
-                let layout =
-                    child.as_widget_mut().layout(tree, renderer, &child_limits);
+                let layout = child.as_widget_mut().layout(tree, renderer, &child_limits);
                 let size = layout.size();
 
                 available -= axis.main(size);
@@ -194,9 +182,7 @@ where
     // We lay out the elements that are fluid in the main axis.
     // We use the remaining space to evenly allocate space based on fill factors.
     if !main_compress {
-        for (i, (child, tree)) in
-            items.iter_mut().zip(trees.iter_mut()).enumerate()
-        {
+        for (i, (child, tree)) in items.iter_mut().zip(trees.iter_mut()).enumerate() {
             let (fill_main_factor, fill_cross_factor) = {
                 let size = child.as_widget().size();
 
@@ -204,8 +190,7 @@ where
             };
 
             if fill_main_factor != 0 {
-                let max_main =
-                    remaining * fill_main_factor as f32 / fill_main_sum as f32;
+                let max_main = remaining * fill_main_factor as f32 / fill_main_sum as f32;
 
                 let max_main = if max_main.is_nan() {
                     f32::INFINITY
@@ -235,8 +220,7 @@ where
                     compression,
                 );
 
-                let layout =
-                    child.as_widget_mut().layout(tree, renderer, &child_limits);
+                let layout = child.as_widget_mut().layout(tree, renderer, &child_limits);
                 cross = cross.max(axis.cross(layout.size()));
 
                 nodes[i] = layout;
@@ -263,11 +247,9 @@ where
 
                 let (max_width, max_height) = axis.pack(main, cross);
 
-                let child_limits =
-                    Limits::new(Size::ZERO, Size::new(max_width, max_height));
+                let child_limits = Limits::new(Size::ZERO, Size::new(max_width, max_height));
 
-                let layout =
-                    child.as_widget_mut().layout(tree, renderer, &child_limits);
+                let layout = child.as_widget_mut().layout(tree, renderer, &child_limits);
                 let size = layout.size();
 
                 cross = cross.max(axis.cross(size));
@@ -293,18 +275,10 @@ where
 
         match axis {
             Axis::Horizontal => {
-                node.align_mut(
-                    Alignment::Start,
-                    align_items,
-                    Size::new(0.0, cross),
-                );
+                node.align_mut(Alignment::Start, align_items, Size::new(0.0, cross));
             }
             Axis::Vertical => {
-                node.align_mut(
-                    align_items,
-                    Alignment::Start,
-                    Size::new(cross, 0.0),
-                );
+                node.align_mut(align_items, Alignment::Start, Size::new(cross, 0.0));
             }
         }
 
@@ -314,11 +288,7 @@ where
     }
 
     let (intrinsic_width, intrinsic_height) = axis.pack(main - pad.0, cross);
-    let size = limits.resolve(
-        width,
-        height,
-        Size::new(intrinsic_width, intrinsic_height),
-    );
+    let size = limits.resolve(width, height, Size::new(intrinsic_width, intrinsic_height));
 
     Node::with_children(size.expand(padding), nodes)
 }

--- a/core/src/layout/limits.rs
+++ b/core/src/layout/limits.rs
@@ -24,11 +24,7 @@ impl Limits {
 
     /// Creates new [`Limits`] with the given minimun and maximum [`Size`], and
     /// whether fluid lengths should be compressed to intrinsic dimensions.
-    pub const fn with_compression(
-        min: Size,
-        max: Size,
-        compress: Size<bool>,
-    ) -> Self {
+    pub const fn with_compression(min: Size, max: Size, compress: Size<bool>) -> Self {
         Limits {
             min,
             max,
@@ -77,8 +73,7 @@ impl Limits {
                 self.compression.height = true;
             }
             Length::Fixed(amount) => {
-                let new_height =
-                    amount.min(self.max.height).max(self.min.height);
+                let new_height = amount.min(self.max.height).max(self.min.height);
 
                 self.min.height = new_height;
                 self.max.height = new_height;
@@ -158,26 +153,14 @@ impl Limits {
         intrinsic_size: Size,
     ) -> Size {
         let width = match width.into() {
-            Length::Fill | Length::FillPortion(_)
-                if !self.compression.width =>
-            {
-                self.max.width
-            }
-            Length::Fixed(amount) => {
-                amount.min(self.max.width).max(self.min.width)
-            }
+            Length::Fill | Length::FillPortion(_) if !self.compression.width => self.max.width,
+            Length::Fixed(amount) => amount.min(self.max.width).max(self.min.width),
             _ => intrinsic_size.width.min(self.max.width).max(self.min.width),
         };
 
         let height = match height.into() {
-            Length::Fill | Length::FillPortion(_)
-                if !self.compression.height =>
-            {
-                self.max.height
-            }
-            Length::Fixed(amount) => {
-                amount.min(self.max.height).max(self.min.height)
-            }
+            Length::Fill | Length::FillPortion(_) if !self.compression.height => self.max.height,
+            Length::Fixed(amount) => amount.min(self.max.height).max(self.min.height),
             _ => intrinsic_size
                 .height
                 .min(self.max.height)

--- a/core/src/layout/node.rs
+++ b/core/src/layout/node.rs
@@ -50,23 +50,13 @@ impl Node {
     }
 
     /// Aligns the [`Node`] in the given space.
-    pub fn align(
-        mut self,
-        align_x: Alignment,
-        align_y: Alignment,
-        space: Size,
-    ) -> Self {
+    pub fn align(mut self, align_x: Alignment, align_y: Alignment, space: Size) -> Self {
         self.align_mut(align_x, align_y, space);
         self
     }
 
     /// Mutable reference version of [`Self::align`].
-    pub fn align_mut(
-        &mut self,
-        align_x: Alignment,
-        align_y: Alignment,
-        space: Size,
-    ) {
+    pub fn align_mut(&mut self, align_x: Alignment, align_y: Alignment, space: Size) {
         match align_x {
             Alignment::Start => {}
             Alignment::Center => {

--- a/core/src/mouse/click.rs
+++ b/core/src/mouse/click.rs
@@ -40,16 +40,10 @@ impl Kind {
 impl Click {
     /// Creates a new [`Click`] with the given position and previous last
     /// [`Click`].
-    pub fn new(
-        position: Point,
-        button: Button,
-        previous: Option<Click>,
-    ) -> Click {
+    pub fn new(position: Point, button: Button, previous: Option<Click>) -> Click {
         let time = Instant::now();
         let kind = if let Some(previous) = previous {
-            if previous.is_consecutive(position, time)
-                && button == previous.button
-            {
+            if previous.is_consecutive(position, time) && button == previous.button {
                 previous.kind.next()
             } else {
                 Kind::Single

--- a/core/src/mouse/cursor.rs
+++ b/core/src/mouse/cursor.rs
@@ -81,9 +81,7 @@ impl std::ops::Add<Vector> for Cursor {
     fn add(self, translation: Vector) -> Self::Output {
         match self {
             Cursor::Available(point) => Cursor::Available(point + translation),
-            Cursor::Levitating(point) => {
-                Cursor::Levitating(point + translation)
-            }
+            Cursor::Levitating(point) => Cursor::Levitating(point + translation),
             Cursor::Unavailable => Cursor::Unavailable,
         }
     }
@@ -95,9 +93,7 @@ impl std::ops::Sub<Vector> for Cursor {
     fn sub(self, translation: Vector) -> Self::Output {
         match self {
             Cursor::Available(point) => Cursor::Available(point - translation),
-            Cursor::Levitating(point) => {
-                Cursor::Levitating(point - translation)
-            }
+            Cursor::Levitating(point) => Cursor::Levitating(point - translation),
             Cursor::Unavailable => Cursor::Unavailable,
         }
     }
@@ -108,12 +104,8 @@ impl std::ops::Mul<Transformation> for Cursor {
 
     fn mul(self, transformation: Transformation) -> Self {
         match self {
-            Self::Available(position) => {
-                Self::Available(position * transformation)
-            }
-            Self::Levitating(position) => {
-                Self::Levitating(position * transformation)
-            }
+            Self::Available(position) => Self::Available(position * transformation),
+            Self::Levitating(position) => Self::Levitating(position * transformation),
             Self::Unavailable => Self::Unavailable,
         }
     }

--- a/core/src/overlay/element.rs
+++ b/core/src/overlay/element.rs
@@ -16,9 +16,7 @@ where
     Renderer: crate::Renderer,
 {
     /// Creates a new [`Element`] containing the given [`Overlay`].
-    pub fn new(
-        overlay: Box<dyn Overlay<Message, Theme, Renderer> + 'a>,
-    ) -> Self {
+    pub fn new(overlay: Box<dyn Overlay<Message, Theme, Renderer> + 'a>) -> Self {
         Self { overlay }
     }
 
@@ -28,17 +26,12 @@ where
     }
 
     /// Returns a mutable reference to the [`Overlay`] of the [`Element`],
-    pub fn as_overlay_mut(
-        &mut self,
-    ) -> &mut dyn Overlay<Message, Theme, Renderer> {
+    pub fn as_overlay_mut(&mut self) -> &mut dyn Overlay<Message, Theme, Renderer> {
         self.overlay.as_mut()
     }
 
     /// Applies a transformation to the produced message of the [`Element`].
-    pub fn map<B>(
-        self,
-        f: &'a dyn Fn(Message) -> B,
-    ) -> Element<'a, B, Theme, Renderer>
+    pub fn map<B>(self, f: &'a dyn Fn(Message) -> B) -> Element<'a, B, Theme, Renderer>
     where
         Message: 'a,
         Theme: 'a,
@@ -65,8 +58,7 @@ impl<'a, A, B, Theme, Renderer> Map<'a, A, B, Theme, Renderer> {
     }
 }
 
-impl<A, B, Theme, Renderer> Overlay<B, Theme, Renderer>
-    for Map<'_, A, B, Theme, Renderer>
+impl<A, B, Theme, Renderer> Overlay<B, Theme, Renderer> for Map<'_, A, B, Theme, Renderer>
 where
     Renderer: crate::Renderer,
 {
@@ -95,14 +87,8 @@ where
         let mut local_messages = Vec::new();
         let mut local_shell = Shell::new(&mut local_messages);
 
-        self.content.update(
-            event,
-            layout,
-            cursor,
-            renderer,
-            clipboard,
-            &mut local_shell,
-        );
+        self.content
+            .update(event, layout, cursor, renderer, clipboard, &mut local_shell);
 
         shell.merge(local_shell, self.mapper);
     }

--- a/core/src/overlay/group.rs
+++ b/core/src/overlay/group.rs
@@ -44,8 +44,7 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer> Default
-    for Group<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme, Renderer> Default for Group<'a, Message, Theme, Renderer>
 where
     Message: 'a,
     Theme: 'a,
@@ -127,11 +126,12 @@ where
         operation: &mut dyn widget::Operation,
     ) {
         operation.traverse(&mut |operation| {
-            self.children.iter_mut().zip(layout.children()).for_each(
-                |(child, layout)| {
+            self.children
+                .iter_mut()
+                .zip(layout.children())
+                .for_each(|(child, layout)| {
                     child.as_overlay_mut().operate(layout, renderer, operation);
-                },
-            );
+                });
         });
     }
 
@@ -144,9 +144,7 @@ where
             .children
             .iter_mut()
             .zip(layout.children())
-            .filter_map(|(child, layout)| {
-                child.as_overlay_mut().overlay(layout, renderer)
-            })
+            .filter_map(|(child, layout)| child.as_overlay_mut().overlay(layout, renderer))
             .collect::<Vec<_>>();
 
         (!children.is_empty()).then(|| Group::with_children(children).overlay())

--- a/core/src/overlay/nested.rs
+++ b/core/src/overlay/nested.rs
@@ -16,20 +16,14 @@ where
     Renderer: renderer::Renderer,
 {
     /// Creates a nested overlay from the provided [`overlay::Element`]
-    pub fn new(
-        element: overlay::Element<'a, Message, Theme, Renderer>,
-    ) -> Self {
+    pub fn new(element: overlay::Element<'a, Message, Theme, Renderer>) -> Self {
         Self { overlay: element }
     }
 
     /// Returns the layout [`Node`] of the [`Nested`] overlay.
     ///
     /// [`Node`]: layout::Node
-    pub fn layout(
-        &mut self,
-        renderer: &Renderer,
-        bounds: Size,
-    ) -> layout::Node {
+    pub fn layout(&mut self, renderer: &Renderer, bounds: Size) -> layout::Node {
         fn recurse<Message, Theme, Renderer>(
             element: &mut overlay::Element<'_, Message, Theme, Renderer>,
             renderer: &Renderer,
@@ -47,10 +41,7 @@ where
                 .map(|nested| recurse(nested, renderer, bounds));
 
             if let Some(nested_node) = nested_node {
-                layout::Node::with_children(
-                    node.size(),
-                    vec![node, nested_node],
-                )
+                layout::Node::with_children(node.size(), vec![node, nested_node])
             } else {
                 layout::Node::with_children(node.size(), vec![node])
             }
@@ -115,14 +106,7 @@ where
                 if let Some((mut nested, nested_layout)) =
                     overlay.overlay(layout, renderer).zip(nested_layout)
                 {
-                    recurse(
-                        &mut nested,
-                        nested_layout,
-                        renderer,
-                        theme,
-                        style,
-                        cursor,
-                    );
+                    recurse(&mut nested, nested_layout, renderer, theme, style, cursor);
                 }
             }
         }
@@ -280,9 +264,7 @@ where
                     .and_then(|(mut overlay, layout)| {
                         recurse(&mut overlay, layout, cursor, renderer)
                     })
-                    .unwrap_or_else(|| {
-                        overlay.mouse_interaction(layout, cursor, renderer)
-                    }),
+                    .unwrap_or_else(|| overlay.mouse_interaction(layout, cursor, renderer)),
             )
         }
 

--- a/core/src/rectangle.rs
+++ b/core/src/rectangle.rs
@@ -72,11 +72,9 @@ impl Rectangle<f32> {
     ) -> (Rectangle, Radians) {
         let width = (top_right.x - top_left.x).hypot(top_right.y - top_left.y);
 
-        let height =
-            (bottom_left.x - top_left.x).hypot(bottom_left.y - top_left.y);
+        let height = (bottom_left.x - top_left.x).hypot(bottom_left.y - top_left.y);
 
-        let rotation =
-            (top_right.y - top_left.y).atan2(top_right.x - top_left.x);
+        let rotation = (top_right.y - top_left.y).atan2(top_right.x - top_left.x);
 
         let rotation = if rotation < 0.0 {
             2.0 * std::f32::consts::PI + rotation
@@ -153,11 +151,9 @@ impl Rectangle<f32> {
     pub fn distance(&self, point: Point) -> f32 {
         let center = self.center();
 
-        let distance_x =
-            ((point.x - center.x).abs() - self.width / 2.0).max(0.0);
+        let distance_x = ((point.x - center.x).abs() - self.width / 2.0).max(0.0);
 
-        let distance_y =
-            ((point.y - center.y).abs() - self.height / 2.0).max(0.0);
+        let distance_y = ((point.y - center.y).abs() - self.height / 2.0).max(0.0);
 
         distance_x.hypot(distance_y)
     }
@@ -212,16 +208,11 @@ impl Rectangle<f32> {
     /// not be on the border.
     pub fn is_within_strict(&self, container: &Rectangle) -> bool {
         container.contains_strict(self.position())
-            && container.contains_strict(
-                self.position() + Vector::new(self.width, self.height),
-            )
+            && container.contains_strict(self.position() + Vector::new(self.width, self.height))
     }
 
     /// Computes the intersection with the given [`Rectangle`].
-    pub fn intersection(
-        &self,
-        other: &Rectangle<f32>,
-    ) -> Option<Rectangle<f32>> {
+    pub fn intersection(&self, other: &Rectangle<f32>) -> Option<Rectangle<f32>> {
         let x = self.x.max(other.x);
         let y = self.y.max(other.y);
 
@@ -345,17 +336,13 @@ impl Rectangle<f32> {
     ) -> Point {
         let x = match align_x.into() {
             alignment::Horizontal::Left => self.x,
-            alignment::Horizontal::Center => {
-                self.x + (self.width - size.width) / 2.0
-            }
+            alignment::Horizontal::Center => self.x + (self.width - size.width) / 2.0,
             alignment::Horizontal::Right => self.x + self.width - size.width,
         };
 
         let y = match align_y.into() {
             alignment::Vertical::Top => self.y,
-            alignment::Vertical::Center => {
-                self.y + (self.height - size.height) / 2.0
-            }
+            alignment::Vertical::Center => self.y + (self.height - size.height) / 2.0,
             alignment::Vertical::Bottom => self.y + self.height - size.height,
         };
 

--- a/core/src/renderer.rs
+++ b/core/src/renderer.rs
@@ -4,8 +4,7 @@ mod null;
 
 use crate::image;
 use crate::{
-    Background, Border, Color, Font, Pixels, Rectangle, Shadow, Size,
-    Transformation, Vector,
+    Background, Border, Color, Font, Pixels, Rectangle, Shadow, Size, Transformation, Vector,
 };
 
 /// A component that can be used by widgets to draw themselves on a screen.
@@ -36,26 +35,15 @@ pub trait Renderer {
     fn end_transformation(&mut self);
 
     /// Applies a [`Transformation`] to the primitives recorded in the given closure.
-    fn with_transformation(
-        &mut self,
-        transformation: Transformation,
-        f: impl FnOnce(&mut Self),
-    ) {
+    fn with_transformation(&mut self, transformation: Transformation, f: impl FnOnce(&mut Self)) {
         self.start_transformation(transformation);
         f(self);
         self.end_transformation();
     }
 
     /// Applies a translation to the primitives recorded in the given closure.
-    fn with_translation(
-        &mut self,
-        translation: Vector,
-        f: impl FnOnce(&mut Self),
-    ) {
-        self.with_transformation(
-            Transformation::translate(translation.x, translation.y),
-            f,
-        );
+    fn with_translation(&mut self, translation: Vector, f: impl FnOnce(&mut Self)) {
+        self.with_transformation(Transformation::translate(translation.x, translation.y), f);
     }
 
     /// Fills a [`Quad`] with the provided [`Background`].
@@ -68,9 +56,7 @@ pub trait Renderer {
     fn allocate_image(
         &mut self,
         handle: &image::Handle,
-        callback: impl FnOnce(Result<image::Allocation, image::Error>)
-        + Send
-        + 'static,
+        callback: impl FnOnce(Result<image::Allocation, image::Error>) + Send + 'static,
     );
 }
 

--- a/core/src/renderer/null.rs
+++ b/core/src/renderer/null.rs
@@ -3,9 +3,7 @@ use crate::image::{self, Image};
 use crate::renderer::{self, Renderer};
 use crate::svg;
 use crate::text::{self, Text};
-use crate::{
-    Background, Color, Font, Pixels, Point, Rectangle, Size, Transformation,
-};
+use crate::{Background, Color, Font, Pixels, Point, Rectangle, Size, Transformation};
 
 impl Renderer for () {
     fn start_layer(&mut self, _bounds: Rectangle) {}
@@ -18,19 +16,12 @@ impl Renderer for () {
 
     fn reset(&mut self, _new_bounds: Rectangle) {}
 
-    fn fill_quad(
-        &mut self,
-        _quad: renderer::Quad,
-        _background: impl Into<Background>,
-    ) {
-    }
+    fn fill_quad(&mut self, _quad: renderer::Quad, _background: impl Into<Background>) {}
 
     fn allocate_image(
         &mut self,
         handle: &image::Handle,
-        callback: impl FnOnce(Result<image::Allocation, image::Error>)
-        + Send
-        + 'static,
+        callback: impl FnOnce(Result<image::Allocation, image::Error>) + Send + 'static,
     ) {
         #[allow(unsafe_code)]
         callback(Ok(unsafe { image::allocate(handle, Size::new(100, 100)) }));
@@ -95,10 +86,7 @@ impl text::Paragraph for () {
 
     fn with_text(_text: Text<&str>) -> Self {}
 
-    fn with_spans<Link>(
-        _text: Text<&[text::Span<'_, Link, Self::Font>], Self::Font>,
-    ) -> Self {
-    }
+    fn with_spans<Link>(_text: Text<&[text::Span<'_, Link, Self::Font>], Self::Font>) -> Self {}
 
     fn resize(&mut self, _new_bounds: Size) {}
 
@@ -230,9 +218,7 @@ impl text::Editor for () {
         &mut self,
         _font: Self::Font,
         _highlighter: &mut H,
-        _format_highlight: impl Fn(
-            &H::Highlight,
-        ) -> text::highlighter::Format<Self::Font>,
+        _format_highlight: impl Fn(&H::Highlight) -> text::highlighter::Format<Self::Font>,
     ) {
     }
 }
@@ -240,10 +226,7 @@ impl text::Editor for () {
 impl image::Renderer for () {
     type Handle = image::Handle;
 
-    fn load_image(
-        &self,
-        handle: &Self::Handle,
-    ) -> Result<image::Allocation, image::Error> {
+    fn load_image(&self, handle: &Self::Handle) -> Result<image::Allocation, image::Error> {
         #[allow(unsafe_code)]
         Ok(unsafe { image::allocate(handle, Size::new(100, 100)) })
     }
@@ -252,13 +235,7 @@ impl image::Renderer for () {
         Some(Size::new(100, 100))
     }
 
-    fn draw_image(
-        &mut self,
-        _image: Image,
-        _bounds: Rectangle,
-        _clip_bounds: Rectangle,
-    ) {
-    }
+    fn draw_image(&mut self, _image: Image, _bounds: Rectangle, _clip_bounds: Rectangle) {}
 }
 
 impl svg::Renderer for () {
@@ -266,13 +243,7 @@ impl svg::Renderer for () {
         Size::default()
     }
 
-    fn draw_svg(
-        &mut self,
-        _svg: svg::Svg,
-        _bounds: Rectangle,
-        _clip_bounds: Rectangle,
-    ) {
-    }
+    fn draw_svg(&mut self, _svg: svg::Svg, _bounds: Rectangle, _clip_bounds: Rectangle) {}
 }
 
 impl renderer::Headless for () {

--- a/core/src/shell.rs
+++ b/core/src/shell.rs
@@ -68,10 +68,7 @@ impl<'a, Message> Shell<'a, Message> {
     }
 
     /// Requests a new frame to be drawn at the given [`window::RedrawRequest`].
-    pub fn request_redraw_at(
-        &mut self,
-        redraw_request: impl Into<window::RedrawRequest>,
-    ) {
+    pub fn request_redraw_at(&mut self, redraw_request: impl Into<window::RedrawRequest>) {
         self.redraw_request = self.redraw_request.min(redraw_request.into());
     }
 
@@ -86,10 +83,7 @@ impl<'a, Message> Shell<'a, Message> {
     /// This is useful if you want to overwrite the redraw request to a previous value.
     /// Since it's a fairly advanced use case and should rarely be used, it is a static
     /// method.
-    pub fn replace_redraw_request(
-        shell: &mut Self,
-        redraw_request: window::RedrawRequest,
-    ) {
+    pub fn replace_redraw_request(shell: &mut Self, redraw_request: window::RedrawRequest) {
         shell.redraw_request = redraw_request;
     }
 
@@ -97,10 +91,7 @@ impl<'a, Message> Shell<'a, Message> {
     ///
     /// __Important__: This request will only be honored by the
     /// [`Shell`] only during a [`window::Event::RedrawRequested`].
-    pub fn request_input_method<T: AsRef<str>>(
-        &mut self,
-        ime: &InputMethod<T>,
-    ) {
+    pub fn request_input_method<T: AsRef<str>>(&mut self, ime: &InputMethod<T>) {
         self.input_method.merge(ime);
     }
 
@@ -160,11 +151,9 @@ impl<'a, Message> Shell<'a, Message> {
     pub fn merge<B>(&mut self, other: Shell<'_, B>, f: impl Fn(B) -> Message) {
         self.messages.extend(other.messages.drain(..).map(f));
 
-        self.is_layout_invalid =
-            self.is_layout_invalid || other.is_layout_invalid;
+        self.is_layout_invalid = self.is_layout_invalid || other.is_layout_invalid;
 
-        self.are_widgets_invalid =
-            self.are_widgets_invalid || other.are_widgets_invalid;
+        self.are_widgets_invalid = self.are_widgets_invalid || other.are_widgets_invalid;
 
         self.redraw_request = self.redraw_request.min(other.redraw_request);
         self.event_status = self.event_status.merge(other.event_status);

--- a/core/src/size.rs
+++ b/core/src/size.rs
@@ -58,10 +58,8 @@ impl Size {
         let radians = f32::from(rotation);
 
         Size {
-            width: (self.width * radians.cos()).abs()
-                + (self.height * radians.sin()).abs(),
-            height: (self.width * radians.sin()).abs()
-                + (self.height * radians.cos()).abs(),
+            width: (self.width * radians.cos()).abs() + (self.height * radians.sin()).abs(),
+            height: (self.width * radians.sin()).abs() + (self.height * radians.cos()).abs(),
         }
     }
 
@@ -79,8 +77,7 @@ impl Size<Length> {
     /// Returns true if either `width` or `height` are 0-sized.
     #[inline]
     pub fn is_void(&self) -> bool {
-        matches!(self.width, Length::Fixed(0.0))
-            || matches!(self.height, Length::Fixed(0.0))
+        matches!(self.width, Length::Fixed(0.0)) || matches!(self.height, Length::Fixed(0.0))
     }
 }
 

--- a/core/src/text.rs
+++ b/core/src/text.rs
@@ -8,9 +8,7 @@ pub use highlighter::Highlighter;
 pub use paragraph::Paragraph;
 
 use crate::alignment;
-use crate::{
-    Background, Border, Color, Padding, Pixels, Point, Rectangle, Size,
-};
+use crate::{Background, Border, Color, Padding, Pixels, Point, Rectangle, Size};
 
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
@@ -526,10 +524,7 @@ impl<'a, Link, Font> Span<'a, Link, Font> {
     }
 
     /// Sets the [`Background`] of the [`Span`], if any.
-    pub fn background_maybe(
-        mut self,
-        background: Option<impl Into<Background>>,
-    ) -> Self {
+    pub fn background_maybe(mut self, background: Option<impl Into<Background>>) -> Self {
         let Some(background) = background else {
             return self;
         };

--- a/core/src/text/paragraph.rs
+++ b/core/src/text/paragraph.rs
@@ -1,8 +1,7 @@
 //! Draw paragraphs.
 use crate::alignment;
 use crate::text::{
-    Affinity, Alignment, Difference, Hit, LineHeight, Shaping, Span, Text,
-    Wrapping,
+    Affinity, Alignment, Difference, Hit, LineHeight, Shaping, Span, Text, Wrapping,
 };
 use crate::{Pixels, Point, Rectangle, Size};
 
@@ -17,9 +16,7 @@ pub trait Paragraph: Sized + Default {
     fn with_text(text: Text<&str, Self::Font>) -> Self;
 
     /// Creates a new [`Paragraph`] laid out with the given [`Text`].
-    fn with_spans<Link>(
-        text: Text<&[Span<'_, Link, Self::Font>], Self::Font>,
-    ) -> Self;
+    fn with_spans<Link>(text: Text<&[Span<'_, Link, Self::Font>], Self::Font>) -> Self;
 
     /// Lays out the [`Paragraph`] with some new boundaries.
     fn resize(&mut self, new_bounds: Size);

--- a/core/src/theme.rs
+++ b/core/src/theme.rs
@@ -88,10 +88,7 @@ impl Theme {
     ];
 
     /// Creates a new custom [`Theme`] from the given [`Palette`].
-    pub fn custom(
-        name: impl Into<Cow<'static, str>>,
-        palette: Palette,
-    ) -> Self {
+    pub fn custom(name: impl Into<Cow<'static, str>>, palette: Palette) -> Self {
         Self::custom_with_fn(name, palette, palette::Extended::generate)
     }
 
@@ -147,9 +144,7 @@ impl Theme {
             Self::GruvboxDark => &palette::EXTENDED_GRUVBOX_DARK,
             Self::CatppuccinLatte => &palette::EXTENDED_CATPPUCCIN_LATTE,
             Self::CatppuccinFrappe => &palette::EXTENDED_CATPPUCCIN_FRAPPE,
-            Self::CatppuccinMacchiato => {
-                &palette::EXTENDED_CATPPUCCIN_MACCHIATO
-            }
+            Self::CatppuccinMacchiato => &palette::EXTENDED_CATPPUCCIN_MACCHIATO,
             Self::CatppuccinMocha => &palette::EXTENDED_CATPPUCCIN_MOCHA,
             Self::TokyoNight => &palette::EXTENDED_TOKYO_NIGHT,
             Self::TokyoNightStorm => &palette::EXTENDED_TOKYO_NIGHT_STORM,

--- a/core/src/theme/palette.rs
+++ b/core/src/theme/palette.rs
@@ -307,16 +307,14 @@ pub static EXTENDED_LIGHT: LazyLock<Extended> =
     LazyLock::new(|| Extended::generate(Palette::LIGHT));
 
 /// The built-in dark variant of an [`Extended`] palette.
-pub static EXTENDED_DARK: LazyLock<Extended> =
-    LazyLock::new(|| Extended::generate(Palette::DARK));
+pub static EXTENDED_DARK: LazyLock<Extended> = LazyLock::new(|| Extended::generate(Palette::DARK));
 
 /// The built-in Dracula variant of an [`Extended`] palette.
 pub static EXTENDED_DRACULA: LazyLock<Extended> =
     LazyLock::new(|| Extended::generate(Palette::DRACULA));
 
 /// The built-in Nord variant of an [`Extended`] palette.
-pub static EXTENDED_NORD: LazyLock<Extended> =
-    LazyLock::new(|| Extended::generate(Palette::NORD));
+pub static EXTENDED_NORD: LazyLock<Extended> = LazyLock::new(|| Extended::generate(Palette::NORD));
 
 /// The built-in Solarized Light variant of an [`Extended`] palette.
 pub static EXTENDED_SOLARIZED_LIGHT: LazyLock<Extended> =
@@ -395,27 +393,11 @@ impl Extended {
     pub fn generate(palette: Palette) -> Self {
         Self {
             background: Background::new(palette.background, palette.text),
-            primary: Primary::generate(
-                palette.primary,
-                palette.background,
-                palette.text,
-            ),
+            primary: Primary::generate(palette.primary, palette.background, palette.text),
             secondary: Secondary::generate(palette.background, palette.text),
-            success: Success::generate(
-                palette.success,
-                palette.background,
-                palette.text,
-            ),
-            warning: Warning::generate(
-                palette.warning,
-                palette.background,
-                palette.text,
-            ),
-            danger: Danger::generate(
-                palette.danger,
-                palette.background,
-                palette.text,
-            ),
+            success: Success::generate(palette.success, palette.background, palette.text),
+            warning: Warning::generate(palette.warning, palette.background, palette.text),
+            danger: Danger::generate(palette.danger, palette.background, palette.text),
             is_dark: is_dark(palette.background),
         }
     }

--- a/core/src/transformation.rs
+++ b/core/src/transformation.rs
@@ -89,12 +89,9 @@ impl Mul<Transformation> for Size {
     type Output = Self;
 
     fn mul(self, transformation: Transformation) -> Self {
-        let new_size = transformation.0.mul_vec4(Vec4::new(
-            self.width,
-            self.height,
-            1.0,
-            0.0,
-        ));
+        let new_size = transformation
+            .0
+            .mul_vec4(Vec4::new(self.width, self.height, 1.0, 0.0));
 
         Size::new(new_size.x, new_size.y)
     }

--- a/core/src/widget/operation.rs
+++ b/core/src/widget/operation.rs
@@ -42,34 +42,16 @@ pub trait Operation<T = ()>: Send {
     }
 
     /// Operates on a widget that can be focused.
-    fn focusable(
-        &mut self,
-        _id: Option<&Id>,
-        _bounds: Rectangle,
-        _state: &mut dyn Focusable,
-    ) {
-    }
+    fn focusable(&mut self, _id: Option<&Id>, _bounds: Rectangle, _state: &mut dyn Focusable) {}
 
     /// Operates on a widget that has text input.
-    fn text_input(
-        &mut self,
-        _id: Option<&Id>,
-        _bounds: Rectangle,
-        _state: &mut dyn TextInput,
-    ) {
-    }
+    fn text_input(&mut self, _id: Option<&Id>, _bounds: Rectangle, _state: &mut dyn TextInput) {}
 
     /// Operates on a widget that contains some text.
     fn text(&mut self, _id: Option<&Id>, _bounds: Rectangle, _text: &str) {}
 
     /// Operates on a custom widget with some state.
-    fn custom(
-        &mut self,
-        _id: Option<&Id>,
-        _bounds: Rectangle,
-        _state: &mut dyn Any,
-    ) {
-    }
+    fn custom(&mut self, _id: Option<&Id>, _bounds: Rectangle, _state: &mut dyn Any) {}
 
     /// Finishes the [`Operation`] and returns its [`Outcome`].
     fn finish(&self) -> Outcome<T> {
@@ -89,12 +71,7 @@ where
         self.as_mut().container(id, bounds);
     }
 
-    fn focusable(
-        &mut self,
-        id: Option<&Id>,
-        bounds: Rectangle,
-        state: &mut dyn Focusable,
-    ) {
+    fn focusable(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Focusable) {
         self.as_mut().focusable(id, bounds, state);
     }
 
@@ -106,21 +83,11 @@ where
         translation: Vector,
         state: &mut dyn Scrollable,
     ) {
-        self.as_mut().scrollable(
-            id,
-            bounds,
-            content_bounds,
-            translation,
-            state,
-        );
+        self.as_mut()
+            .scrollable(id, bounds, content_bounds, translation, state);
     }
 
-    fn text_input(
-        &mut self,
-        id: Option<&Id>,
-        bounds: Rectangle,
-        state: &mut dyn TextInput,
-    ) {
+    fn text_input(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn TextInput) {
         self.as_mut().text_input(id, bounds, state);
     }
 
@@ -128,12 +95,7 @@ where
         self.as_mut().text(id, bounds, text);
     }
 
-    fn custom(
-        &mut self,
-        id: Option<&Id>,
-        bounds: Rectangle,
-        state: &mut dyn Any,
-    ) {
+    fn custom(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Any) {
         self.as_mut().custom(id, bounds, state);
     }
 
@@ -168,9 +130,7 @@ where
 }
 
 /// Wraps the [`Operation`] in a black box, erasing its returning type.
-pub fn black_box<'a, T, O>(
-    operation: &'a mut dyn Operation<T>,
-) -> impl Operation<O> + 'a
+pub fn black_box<'a, T, O>(operation: &'a mut dyn Operation<T>) -> impl Operation<O> + 'a
 where
     T: 'a,
 {
@@ -192,12 +152,7 @@ where
             self.operation.container(id, bounds);
         }
 
-        fn focusable(
-            &mut self,
-            id: Option<&Id>,
-            bounds: Rectangle,
-            state: &mut dyn Focusable,
-        ) {
+        fn focusable(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Focusable) {
             self.operation.focusable(id, bounds, state);
         }
 
@@ -209,21 +164,11 @@ where
             translation: Vector,
             state: &mut dyn Scrollable,
         ) {
-            self.operation.scrollable(
-                id,
-                bounds,
-                content_bounds,
-                translation,
-                state,
-            );
+            self.operation
+                .scrollable(id, bounds, content_bounds, translation, state);
         }
 
-        fn text_input(
-            &mut self,
-            id: Option<&Id>,
-            bounds: Rectangle,
-            state: &mut dyn TextInput,
-        ) {
+        fn text_input(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn TextInput) {
             self.operation.text_input(id, bounds, state);
         }
 
@@ -231,12 +176,7 @@ where
             self.operation.text(id, bounds, text);
         }
 
-        fn custom(
-            &mut self,
-            id: Option<&Id>,
-            bounds: Rectangle,
-            state: &mut dyn Any,
-        ) {
+        fn custom(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Any) {
             self.operation.custom(id, bounds, state);
         }
 
@@ -274,10 +214,7 @@ where
             }
 
             impl<A, B> Operation<B> for MapRef<'_, A> {
-                fn traverse(
-                    &mut self,
-                    operate: &mut dyn FnMut(&mut dyn Operation<B>),
-                ) {
+                fn traverse(&mut self, operate: &mut dyn FnMut(&mut dyn Operation<B>)) {
                     self.operation.traverse(&mut |operation| {
                         operate(&mut MapRef { operation });
                     });
@@ -297,13 +234,8 @@ where
                     translation: Vector,
                     state: &mut dyn Scrollable,
                 ) {
-                    self.operation.scrollable(
-                        id,
-                        bounds,
-                        content_bounds,
-                        translation,
-                        state,
-                    );
+                    self.operation
+                        .scrollable(id, bounds, content_bounds, translation, state);
                 }
 
                 fn focusable(
@@ -324,21 +256,11 @@ where
                     self.operation.text_input(id, bounds, state);
                 }
 
-                fn text(
-                    &mut self,
-                    id: Option<&Id>,
-                    bounds: Rectangle,
-                    text: &str,
-                ) {
+                fn text(&mut self, id: Option<&Id>, bounds: Rectangle, text: &str) {
                     self.operation.text(id, bounds, text);
                 }
 
-                fn custom(
-                    &mut self,
-                    id: Option<&Id>,
-                    bounds: Rectangle,
-                    state: &mut dyn Any,
-                ) {
+                fn custom(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Any) {
                     self.operation.custom(id, bounds, state);
                 }
             }
@@ -352,12 +274,7 @@ where
             self.operation.container(id, bounds);
         }
 
-        fn focusable(
-            &mut self,
-            id: Option<&Id>,
-            bounds: Rectangle,
-            state: &mut dyn Focusable,
-        ) {
+        fn focusable(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Focusable) {
             self.operation.focusable(id, bounds, state);
         }
 
@@ -369,21 +286,11 @@ where
             translation: Vector,
             state: &mut dyn Scrollable,
         ) {
-            self.operation.scrollable(
-                id,
-                bounds,
-                content_bounds,
-                translation,
-                state,
-            );
+            self.operation
+                .scrollable(id, bounds, content_bounds, translation, state);
         }
 
-        fn text_input(
-            &mut self,
-            id: Option<&Id>,
-            bounds: Rectangle,
-            state: &mut dyn TextInput,
-        ) {
+        fn text_input(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn TextInput) {
             self.operation.text_input(id, bounds, state);
         }
 
@@ -391,12 +298,7 @@ where
             self.operation.text(id, bounds, text);
         }
 
-        fn custom(
-            &mut self,
-            id: Option<&Id>,
-            bounds: Rectangle,
-            state: &mut dyn Any,
-        ) {
+        fn custom(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Any) {
             self.operation.custom(id, bounds, state);
         }
 
@@ -420,10 +322,7 @@ where
 
 /// Chains the output of an [`Operation`] with the provided function to
 /// build a new [`Operation`].
-pub fn then<A, B, O>(
-    operation: impl Operation<A> + 'static,
-    f: fn(A) -> O,
-) -> impl Operation<B>
+pub fn then<A, B, O>(operation: impl Operation<A> + 'static, f: fn(A) -> O) -> impl Operation<B>
 where
     A: 'static,
     B: Send + 'static,
@@ -456,12 +355,7 @@ where
             self.operation.container(id, bounds);
         }
 
-        fn focusable(
-            &mut self,
-            id: Option<&Id>,
-            bounds: Rectangle,
-            state: &mut dyn Focusable,
-        ) {
+        fn focusable(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Focusable) {
             self.operation.focusable(id, bounds, state);
         }
 
@@ -473,21 +367,11 @@ where
             translation: crate::Vector,
             state: &mut dyn Scrollable,
         ) {
-            self.operation.scrollable(
-                id,
-                bounds,
-                content_bounds,
-                translation,
-                state,
-            );
+            self.operation
+                .scrollable(id, bounds, content_bounds, translation, state);
         }
 
-        fn text_input(
-            &mut self,
-            id: Option<&Id>,
-            bounds: Rectangle,
-            state: &mut dyn TextInput,
-        ) {
+        fn text_input(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn TextInput) {
             self.operation.text_input(id, bounds, state);
         }
 
@@ -495,24 +379,15 @@ where
             self.operation.text(id, bounds, text);
         }
 
-        fn custom(
-            &mut self,
-            id: Option<&Id>,
-            bounds: Rectangle,
-            state: &mut dyn Any,
-        ) {
+        fn custom(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Any) {
             self.operation.custom(id, bounds, state);
         }
 
         fn finish(&self) -> Outcome<B> {
             match self.operation.finish() {
                 Outcome::None => Outcome::None,
-                Outcome::Some(value) => {
-                    Outcome::Chain(Box::new((self.next)(value)))
-                }
-                Outcome::Chain(operation) => {
-                    Outcome::Chain(Box::new(then(operation, self.next)))
-                }
+                Outcome::Some(value) => Outcome::Chain(Box::new((self.next)(value))),
+                Outcome::Chain(operation) => Outcome::Chain(Box::new(then(operation, self.next))),
             }
         }
     }
@@ -526,10 +401,7 @@ where
 
 /// Produces an [`Operation`] that applies the given [`Operation`] to the
 /// children of a container with the given [`Id`].
-pub fn scoped<T: 'static>(
-    target: Id,
-    operation: impl Operation<T> + 'static,
-) -> impl Operation<T> {
+pub fn scoped<T: 'static>(target: Id, operation: impl Operation<T> + 'static) -> impl Operation<T> {
     struct ScopedOperation<Message> {
         target: Id,
         current: Option<Id>,
@@ -537,10 +409,7 @@ pub fn scoped<T: 'static>(
     }
 
     impl<Message: 'static> Operation<Message> for ScopedOperation<Message> {
-        fn traverse(
-            &mut self,
-            operate: &mut dyn FnMut(&mut dyn Operation<Message>),
-        ) {
+        fn traverse(&mut self, operate: &mut dyn FnMut(&mut dyn Operation<Message>)) {
             if self.current.as_ref() == Some(&self.target) {
                 self.operation.as_mut().traverse(operate);
             } else {
@@ -556,13 +425,11 @@ pub fn scoped<T: 'static>(
 
         fn finish(&self) -> Outcome<Message> {
             match self.operation.finish() {
-                Outcome::Chain(next) => {
-                    Outcome::Chain(Box::new(ScopedOperation {
-                        target: self.target.clone(),
-                        current: None,
-                        operation: next,
-                    }))
-                }
+                Outcome::Chain(next) => Outcome::Chain(Box::new(ScopedOperation {
+                    target: self.target.clone(),
+                    current: None,
+                    operation: next,
+                })),
                 outcome => outcome,
             }
         }

--- a/core/src/widget/operation/focusable.rs
+++ b/core/src/widget/operation/focusable.rs
@@ -33,12 +33,7 @@ pub fn focus<T>(target: Id) -> impl Operation<T> {
     }
 
     impl<T> Operation<T> for Focus {
-        fn focusable(
-            &mut self,
-            id: Option<&Id>,
-            _bounds: Rectangle,
-            state: &mut dyn Focusable,
-        ) {
+        fn focusable(&mut self, id: Option<&Id>, _bounds: Rectangle, state: &mut dyn Focusable) {
             match id {
                 Some(id) if IdEq::eq(&id.0, &self.target.0) => {
                     state.focus();
@@ -62,12 +57,7 @@ pub fn unfocus<T>() -> impl Operation<T> {
     struct Unfocus;
 
     impl<T> Operation<T> for Unfocus {
-        fn focusable(
-            &mut self,
-            _id: Option<&Id>,
-            _bounds: Rectangle,
-            state: &mut dyn Focusable,
-        ) {
+        fn focusable(&mut self, _id: Option<&Id>, _bounds: Rectangle, state: &mut dyn Focusable) {
             state.unfocus();
         }
 
@@ -87,12 +77,7 @@ pub fn count() -> impl Operation<Count> {
     }
 
     impl Operation<Count> for CountFocusable {
-        fn focusable(
-            &mut self,
-            _id: Option<&Id>,
-            _bounds: Rectangle,
-            state: &mut dyn Focusable,
-        ) {
+        fn focusable(&mut self, _id: Option<&Id>, _bounds: Rectangle, state: &mut dyn Focusable) {
             if state.is_focused() {
                 self.count.focused = Some(self.count.total);
             }
@@ -100,10 +85,7 @@ pub fn count() -> impl Operation<Count> {
             self.count.total += 1;
         }
 
-        fn traverse(
-            &mut self,
-            operate: &mut dyn FnMut(&mut dyn Operation<Count>),
-        ) {
+        fn traverse(&mut self, operate: &mut dyn FnMut(&mut dyn Operation<Count>)) {
             operate(self);
         }
 
@@ -130,12 +112,7 @@ where
     }
 
     impl<T> Operation<T> for FocusPrevious {
-        fn focusable(
-            &mut self,
-            _id: Option<&Id>,
-            _bounds: Rectangle,
-            state: &mut dyn Focusable,
-        ) {
+        fn focusable(&mut self, _id: Option<&Id>, _bounds: Rectangle, state: &mut dyn Focusable) {
             if self.count.total == 0 {
                 return;
             }
@@ -144,9 +121,7 @@ where
                 None if self.current == self.count.total - 1 => state.focus(),
                 Some(0) if self.current == 0 && self.count.total == 1 => {}
                 Some(0) if self.current == 0 => state.unfocus(),
-                Some(0) if self.current == self.count.total - 1 => {
-                    state.focus()
-                }
+                Some(0) if self.current == self.count.total - 1 => state.focus(),
                 Some(0) => {}
                 Some(focused) if focused == self.current => state.unfocus(),
                 Some(focused) if focused - 1 == self.current => state.focus(),
@@ -177,21 +152,13 @@ where
     }
 
     impl<T> Operation<T> for FocusNext {
-        fn focusable(
-            &mut self,
-            _id: Option<&Id>,
-            _bounds: Rectangle,
-            state: &mut dyn Focusable,
-        ) {
+        fn focusable(&mut self, _id: Option<&Id>, _bounds: Rectangle, state: &mut dyn Focusable) {
             match self.count.focused {
                 None if self.current == 0 => state.focus(),
-                Some(focused)
-                    if focused == self.current && self.count.total == 1 => {}
+                Some(focused) if focused == self.current && self.count.total == 1 => {}
                 Some(focused) if focused == self.current => state.unfocus(),
                 Some(focused) if focused + 1 == self.current => state.focus(),
-                Some(focused)
-                    if focused == self.count.total - 1 && self.current == 0 =>
-                {
+                Some(focused) if focused == self.count.total - 1 && self.current == 0 => {
                     state.focus()
                 }
                 _ => {}
@@ -216,21 +183,13 @@ pub fn find_focused() -> impl Operation<Id> {
     }
 
     impl Operation<Id> for FindFocused {
-        fn focusable(
-            &mut self,
-            id: Option<&Id>,
-            _bounds: Rectangle,
-            state: &mut dyn Focusable,
-        ) {
+        fn focusable(&mut self, id: Option<&Id>, _bounds: Rectangle, state: &mut dyn Focusable) {
             if state.is_focused() && id.is_some() {
                 self.focused = id.cloned();
             }
         }
 
-        fn traverse(
-            &mut self,
-            operate: &mut dyn FnMut(&mut dyn Operation<Id>),
-        ) {
+        fn traverse(&mut self, operate: &mut dyn FnMut(&mut dyn Operation<Id>)) {
             operate(self);
         }
 
@@ -256,21 +215,13 @@ pub fn is_focused(target: Id) -> impl Operation<bool> {
     }
 
     impl Operation<bool> for IsFocused {
-        fn focusable(
-            &mut self,
-            id: Option<&Id>,
-            _bounds: Rectangle,
-            state: &mut dyn Focusable,
-        ) {
+        fn focusable(&mut self, id: Option<&Id>, _bounds: Rectangle, state: &mut dyn Focusable) {
             if id.is_some_and(|id| *id == self.target) {
                 self.is_focused = Some(state.is_focused());
             }
         }
 
-        fn traverse(
-            &mut self,
-            operate: &mut dyn FnMut(&mut dyn Operation<bool>),
-        ) {
+        fn traverse(&mut self, operate: &mut dyn FnMut(&mut dyn Operation<bool>)) {
             if self.is_focused.is_some() {
                 return;
             }

--- a/core/src/widget/operation/scrollable.rs
+++ b/core/src/widget/operation/scrollable.rs
@@ -11,20 +11,12 @@ pub trait Scrollable {
     fn scroll_to(&mut self, offset: AbsoluteOffset<Option<f32>>);
 
     /// Scroll the widget by the given [`AbsoluteOffset`] along the horizontal & vertical axis.
-    fn scroll_by(
-        &mut self,
-        offset: AbsoluteOffset,
-        bounds: Rectangle,
-        content_bounds: Rectangle,
-    );
+    fn scroll_by(&mut self, offset: AbsoluteOffset, bounds: Rectangle, content_bounds: Rectangle);
 }
 
 /// Produces an [`Operation`] that snaps the widget with the given [`Id`] to
 /// the provided `percentage`.
-pub fn snap_to<T>(
-    target: Id,
-    offset: RelativeOffset<Option<f32>>,
-) -> impl Operation<T> {
+pub fn snap_to<T>(target: Id, offset: RelativeOffset<Option<f32>>) -> impl Operation<T> {
     struct SnapTo {
         target: Id,
         offset: RelativeOffset<Option<f32>>,
@@ -54,10 +46,7 @@ pub fn snap_to<T>(
 
 /// Produces an [`Operation`] that scrolls the widget with the given [`Id`] to
 /// the provided [`AbsoluteOffset`].
-pub fn scroll_to<T>(
-    target: Id,
-    offset: AbsoluteOffset<Option<f32>>,
-) -> impl Operation<T> {
+pub fn scroll_to<T>(target: Id, offset: AbsoluteOffset<Option<f32>>) -> impl Operation<T> {
     struct ScrollTo {
         target: Id,
         offset: AbsoluteOffset<Option<f32>>,

--- a/core/src/widget/operation/search_id.rs
+++ b/core/src/widget/operation/search_id.rs
@@ -15,12 +15,7 @@ pub fn search_id(target: Id) -> impl Operation<Id> {
     }
 
     impl Operation<Id> for Find {
-        fn custom(
-            &mut self,
-            id: Option<&Id>,
-            _bounds: Rectangle,
-            _state: &mut dyn std::any::Any,
-        ) {
+        fn custom(&mut self, id: Option<&Id>, _bounds: Rectangle, _state: &mut dyn std::any::Any) {
             if Some(&self.target) == id {
                 self.found = true;
             }
@@ -34,10 +29,7 @@ pub fn search_id(target: Id) -> impl Operation<Id> {
             }
         }
 
-        fn traverse(
-            &mut self,
-            operate: &mut dyn FnMut(&mut dyn Operation<Id>),
-        ) {
+        fn traverse(&mut self, operate: &mut dyn FnMut(&mut dyn Operation<Id>)) {
             operate(self);
         }
     }

--- a/core/src/widget/operation/text_input.rs
+++ b/core/src/widget/operation/text_input.rs
@@ -33,12 +33,7 @@ pub fn move_cursor_to_front<T>(target: Id) -> impl Operation<T> {
     }
 
     impl<T> Operation<T> for MoveCursor {
-        fn text_input(
-            &mut self,
-            id: Option<&Id>,
-            _bounds: Rectangle,
-            state: &mut dyn TextInput,
-        ) {
+        fn text_input(&mut self, id: Option<&Id>, _bounds: Rectangle, state: &mut dyn TextInput) {
             match id {
                 Some(id) if id == &self.target => {
                     state.move_cursor_to_front();
@@ -63,12 +58,7 @@ pub fn move_cursor_to_end<T>(target: Id) -> impl Operation<T> {
     }
 
     impl<T> Operation<T> for MoveCursor {
-        fn text_input(
-            &mut self,
-            id: Option<&Id>,
-            _bounds: Rectangle,
-            state: &mut dyn TextInput,
-        ) {
+        fn text_input(&mut self, id: Option<&Id>, _bounds: Rectangle, state: &mut dyn TextInput) {
             match id {
                 Some(id) if id == &self.target => {
                     state.move_cursor_to_end();
@@ -94,12 +84,7 @@ pub fn move_cursor_to<T>(target: Id, position: usize) -> impl Operation<T> {
     }
 
     impl<T> Operation<T> for MoveCursor {
-        fn text_input(
-            &mut self,
-            id: Option<&Id>,
-            _bounds: Rectangle,
-            state: &mut dyn TextInput,
-        ) {
+        fn text_input(&mut self, id: Option<&Id>, _bounds: Rectangle, state: &mut dyn TextInput) {
             match id {
                 Some(id) if id == &self.target => {
                     state.move_cursor_to(self.position);
@@ -123,12 +108,7 @@ pub fn select_all<T>(target: Id) -> impl Operation<T> {
     }
 
     impl<T> Operation<T> for MoveCursor {
-        fn text_input(
-            &mut self,
-            id: Option<&Id>,
-            _bounds: Rectangle,
-            state: &mut dyn TextInput,
-        ) {
+        fn text_input(&mut self, id: Option<&Id>, _bounds: Rectangle, state: &mut dyn TextInput) {
             match id {
                 Some(id) if id == &self.target => {
                     state.select_all();
@@ -146,11 +126,7 @@ pub fn select_all<T>(target: Id) -> impl Operation<T> {
 }
 
 /// Produces an [`Operation`] that selects the given content range of the widget with the given [`Id`].
-pub fn select_range<T>(
-    target: Id,
-    start: usize,
-    end: usize,
-) -> impl Operation<T> {
+pub fn select_range<T>(target: Id, start: usize, end: usize) -> impl Operation<T> {
     struct SelectRange {
         target: Id,
         start: usize,
@@ -158,12 +134,7 @@ pub fn select_range<T>(
     }
 
     impl<T> Operation<T> for SelectRange {
-        fn text_input(
-            &mut self,
-            id: Option<&Id>,
-            _bounds: Rectangle,
-            state: &mut dyn TextInput,
-        ) {
+        fn text_input(&mut self, id: Option<&Id>, _bounds: Rectangle, state: &mut dyn TextInput) {
             match id {
                 Some(id) if id == &self.target => {
                     state.select_range(self.start, self.end);

--- a/core/src/widget/text.rs
+++ b/core/src/widget/text.rs
@@ -27,9 +27,7 @@ use crate::renderer;
 use crate::text::paragraph::{self, Paragraph};
 use crate::text::{self, Fragment};
 use crate::widget::tree::{self, Tree};
-use crate::{
-    Color, Element, Layout, Length, Pixels, Rectangle, Size, Theme, Widget,
-};
+use crate::{Color, Element, Layout, Length, Pixels, Rectangle, Size, Theme, Widget};
 
 use std::borrow::Cow;
 pub use text::{Alignment, Ellipsize, LineHeight, Shaping, Wrapping};
@@ -105,10 +103,7 @@ where
     /// Sets the [`Font`] of the [`Text`], if `Some`.
     ///
     /// [`Font`]: crate::text::Renderer::Font
-    pub fn font_maybe(
-        mut self,
-        font: Option<impl Into<Renderer::Font>>,
-    ) -> Self {
+    pub fn font_maybe(mut self, font: Option<impl Into<Renderer::Font>>) -> Self {
         self.format.font = font.map(Into::into);
         self
     }
@@ -138,10 +133,7 @@ where
     }
 
     /// Sets the [`alignment::Vertical`] of the [`Text`].
-    pub fn align_y(
-        mut self,
-        alignment: impl Into<alignment::Vertical>,
-    ) -> Self {
+    pub fn align_y(mut self, alignment: impl Into<alignment::Vertical>) -> Self {
         self.format.align_y = alignment.into();
         self
     }
@@ -204,8 +196,7 @@ where
 /// The internal state of a [`Text`] widget.
 pub type State<P> = paragraph::Plain<P>;
 
-impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for Text<'_, Theme, Renderer>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Text<'_, Theme, Renderer>
 where
     Theme: Catalog,
     Renderer: text::Renderer,
@@ -291,12 +282,7 @@ where
             width,
             height,
         } = layout.bounds();
-        let bounds = Rect::new(
-            x as f64,
-            y as f64,
-            (x + width) as f64,
-            (y + height) as f64,
-        );
+        let bounds = Rect::new(x as f64, y as f64, (x + width) as f64, (y + height) as f64);
 
         let mut node = Node::new(Role::Paragraph);
 
@@ -419,9 +405,7 @@ where
     Theme: Catalog + 'a,
     Renderer: text::Renderer + 'a,
 {
-    fn from(
-        text: Text<'a, Theme, Renderer>,
-    ) -> Element<'a, Message, Theme, Renderer> {
+    fn from(text: Text<'a, Theme, Renderer>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(text)
     }
 }
@@ -459,8 +443,7 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer> From<&'a str>
-    for Element<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme, Renderer> From<&'a str> for Element<'a, Message, Theme, Renderer>
 where
     Theme: Catalog + 'a,
     Renderer: text::Renderer + 'a,

--- a/core/src/widget/tree.rs
+++ b/core/src/widget/tree.rs
@@ -59,9 +59,7 @@ impl Tree {
     }
 
     /// Takes all named widgets from the tree.
-    pub fn take_all_named(
-        &mut self,
-    ) -> HashMap<Cow<'static, str>, (State, Vec<(usize, Tree)>)> {
+    pub fn take_all_named(&mut self) -> HashMap<Cow<'static, str>, (State, Vec<(usize, Tree)>)> {
         let mut named = HashMap::new();
         struct Visit {
             parent: Cow<'static, str>,
@@ -75,25 +73,21 @@ impl Tree {
             if let Some(Id(Internal::Custom(_, n))) = tree.id.clone() {
                 let state = mem::replace(&mut tree.state, State::None);
                 let children_count = tree.children.len();
-                let children =
-                    tree.children.iter_mut().enumerate().rev().map(|(i, c)| {
-                        if matches!(c.id, Some(Id(Internal::Custom(_, _)))) {
-                            (c, None)
-                        } else {
-                            (
-                                c,
-                                Some(Visit {
-                                    index: i,
-                                    parent: n.clone(),
-                                    visited: false,
-                                }),
-                            )
-                        }
-                    });
-                _ = named.insert(
-                    n.clone(),
-                    (state, Vec::with_capacity(children_count)),
-                );
+                let children = tree.children.iter_mut().enumerate().rev().map(|(i, c)| {
+                    if matches!(c.id, Some(Id(Internal::Custom(_, _)))) {
+                        (c, None)
+                    } else {
+                        (
+                            c,
+                            Some(Visit {
+                                index: i,
+                                parent: n.clone(),
+                                visited: false,
+                            }),
+                        )
+                    }
+                });
+                _ = named.insert(n.clone(), (state, Vec::with_capacity(children_count)));
                 stack.extend(children);
             } else if let Some(visit) = visit {
                 if visit.visited {
@@ -161,8 +155,7 @@ impl Tree {
     ) where
         Renderer: crate::Renderer,
     {
-        let borrowed: &mut dyn Widget<Message, Theme, Renderer> =
-            new.borrow_mut();
+        let borrowed: &mut dyn Widget<Message, Theme, Renderer> = new.borrow_mut();
 
         let mut tag_match = self.tag == borrowed.tag();
 
@@ -172,8 +165,7 @@ impl Tree {
                     .with(|named| named.borrow_mut().remove(&n))
                     .or_else(|| {
                         //check self.id
-                        if let Some(Id(Internal::Custom(_, ref name))) = self.id
-                        {
+                        if let Some(Id(Internal::Custom(_, ref name))) = self.id {
                             if name == &n {
                                 Some((
                                     mem::replace(&mut self.state, State::None),
@@ -207,8 +199,7 @@ impl Tree {
                         self.children = widget_children;
                     } else {
                         for (old_i, mut old) in children {
-                            let Some(my_state) = self.children.get_mut(old_i)
-                            else {
+                            let Some(my_state) = self.children.get_mut(old_i) else {
                                 continue;
                             };
                             if my_state.tag != old.tag || {
@@ -217,10 +208,9 @@ impl Tree {
                                         Some(Id(Internal::Custom(_, old_name))),
                                         Some(Id(Internal::Custom(_, my_name))),
                                     ) => old_name == my_name,
-                                    (
-                                        Some(Id(Internal::Set(a))),
-                                        Some(Id(Internal::Set(b))),
-                                    ) => a.len() == b.len(),
+                                    (Some(Id(Internal::Set(a))), Some(Id(Internal::Set(b)))) => {
+                                        a.len() == b.len()
+                                    }
                                     (
                                         Some(Id(Internal::Unique(_))),
                                         Some(Id(Internal::Unique(_))),
@@ -256,9 +246,7 @@ impl Tree {
     /// Reconciles the children of the tree with the provided list of widgets.
     pub fn diff_children<'a, Message, Theme, Renderer>(
         &mut self,
-        new_children: &mut [impl BorrowMut<
-            dyn Widget<Message, Theme, Renderer> + 'a,
-        >],
+        new_children: &mut [impl BorrowMut<dyn Widget<Message, Theme, Renderer> + 'a>],
     ) where
         Renderer: crate::Renderer,
     {
@@ -291,30 +279,25 @@ impl Tree {
         }
 
         let children_len = self.children.len();
-        let (mut id_map, mut id_list): (
-            HashMap<String, &mut Tree>,
-            VecDeque<(usize, &mut Tree)>,
-        ) = self.children.iter_mut().enumerate().fold(
-            (HashMap::new(), VecDeque::with_capacity(children_len)),
-            |(mut id_map, mut id_list), (i, c)| {
-                if let Some(id) = c.id.as_ref() {
-                    if let Internal::Custom(_, ref name) = id.0 {
-                        let _ = id_map.insert(name.to_string(), c);
+        let (mut id_map, mut id_list): (HashMap<String, &mut Tree>, VecDeque<(usize, &mut Tree)>) =
+            self.children.iter_mut().enumerate().fold(
+                (HashMap::new(), VecDeque::with_capacity(children_len)),
+                |(mut id_map, mut id_list), (i, c)| {
+                    if let Some(id) = c.id.as_ref() {
+                        if let Internal::Custom(_, ref name) = id.0 {
+                            let _ = id_map.insert(name.to_string(), c);
+                        } else {
+                            id_list.push_back((i, c));
+                        }
                     } else {
                         id_list.push_back((i, c));
                     }
-                } else {
-                    id_list.push_back((i, c));
-                }
-                (id_map, id_list)
-            },
-        );
+                    (id_map, id_list)
+                },
+            );
 
-        let mut new_trees: Vec<(Tree, usize)> =
-            Vec::with_capacity(new_children.len());
-        for (i, (new, new_id)) in
-            new_children.iter_mut().zip(new_ids.iter()).enumerate()
-        {
+        let mut new_trees: Vec<(Tree, usize)> = Vec::with_capacity(new_children.len());
+        for (i, (new, new_id)) in new_children.iter_mut().zip(new_ids.iter()).enumerate() {
             let child_state = if let Some(c) = new_id.as_ref().and_then(|id| {
                 if let Internal::Custom(_, ref name) = id.0 {
                     id_map.remove(name.as_ref())
@@ -396,9 +379,7 @@ pub fn diff_children_custom_with_search<T>(
             };
 
             let _ = current_children.splice(
-                difference_index
-                    ..difference_index
-                        + (current_children.len() - new_children.len()),
+                difference_index..difference_index + (current_children.len() - new_children.len()),
                 std::iter::empty(),
             );
         }
@@ -409,9 +390,7 @@ pub fn diff_children_custom_with_search<T>(
         let last_maybe_changed = maybe_changed(current_children.len() - 1);
 
         if !first_maybe_changed && last_maybe_changed {
-            current_children.extend(
-                new_children[current_children.len()..].iter().map(new_state),
-            );
+            current_children.extend(new_children[current_children.len()..].iter().map(new_state));
         } else {
             let difference_index = if first_maybe_changed {
                 0
@@ -424,8 +403,7 @@ pub fn diff_children_custom_with_search<T>(
             let _ = current_children.splice(
                 difference_index..difference_index,
                 new_children[difference_index
-                    ..difference_index
-                        + (new_children.len() - current_children.len())]
+                    ..difference_index + (new_children.len() - current_children.len())]
                     .iter()
                     .map(new_state),
             );
@@ -433,9 +411,7 @@ pub fn diff_children_custom_with_search<T>(
     }
 
     // TODO: Merge loop with extend logic (?)
-    for (child_state, new) in
-        current_children.iter_mut().zip(new_children.iter_mut())
-    {
+    for (child_state, new) in current_children.iter_mut().zip(new_children.iter_mut()) {
         diff(child_state, new);
     }
 }
@@ -487,9 +463,7 @@ impl State {
     {
         match self {
             State::None => panic!("Downcast on stateless state"),
-            State::Some(state) => {
-                state.downcast_ref().expect("Downcast widget state")
-            }
+            State::Some(state) => state.downcast_ref().expect("Downcast widget state"),
         }
     }
 
@@ -503,9 +477,7 @@ impl State {
     {
         match self {
             State::None => panic!("Downcast on stateless state"),
-            State::Some(state) => {
-                state.downcast_mut().expect("Downcast widget state")
-            }
+            State::Some(state) => state.downcast_mut().expect("Downcast widget state"),
         }
     }
 }

--- a/core/src/window/icon.rs
+++ b/core/src/window/icon.rs
@@ -4,11 +4,7 @@ use crate::Size;
 use std::mem;
 
 /// Builds an  [`Icon`] from its RGBA pixels in the `sRGB` color space.
-pub fn from_rgba(
-    rgba: Vec<u8>,
-    width: u32,
-    height: u32,
-) -> Result<Icon, Error> {
+pub fn from_rgba(rgba: Vec<u8>, width: u32, height: u32) -> Result<Icon, Error> {
     const PIXEL_SIZE: usize = mem::size_of::<u8>() * 4;
 
     if !rgba.len().is_multiple_of(PIXEL_SIZE) {

--- a/core/src/window/screenshot.rs
+++ b/core/src/window/screenshot.rs
@@ -31,11 +31,7 @@ impl Debug for Screenshot {
 
 impl Screenshot {
     /// Creates a new [`Screenshot`].
-    pub fn new(
-        rgba: impl Into<Bytes>,
-        size: Size<u32>,
-        scale_factor: f32,
-    ) -> Self {
+    pub fn new(rgba: impl Into<Bytes>, size: Size<u32>, scale_factor: f32) -> Self {
         Self {
             rgba: rgba.into(),
             size,
@@ -50,8 +46,7 @@ impl Screenshot {
             return Err(CropError::Zero);
         }
 
-        if region.x + region.width > self.size.width
-            || region.y + region.height > self.size.height
+        if region.x + region.width > self.size.width || region.y + region.height > self.size.height
         {
             return Err(CropError::OutOfBounds);
         }
@@ -61,19 +56,20 @@ impl Screenshot {
 
         let bytes_per_row = self.size.width as usize * PIXEL_SIZE;
         let row_range = region.y as usize..(region.y + region.height) as usize;
-        let column_range = region.x as usize * PIXEL_SIZE
-            ..(region.x + region.width) as usize * PIXEL_SIZE;
+        let column_range =
+            region.x as usize * PIXEL_SIZE..(region.x + region.width) as usize * PIXEL_SIZE;
 
-        let chopped = self.rgba.chunks(bytes_per_row).enumerate().fold(
-            vec![],
-            |mut acc, (row, bytes)| {
-                if row_range.contains(&row) {
-                    acc.extend(&bytes[column_range.clone()]);
-                }
+        let chopped =
+            self.rgba
+                .chunks(bytes_per_row)
+                .enumerate()
+                .fold(vec![], |mut acc, (row, bytes)| {
+                    if row_range.contains(&row) {
+                        acc.extend(&bytes[column_range.clone()]);
+                    }
 
-                acc
-            },
-        );
+                    acc
+                });
 
         Ok(Self {
             rgba: Bytes::from(chopped),

--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -147,12 +147,11 @@ mod internal {
     pub fn init(metadata: Metadata) {
         let name = metadata.name.split("::").next().unwrap_or(metadata.name);
 
-        *METADATA.write().expect("Write application metadata") =
-            client::Metadata {
-                name,
-                theme: metadata.theme,
-                can_time_travel: metadata.can_time_travel,
-            };
+        *METADATA.write().expect("Write application metadata") = client::Metadata {
+            name,
+            theme: metadata.theme,
+            can_time_travel: metadata.can_time_travel,
+        };
     }
 
     pub fn quit() -> bool {
@@ -170,9 +169,7 @@ mod internal {
             return;
         };
 
-        if METADATA.read().expect("Read last palette").theme.as_ref()
-            != Some(&palette)
-        {
+        if METADATA.read().expect("Read last palette").theme.as_ref() != Some(&palette) {
             log(client::Event::ThemeChanged(palette));
 
             METADATA.write().expect("Write last palette").theme = Some(palette);
@@ -205,9 +202,7 @@ mod internal {
         let elapsed = start.elapsed();
 
         if elapsed.as_millis() >= 1 {
-            log::warn!(
-                "Slow `Debug` implementation of `Message` (took {elapsed:?})!"
-            );
+            log::warn!("Slow `Debug` implementation of `Message` (took {elapsed:?})!");
         }
 
         let message = if message.len() > 49 {
@@ -271,9 +266,7 @@ mod internal {
 
             stream::unfold(BEACON.subscribe(), async move |mut receiver| {
                 let command = match receiver.recv().await? {
-                    client::Command::RewindTo { message } => {
-                        Command::RewindTo { message }
-                    }
+                    client::Command::RewindTo { message } => Command::RewindTo { message },
                     client::Command::GoLive => Command::GoLive,
                 };
 
@@ -421,8 +414,7 @@ mod hot {
 
     static IS_STALE: AtomicBool = AtomicBool::new(false);
 
-    static HOT_FUNCTIONS_PENDING: Mutex<BTreeSet<u64>> =
-        Mutex::new(BTreeSet::new());
+    static HOT_FUNCTIONS_PENDING: Mutex<BTreeSet<u64>> = Mutex::new(BTreeSet::new());
 
     static HOT_FUNCTIONS: OnceLock<BTreeSet<u64>> = OnceLock::new();
 
@@ -433,9 +425,7 @@ mod hot {
             if HOT_FUNCTIONS.get().is_none() {
                 HOT_FUNCTIONS
                     .set(std::mem::take(
-                        &mut HOT_FUNCTIONS_PENDING
-                            .lock()
-                            .expect("Lock hot functions"),
+                        &mut HOT_FUNCTIONS_PENDING.lock().expect("Lock hot functions"),
                     ))
                     .expect("Set hot functions");
             }

--- a/devtools/src/comet.rs
+++ b/devtools/src/comet.rs
@@ -2,8 +2,7 @@ use crate::runtime::task::{self, Task};
 
 use std::process;
 
-pub const COMPATIBLE_REVISION: &str =
-    "3f75f3240edc1719df584810337bc7df010327d8";
+pub const COMPATIBLE_REVISION: &str = "3f75f3240edc1719df584810337bc7df010327d8";
 
 pub fn launch() -> Task<launch::Result> {
     task::try_blocking(|mut sender| {
@@ -65,9 +64,7 @@ pub fn install() -> Task<install::Result> {
             .stderr(Stdio::piped())
             .spawn()?;
 
-        let mut stderr = BufReader::new(
-            install.stderr.take().expect("stderr must be piped"),
-        );
+        let mut stderr = BufReader::new(install.stderr.take().expect("stderr must be piped"));
 
         let mut log = String::new();
 
@@ -82,8 +79,7 @@ pub fn install() -> Task<install::Result> {
                 }
             }
 
-            let _ = sender
-                .try_send(install::Event::Logged(log.trim_end().to_owned()));
+            let _ = sender.try_send(install::Event::Logged(log.trim_end().to_owned()));
 
             log.clear();
         }

--- a/devtools/src/lib.rs
+++ b/devtools/src/lib.rs
@@ -14,17 +14,15 @@ use crate::core::keyboard;
 use crate::core::theme::{self, Theme};
 use crate::core::time::seconds;
 use crate::core::window;
-use crate::core::{
-    Alignment::Center, Color, Element, Font, Length::Fill, Settings,
-};
+use crate::core::{Alignment::Center, Color, Element, Font, Length::Fill, Settings};
 use crate::futures::Subscription;
 use crate::program::Program;
 use crate::program::message;
 use crate::runtime::task::{self, Task};
 use crate::time_machine::TimeMachine;
 use crate::widget::{
-    bottom_right, button, center, column, container, opaque, row, scrollable,
-    space, stack, text, themer,
+    bottom_right, button, center, column, container, opaque, row, scrollable, space, stack, text,
+    themer,
 };
 
 use std::fmt;
@@ -74,11 +72,7 @@ where
         )
     }
 
-    fn update(
-        &self,
-        state: &mut Self::State,
-        message: Self::Message,
-    ) -> Task<Self::Message> {
+    fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
         state.update(&self.program, message)
     }
 
@@ -98,11 +92,7 @@ where
         state.subscription(&self.program)
     }
 
-    fn theme(
-        &self,
-        state: &Self::State,
-        window: window::Id,
-    ) -> Option<Self::Theme> {
+    fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
         state.theme(&self.program, window)
     }
 
@@ -220,16 +210,14 @@ where
                     Task::none()
                 }
                 Message::InstallComet => {
-                    self.mode =
-                        Mode::Setup(Setup::Running { logs: Vec::new() });
+                    self.mode = Mode::Setup(Setup::Running { logs: Vec::new() });
 
                     comet::install()
                         .map(Message::Installing)
                         .map(Event::Message)
                 }
                 Message::Installing(Ok(installation)) => {
-                    let Mode::Setup(Setup::Running { logs }) = &mut self.mode
-                    else {
+                    let Mode::Setup(Setup::Running { logs }) = &mut self.mode else {
                         return Task::none();
                     };
 
@@ -245,8 +233,7 @@ where
                     }
                 }
                 Message::Installing(Err(error)) => {
-                    let Mode::Setup(Setup::Running { logs }) = &mut self.mode
-                    else {
+                    let Mode::Setup(Setup::Running { logs }) = &mut self.mode else {
                         return Task::none();
                     };
 
@@ -339,10 +326,7 @@ where
                     .style(container::bordered_box),
             )
             .padding(10)
-            .style(|_theme| {
-                container::Style::default()
-                    .background(Color::BLACK.scale_alpha(0.8))
-            });
+            .style(|_theme| container::Style::default().background(Color::BLACK.scale_alpha(0.8)));
 
             Some(themer(theme(), opaque(setup).map(Event::Message)))
         } else {
@@ -353,19 +337,14 @@ where
             .show_notification
             .then(|| text("Press F12 to open debug metrics"))
             .or_else(|| {
-                debug::is_stale().then(|| {
-                    text(
-                        "Types have changed. Restart to re-enable hotpatching.",
-                    )
-                })
+                debug::is_stale()
+                    .then(|| text("Types have changed. Restart to re-enable hotpatching."))
             })
             .map(|notification| {
                 themer(
                     theme(),
                     bottom_right(opaque(
-                        container(notification)
-                            .padding(10)
-                            .style(container::dark),
+                        container(notification).padding(10).style(container::dark),
                     )),
                 )
             });
@@ -377,15 +356,13 @@ where
     }
 
     pub fn subscription(&self, program: &P) -> Subscription<Event<P>> {
-        let subscription =
-            program.subscription(&self.state).map(Event::Program);
+        let subscription = program.subscription(&self.state).map(Event::Program);
         debug::subscriptions_tracked(subscription.units());
 
         let hotkeys = futures::keyboard::listen()
             .filter_map(|event| match event {
                 keyboard::Event::KeyPressed {
-                    modified_key:
-                        keyboard::Key::Named(keyboard::key::Named::F12),
+                    modified_key: keyboard::Key::Named(keyboard::key::Named::F12),
                     ..
                 } => Some(Message::ToggleComet),
                 _ => None,
@@ -527,9 +504,7 @@ where
     })
 }
 
-fn installation<'a, Renderer>(
-    logs: &'a [String],
-) -> Element<'a, Message, Theme, Renderer>
+fn installation<'a, Renderer>(logs: &'a [String]) -> Element<'a, Message, Theme, Renderer>
 where
     Renderer: program::Renderer + 'a,
 {
@@ -537,9 +512,10 @@ where
         text("Installing comet...").size(20),
         container(
             scrollable(
-                column(logs.iter().map(|log| {
-                    text(log).size(12).font(Font::MONOSPACE).into()
-                }))
+                column(
+                    logs.iter()
+                        .map(|log| { text(log).size(12).font(Font::MONOSPACE).into() })
+                )
                 .spacing(3),
             )
             .spacing(10)

--- a/examples/arc/src/main.rs
+++ b/examples/arc/src/main.rs
@@ -1,9 +1,7 @@
 use std::{f32::consts::PI, time::Instant};
 
 use iced::mouse;
-use iced::widget::canvas::{
-    self, Cache, Canvas, Geometry, Path, Stroke, stroke,
-};
+use iced::widget::canvas::{self, Cache, Canvas, Geometry, Path, Stroke, stroke};
 use iced::window;
 use iced::{Element, Fill, Point, Rectangle, Renderer, Subscription, Theme};
 
@@ -64,10 +62,7 @@ impl<Message> canvas::Program<Message> for Arc {
 
             let start = Point::new(center.x, center.y - radius);
 
-            let angle = (self.start.elapsed().as_millis() % 10_000) as f32
-                / 10_000.0
-                * 2.0
-                * PI;
+            let angle = (self.start.elapsed().as_millis() % 10_000) as f32 / 10_000.0 * 2.0 * PI;
 
             let end = Point::new(
                 center.x + radius * angle.cos(),

--- a/examples/bezier_tool/src/main.rs
+++ b/examples/bezier_tool/src/main.rs
@@ -55,9 +55,7 @@ impl Example {
 
 mod bezier {
     use iced::mouse;
-    use iced::widget::canvas::{
-        self, Canvas, Event, Frame, Geometry, Path, Stroke,
-    };
+    use iced::widget::canvas::{self, Canvas, Event, Frame, Geometry, Path, Stroke};
     use iced::{Element, Fill, Point, Rectangle, Renderer, Theme};
 
     #[derive(Default)]
@@ -99,9 +97,7 @@ mod bezier {
             let cursor_position = cursor.position_in(bounds)?;
 
             match event {
-                Event::Mouse(mouse::Event::ButtonPressed(
-                    mouse::Button::Left,
-                )) => Some(
+                Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) => Some(
                     match *state {
                         None => {
                             *state = Some(Pending::One {
@@ -130,9 +126,7 @@ mod bezier {
                     }
                     .and_capture(),
                 ),
-                Event::Mouse(mouse::Event::CursorMoved { .. })
-                    if state.is_some() =>
-                {
+                Event::Mouse(mouse::Event::CursorMoved { .. }) if state.is_some() => {
                     Some(canvas::Action::request_redraw())
                 }
                 _ => None,
@@ -147,17 +141,16 @@ mod bezier {
             bounds: Rectangle,
             cursor: mouse::Cursor,
         ) -> Vec<Geometry> {
-            let content =
-                self.state.cache.draw(renderer, bounds.size(), |frame| {
-                    Curve::draw_all(self.curves, frame, theme);
+            let content = self.state.cache.draw(renderer, bounds.size(), |frame| {
+                Curve::draw_all(self.curves, frame, theme);
 
-                    frame.stroke(
-                        &Path::rectangle(Point::ORIGIN, frame.size()),
-                        Stroke::default()
-                            .with_width(2.0)
-                            .with_color(theme.palette().text),
-                    );
-                });
+                frame.stroke(
+                    &Path::rectangle(Point::ORIGIN, frame.size()),
+                    Stroke::default()
+                        .with_width(2.0)
+                        .with_color(theme.palette().text),
+                );
+            });
 
             if let Some(pending) = state {
                 vec![content, pending.draw(renderer, theme, bounds, cursor)]

--- a/examples/changelog/src/changelog.rs
+++ b/examples/changelog/src/changelog.rs
@@ -233,11 +233,7 @@ pub struct Entry {
 }
 
 impl Entry {
-    pub fn new(
-        title: &str,
-        category: Category,
-        pull_request: &PullRequest,
-    ) -> Option<Self> {
+    pub fn new(title: &str, category: Category, pull_request: &PullRequest) -> Option<Self> {
         let title = title.strip_suffix(".").unwrap_or(title);
 
         if title.is_empty() {
@@ -262,8 +258,7 @@ pub enum Category {
 }
 
 impl Category {
-    pub const ALL: &'static [Self] =
-        &[Self::Added, Self::Changed, Self::Fixed, Self::Removed];
+    pub const ALL: &'static [Self] = &[Self::Added, Self::Changed, Self::Fixed, Self::Removed];
 
     pub fn guess(label: &str) -> Option<Self> {
         Some(match label {
@@ -356,8 +351,7 @@ impl PullRequest {
                 "Authorization",
                 format!(
                     "Bearer {}",
-                    env::var("GITHUB_TOKEN")
-                        .map_err(|_| Error::GitHubTokenNotFound)?
+                    env::var("GITHUB_TOKEN").map_err(|_| Error::GitHubTokenNotFound)?
                 ),
             );
 

--- a/examples/changelog/src/main.rs
+++ b/examples/changelog/src/main.rs
@@ -4,8 +4,8 @@ use crate::changelog::Changelog;
 
 use iced::font;
 use iced::widget::{
-    button, center, column, container, markdown, pick_list, progress_bar,
-    rich_text, row, scrollable, span, stack, text, text_input,
+    button, center, column, container, markdown, pick_list, progress_bar, rich_text, row,
+    scrollable, span, stack, text, text_input,
 };
 use iced::{Center, Element, Fill, FillPortion, Font, Task, Theme};
 
@@ -41,9 +41,7 @@ enum State {
 
 #[derive(Debug, Clone)]
 enum Message {
-    ChangelogListed(
-        Result<(Changelog, Vec<changelog::Contribution>), changelog::Error>,
-    ),
+    ChangelogListed(Result<(Changelog, Vec<changelog::Contribution>), changelog::Error>),
     PullRequestFetched(Result<changelog::PullRequest, changelog::Error>),
     LinkClicked(markdown::Uri),
     TitleChanged(String),
@@ -66,8 +64,7 @@ impl Generator {
         match message {
             Message::ChangelogListed(Ok((changelog, mut pending))) => {
                 if let Some(contribution) = pending.pop() {
-                    let preview =
-                        markdown::parse(&changelog.to_string()).collect();
+                    let preview = markdown::parse(&changelog.to_string()).collect();
 
                     *self = Self::Reviewing {
                         changelog,
@@ -168,18 +165,12 @@ impl Generator {
                     return Task::none();
                 };
 
-                if let Some(entry) =
-                    changelog::Entry::new(title, *category, pull_request)
-                {
+                if let Some(entry) = changelog::Entry::new(title, *category, pull_request) {
                     changelog.push(entry);
 
-                    let save = Task::perform(
-                        changelog.clone().save(),
-                        Message::ChangelogSaved,
-                    );
+                    let save = Task::perform(changelog.clone().save(), Message::ChangelogSaved);
 
-                    *preview =
-                        markdown::parse(&changelog.to_string()).collect();
+                    *preview = markdown::parse(&changelog.to_string()).collect();
 
                     if let Some(contribution) = pending.pop() {
                         *state = State::Loading(contribution.clone());
@@ -200,9 +191,7 @@ impl Generator {
                 }
             }
             Message::OpenPullRequest(id) => {
-                let _ = webbrowser::open(&format!(
-                    "https://github.com/iced-rs/iced/pull/{id}"
-                ));
+                let _ = webbrowser::open(&format!("https://github.com/iced-rs/iced/pull/{id}"));
 
                 Task::none()
             }
@@ -224,8 +213,7 @@ impl Generator {
             Self::Loading => center("Loading...").into(),
             Self::Done => center(
                 column![
-                    text("Changelog is up-to-date! 🎉")
-                        .shaping(text::Shaping::Advanced),
+                    text("Changelog is up-to-date! 🎉").shaping(text::Shaping::Advanced),
                     button("Quit").on_press(Message::Quit),
                 ]
                 .spacing(10)
@@ -243,8 +231,7 @@ impl Generator {
                     let total = pending.len() + changelog.len();
                     let percent = 100.0 * changelog.len() as f32 / total as f32;
 
-                    let bar = progress_bar(0.0..=100.0, percent)
-                        .style(progress_bar::secondary);
+                    let bar = progress_bar(0.0..=100.0, percent).style(progress_bar::secondary);
 
                     let label = text!(
                         "{amount_reviewed} / {total} ({percent:.0}%)",
@@ -257,9 +244,7 @@ impl Generator {
                 };
 
                 let form: Element<_> = match state {
-                    State::Loading(contribution) => {
-                        text!("Loading #{}...", contribution.id).into()
-                    }
+                    State::Loading(contribution) => text!("Loading #{}...", contribution.id).into(),
                     State::Loaded {
                         pull_request,
                         description,
@@ -268,36 +253,27 @@ impl Generator {
                     } => {
                         let details = {
                             let title = rich_text![
-                                span(&pull_request.title)
-                                    .size(24)
-                                    .link(pull_request.id),
+                                span(&pull_request.title).size(24).link(pull_request.id),
                                 "\n",
-                                span(format!(" by {}", pull_request.author))
-                                    .font(Font {
-                                        style: font::Style::Italic,
-                                        ..Font::default()
-                                    }),
+                                span(format!(" by {}", pull_request.author)).font(Font {
+                                    style: font::Style::Italic,
+                                    ..Font::default()
+                                }),
                             ]
                             .on_link_click(Message::OpenPullRequest)
                             .font(Font::MONOSPACE);
 
                             let description =
-                                markdown(description, self.theme())
-                                    .map(Message::LinkClicked);
+                                markdown(description, self.theme()).map(Message::LinkClicked);
 
-                            let labels =
-                                row(pull_request.labels.iter().map(|label| {
-                                    container(
-                                        text(label)
-                                            .size(10)
-                                            .font(Font::MONOSPACE),
-                                    )
+                            let labels = row(pull_request.labels.iter().map(|label| {
+                                container(text(label).size(10).font(Font::MONOSPACE))
                                     .padding(5)
                                     .style(container::rounded_box)
                                     .into()
-                                }))
-                                .spacing(10)
-                                .wrap();
+                            }))
+                            .spacing(10)
+                            .wrap();
 
                             let created_at = text(
                                 timezone
@@ -309,23 +285,15 @@ impl Generator {
 
                             column![
                                 title,
-                                row![labels, created_at]
-                                    .align_y(Center)
-                                    .spacing(10),
-                                scrollable(description)
-                                    .spacing(10)
-                                    .width(Fill)
-                                    .height(Fill)
+                                row![labels, created_at].align_y(Center).spacing(10),
+                                scrollable(description).spacing(10).width(Fill).height(Fill)
                             ]
                             .spacing(10)
                         };
 
-                        let title = text_input(
-                            "Type a changelog entry title...",
-                            title,
-                        )
-                        .on_input(Message::TitleChanged)
-                        .on_submit(Message::Next);
+                        let title = text_input("Type a changelog entry title...", title)
+                            .on_input(Message::TitleChanged)
+                            .on_submit(Message::Next);
 
                         let category = pick_list(
                             changelog::Category::ALL,
@@ -337,32 +305,24 @@ impl Generator {
                             .on_press(Message::Next)
                             .style(button::success);
 
-                        column![
-                            details,
-                            row![title, category, next].spacing(10)
-                        ]
-                        .spacing(10)
-                        .into()
+                        column![details, row![title, category, next].spacing(10)]
+                            .spacing(10)
+                            .into()
                     }
                 };
 
                 let preview = if preview.is_empty() {
                     center(
-                        container(
-                            text("The changelog is empty... so far!").size(12),
-                        )
-                        .padding(10)
-                        .style(container::rounded_box),
+                        container(text("The changelog is empty... so far!").size(12))
+                            .padding(10)
+                            .style(container::rounded_box),
                     )
                 } else {
                     container(
                         scrollable(
                             markdown(
                                 preview,
-                                markdown::Settings::with_text_size(
-                                    12,
-                                    self.theme(),
-                                ),
+                                markdown::Settings::with_text_size(12, self.theme()),
                             )
                             .map(Message::LinkClicked),
                         )

--- a/examples/checkbox/src/main.rs
+++ b/examples/checkbox/src/main.rs
@@ -68,8 +68,7 @@ impl Example {
                 shaping: text::Shaping::Basic,
             });
 
-        let content =
-            column![default_checkbox, checkboxes, custom_checkbox].spacing(20);
+        let content = column![default_checkbox, checkboxes, custom_checkbox].spacing(20);
 
         center(content).into()
     }

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -4,8 +4,8 @@ use iced::time::{self, milliseconds};
 use iced::widget::canvas::{Cache, Geometry, LineCap, Path, Stroke, stroke};
 use iced::widget::{canvas, container, text};
 use iced::{
-    Degrees, Element, Fill, Font, Point, Radians, Rectangle, Renderer, Size,
-    Subscription, Theme, Vector,
+    Degrees, Element, Fill, Font, Point, Radians, Rectangle, Renderer, Size, Subscription, Theme,
+    Vector,
 };
 
 pub fn main() -> iced::Result {
@@ -55,13 +55,11 @@ impl Clock {
     }
 
     fn subscription(&self) -> Subscription<Message> {
-        time::every(milliseconds(500))
-            .map(|_| Message::Tick(chrono::offset::Local::now()))
+        time::every(milliseconds(500)).map(|_| Message::Tick(chrono::offset::Local::now()))
     }
 
     fn theme(&self) -> Theme {
-        Theme::ALL[(self.now.timestamp() as usize / 10) % Theme::ALL.len()]
-            .clone()
+        Theme::ALL[(self.now.timestamp() as usize / 10) % Theme::ALL.len()].clone()
     }
 }
 
@@ -87,11 +85,9 @@ impl<Message> canvas::Program<Message> for Clock {
             let background = Path::circle(center, radius);
             frame.fill(&background, palette.secondary.strong.color);
 
-            let short_hand =
-                Path::line(Point::ORIGIN, Point::new(0.0, -0.5 * radius));
+            let short_hand = Path::line(Point::ORIGIN, Point::new(0.0, -0.5 * radius));
 
-            let long_hand =
-                Path::line(Point::ORIGIN, Point::new(0.0, -0.8 * radius));
+            let long_hand = Path::line(Point::ORIGIN, Point::new(0.0, -0.8 * radius));
 
             let width = radius / 100.0;
 
@@ -114,11 +110,9 @@ impl<Message> canvas::Program<Message> for Clock {
             };
 
             frame.translate(Vector::new(center.x, center.y));
-            let minutes_portion =
-                Radians::from(hand_rotation(self.now.minute(), 60)) / 12.0;
+            let minutes_portion = Radians::from(hand_rotation(self.now.minute(), 60)) / 12.0;
             let hour_hand_angle =
-                Radians::from(hand_rotation(self.now.hour(), 12))
-                    + minutes_portion;
+                Radians::from(hand_rotation(self.now.hour(), 12)) + minutes_portion;
 
             frame.with_save(|frame| {
                 frame.rotate(hour_hand_angle);
@@ -142,10 +136,7 @@ impl<Message> canvas::Program<Message> for Clock {
                 frame.fill_text(canvas::Text {
                     content: theme.to_string(),
                     size: (radius / 15.0).into(),
-                    position: Point::new(
-                        (0.78 * radius) * rotate_factor,
-                        -width * 2.0,
-                    ),
+                    position: Point::new((0.78 * radius) * rotate_factor, -width * 2.0),
                     color: palette.secondary.strong.text,
                     align_x: if rotate_factor > 0.0 {
                         text::Alignment::Right
@@ -160,8 +151,7 @@ impl<Message> canvas::Program<Message> for Clock {
 
             // Draw clock numbers
             for hour in 1..=12 {
-                let angle = Radians::from(hand_rotation(hour, 12))
-                    - Radians::from(Degrees(90.0));
+                let angle = Radians::from(hand_rotation(hour, 12)) - Radians::from(Degrees(90.0));
                 let x = radius * angle.0.cos();
                 let y = radius * angle.0.sin();
 
@@ -185,10 +175,7 @@ impl<Message> canvas::Program<Message> for Clock {
                 frame.with_save(|frame| {
                     frame.rotate(angle);
                     frame.fill(
-                        &Path::rectangle(
-                            Point::new(0.0, radius - 15.0),
-                            Size::new(width, 7.0),
-                        ),
+                        &Path::rectangle(Point::new(0.0, radius - 15.0), Size::new(width, 7.0)),
                         palette.secondary.strong.text,
                     );
                 });

--- a/examples/color_palette/src/main.rs
+++ b/examples/color_palette/src/main.rs
@@ -2,10 +2,7 @@ use iced::alignment;
 use iced::mouse;
 use iced::widget::canvas::{self, Canvas, Frame, Geometry, Path};
 use iced::widget::{Slider, column, row, text};
-use iced::{
-    Center, Color, Element, Fill, Font, Pixels, Point, Rectangle, Renderer,
-    Size, Vector,
-};
+use iced::{Center, Color, Element, Fill, Font, Pixels, Point, Rectangle, Renderer, Size, Vector};
 use palette::{Darken, Hsl, Lighten, ShiftHue, convert::FromColor, rgb::Rgb};
 use std::marker::PhantomData;
 use std::ops::RangeInclusive;
@@ -305,8 +302,7 @@ impl<C: ColorSpace + Copy> ColorPicker<C> {
             component: f32,
             update: impl Fn(f32) -> C + 'a,
         ) -> Slider<'a, f64, C> {
-            Slider::new(range, f64::from(component), move |v| update(v as f32))
-                .step(0.01)
+            Slider::new(range, f64::from(component), move |v| update(v as f32)).step(0.01)
         }
 
         row![
@@ -324,8 +320,7 @@ impl<C: ColorSpace + Copy> ColorPicker<C> {
 
 impl ColorSpace for Color {
     const LABEL: &'static str = "RGB";
-    const COMPONENT_RANGES: [RangeInclusive<f64>; 3] =
-        [0.0..=1.0, 0.0..=1.0, 0.0..=1.0];
+    const COMPONENT_RANGES: [RangeInclusive<f64>; 3] = [0.0..=1.0, 0.0..=1.0, 0.0..=1.0];
 
     fn new(r: f32, g: f32, b: f32) -> Self {
         Color::from_rgb(r, g, b)
@@ -347,15 +342,10 @@ impl ColorSpace for Color {
 
 impl ColorSpace for palette::Hsl {
     const LABEL: &'static str = "HSL";
-    const COMPONENT_RANGES: [RangeInclusive<f64>; 3] =
-        [0.0..=360.0, 0.0..=1.0, 0.0..=1.0];
+    const COMPONENT_RANGES: [RangeInclusive<f64>; 3] = [0.0..=360.0, 0.0..=1.0, 0.0..=1.0];
 
     fn new(hue: f32, saturation: f32, lightness: f32) -> Self {
-        palette::Hsl::new(
-            palette::RgbHue::from_degrees(hue),
-            saturation,
-            lightness,
-        )
+        palette::Hsl::new(palette::RgbHue::from_degrees(hue), saturation, lightness)
     }
 
     fn components(&self) -> [f32; 3] {
@@ -378,8 +368,7 @@ impl ColorSpace for palette::Hsl {
 
 impl ColorSpace for palette::Hsv {
     const LABEL: &'static str = "HSV";
-    const COMPONENT_RANGES: [RangeInclusive<f64>; 3] =
-        [0.0..=360.0, 0.0..=1.0, 0.0..=1.0];
+    const COMPONENT_RANGES: [RangeInclusive<f64>; 3] = [0.0..=360.0, 0.0..=1.0, 0.0..=1.0];
 
     fn new(hue: f32, saturation: f32, value: f32) -> Self {
         palette::Hsv::new(palette::RgbHue::from_degrees(hue), saturation, value)
@@ -405,15 +394,10 @@ impl ColorSpace for palette::Hsv {
 
 impl ColorSpace for palette::Hwb {
     const LABEL: &'static str = "HWB";
-    const COMPONENT_RANGES: [RangeInclusive<f64>; 3] =
-        [0.0..=360.0, 0.0..=1.0, 0.0..=1.0];
+    const COMPONENT_RANGES: [RangeInclusive<f64>; 3] = [0.0..=360.0, 0.0..=1.0, 0.0..=1.0];
 
     fn new(hue: f32, whiteness: f32, blackness: f32) -> Self {
-        palette::Hwb::new(
-            palette::RgbHue::from_degrees(hue),
-            whiteness,
-            blackness,
-        )
+        palette::Hwb::new(palette::RgbHue::from_degrees(hue), whiteness, blackness)
     }
 
     fn components(&self) -> [f32; 3] {
@@ -454,8 +438,7 @@ impl ColorSpace for palette::Lab {
 
 impl ColorSpace for palette::Lch {
     const LABEL: &'static str = "Lch";
-    const COMPONENT_RANGES: [RangeInclusive<f64>; 3] =
-        [0.0..=100.0, 0.0..=128.0, 0.0..=360.0];
+    const COMPONENT_RANGES: [RangeInclusive<f64>; 3] = [0.0..=100.0, 0.0..=128.0, 0.0..=360.0];
 
     fn new(l: f32, chroma: f32, hue: f32) -> Self {
         palette::Lch::new(l, chroma, palette::LabHue::from_degrees(hue))

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,5 +1,5 @@
+use iced::widget::{button, column, text, Column};
 use iced::Center;
-use iced::widget::{Column, button, column, text};
 
 pub fn main() -> iced::Result {
     iced::run(Counter::update, Counter::view)
@@ -42,7 +42,7 @@ impl Counter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use iced_test::{Error, simulator};
+    use iced_test::{simulator, Error};
 
     #[test]
     fn it_counts() -> Result<(), Error> {

--- a/examples/custom_quad/src/main.rs
+++ b/examples/custom_quad/src/main.rs
@@ -99,20 +99,16 @@ impl Example {
             text!("Radius: {top_left:.2}/{top_right:.2}/{bottom_right:.2}/{bottom_left:.2}"),
             slider(1.0..=200.0, top_left, Message::RadiusTopLeftChanged).step(0.01),
             slider(1.0..=200.0, top_right, Message::RadiusTopRightChanged).step(0.01),
-            slider(1.0..=200.0, bottom_right, Message::RadiusBottomRightChanged)
-                .step(0.01),
-            slider(1.0..=200.0, bottom_left, Message::RadiusBottomLeftChanged)
-                .step(0.01),
-            slider(0.0..=10.0, self.border_width, Message::BorderWidthChanged)
-                .step(0.01),
+            slider(1.0..=200.0, bottom_right, Message::RadiusBottomRightChanged).step(0.01),
+            slider(1.0..=200.0, bottom_left, Message::RadiusBottomLeftChanged).step(0.01),
+            slider(0.0..=10.0, self.border_width, Message::BorderWidthChanged).step(0.01),
             text!("Shadow: {sx:.2}x{sy:.2}, {sr:.2}"),
-            slider(-100.0..=100.0, sx, Message::ShadowXOffsetChanged)
-                .step(0.01),
-            slider(-100.0..=100.0, sy, Message::ShadowYOffsetChanged)
-                .step(0.01),
-            slider(0.0..=100.0, sr, Message::ShadowBlurRadiusChanged)
-                .step(0.01),
-            toggler(self.snap).label("Snap to pixel grid").on_toggle(Message::SnapToggled),
+            slider(-100.0..=100.0, sx, Message::ShadowXOffsetChanged).step(0.01),
+            slider(-100.0..=100.0, sy, Message::ShadowYOffsetChanged).step(0.01),
+            slider(0.0..=100.0, sr, Message::ShadowBlurRadiusChanged).step(0.01),
+            toggler(self.snap)
+                .label("Snap to pixel grid")
+                .on_toggle(Message::SnapToggled),
         ]
         .padding(20)
         .spacing(20)

--- a/examples/custom_shader/src/scene.rs
+++ b/examples/custom_shader/src/scene.rs
@@ -176,11 +176,7 @@ fn rnd_origin() -> Vec3 {
 }
 
 impl shader::Pipeline for Pipeline {
-    fn new(
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        format: wgpu::TextureFormat,
-    ) -> Pipeline {
+    fn new(device: &wgpu::Device, queue: &wgpu::Queue, format: wgpu::TextureFormat) -> Pipeline {
         Self::new(device, queue, format)
     }
 }

--- a/examples/custom_shader/src/scene/camera.rs
+++ b/examples/custom_shader/src/scene/camera.rs
@@ -35,12 +35,7 @@ impl Camera {
     pub fn build_view_proj_matrix(&self, bounds: Rectangle) -> glam::Mat4 {
         let aspect_ratio = bounds.width / bounds.height;
         let view = glam::Mat4::look_at_rh(self.eye, self.target, self.up);
-        let proj = glam::Mat4::perspective_rh(
-            self.fov_y,
-            aspect_ratio,
-            self.near,
-            self.far,
-        );
+        let proj = glam::Mat4::perspective_rh(self.fov_y, aspect_ratio, self.near, self.far);
 
         OPENGL_TO_WGPU_MATRIX * proj * view
     }

--- a/examples/custom_shader/src/scene/pipeline.rs
+++ b/examples/custom_shader/src/scene/pipeline.rs
@@ -28,18 +28,13 @@ pub struct Pipeline {
 }
 
 impl Pipeline {
-    pub fn new(
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        format: wgpu::TextureFormat,
-    ) -> Self {
+    pub fn new(device: &wgpu::Device, queue: &wgpu::Queue, format: wgpu::TextureFormat) -> Self {
         //vertices of one cube
-        let vertices =
-            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("cubes vertex buffer"),
-                contents: bytemuck::cast_slice(&cube::Raw::vertices()),
-                usage: wgpu::BufferUsages::VERTEX,
-            });
+        let vertices = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("cubes vertex buffer"),
+            contents: bytemuck::cast_slice(&cube::Raw::vertices()),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
 
         //cube instance data
         let cubes_buffer = Buffer::new(
@@ -69,13 +64,11 @@ impl Pipeline {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::Depth32Float,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
-                | wgpu::TextureUsages::TEXTURE_BINDING,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
         });
 
-        let depth_view =
-            depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let depth_view = depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         let normal_map_data = load_normal_map_data();
 
@@ -100,8 +93,7 @@ impl Pipeline {
             &normal_map_data,
         );
 
-        let normal_view =
-            normal_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let normal_view = normal_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         //skybox texture for reflection/refraction
         let skybox_data = load_skybox_data();
@@ -126,12 +118,11 @@ impl Pipeline {
             &skybox_data,
         );
 
-        let sky_view =
-            skybox_texture.create_view(&wgpu::TextureViewDescriptor {
-                label: Some("cubes skybox texture view"),
-                dimension: Some(wgpu::TextureViewDimension::Cube),
-                ..Default::default()
-            });
+        let sky_view = skybox_texture.create_view(&wgpu::TextureViewDescriptor {
+            label: Some("cubes skybox texture view"),
+            dimension: Some(wgpu::TextureViewDimension::Cube),
+            ..Default::default()
+        });
 
         let sky_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             label: Some("cubes skybox sampler"),
@@ -162,9 +153,7 @@ impl Pipeline {
                         binding: 1,
                         visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
-                            sample_type: wgpu::TextureSampleType::Float {
-                                filterable: true,
-                            },
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
                             view_dimension: wgpu::TextureViewDimension::Cube,
                             multisampled: false,
                         },
@@ -173,18 +162,14 @@ impl Pipeline {
                     wgpu::BindGroupLayoutEntry {
                         binding: 2,
                         visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Sampler(
-                            wgpu::SamplerBindingType::Filtering,
-                        ),
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                         count: None,
                     },
                     wgpu::BindGroupLayoutEntry {
                         binding: 3,
                         visibility: wgpu::ShaderStages::FRAGMENT,
                         ty: wgpu::BindingType::Texture {
-                            sample_type: wgpu::TextureSampleType::Float {
-                                filterable: true,
-                            },
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
                             view_dimension: wgpu::TextureViewDimension::D2,
                             multisampled: false,
                         },
@@ -193,96 +178,88 @@ impl Pipeline {
                 ],
             });
 
-        let uniform_bind_group =
-            device.create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("cubes uniform bind group"),
-                layout: &uniform_bind_group_layout,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: uniforms.as_entire_binding(),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 1,
-                        resource: wgpu::BindingResource::TextureView(&sky_view),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 2,
-                        resource: wgpu::BindingResource::Sampler(&sky_sampler),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 3,
-                        resource: wgpu::BindingResource::TextureView(
-                            &normal_view,
-                        ),
-                    },
-                ],
-            });
-
-        let layout =
-            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("cubes pipeline layout"),
-                bind_group_layouts: &[&uniform_bind_group_layout],
-                immediate_size: 0,
-            });
-
-        let shader =
-            device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("cubes shader"),
-                source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
-                    include_str!("../shaders/cubes.wgsl"),
-                )),
-            });
-
-        let pipeline =
-            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("cubes pipeline"),
-                layout: Some(&layout),
-                vertex: wgpu::VertexState {
-                    module: &shader,
-                    entry_point: Some("vs_main"),
-                    buffers: &[Vertex::desc(), cube::Raw::desc()],
-                    compilation_options:
-                        wgpu::PipelineCompilationOptions::default(),
+        let uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("cubes uniform bind group"),
+            layout: &uniform_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: uniforms.as_entire_binding(),
                 },
-                primitive: wgpu::PrimitiveState::default(),
-                depth_stencil: Some(wgpu::DepthStencilState {
-                    format: wgpu::TextureFormat::Depth32Float,
-                    depth_write_enabled: true,
-                    depth_compare: wgpu::CompareFunction::Less,
-                    stencil: wgpu::StencilState::default(),
-                    bias: wgpu::DepthBiasState::default(),
-                }),
-                multisample: wgpu::MultisampleState {
-                    count: 1,
-                    mask: !0,
-                    alpha_to_coverage_enabled: false,
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&sky_view),
                 },
-                fragment: Some(wgpu::FragmentState {
-                    module: &shader,
-                    entry_point: Some("fs_main"),
-                    targets: &[Some(wgpu::ColorTargetState {
-                        format,
-                        blend: Some(wgpu::BlendState {
-                            color: wgpu::BlendComponent {
-                                src_factor: wgpu::BlendFactor::SrcAlpha,
-                                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                                operation: wgpu::BlendOperation::Add,
-                            },
-                            alpha: wgpu::BlendComponent {
-                                src_factor: wgpu::BlendFactor::One,
-                                dst_factor: wgpu::BlendFactor::One,
-                                operation: wgpu::BlendOperation::Max,
-                            },
-                        }),
-                        write_mask: wgpu::ColorWrites::ALL,
-                    })],
-                    compilation_options:
-                        wgpu::PipelineCompilationOptions::default(),
-                }),
-                multiview_mask: None,
-                cache: None,
-            });
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(&sky_sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: wgpu::BindingResource::TextureView(&normal_view),
+                },
+            ],
+        });
+
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("cubes pipeline layout"),
+            bind_group_layouts: &[&uniform_bind_group_layout],
+            immediate_size: 0,
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("cubes shader"),
+            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(include_str!(
+                "../shaders/cubes.wgsl"
+            ))),
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("cubes pipeline"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[Vertex::desc(), cube::Raw::desc()],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: wgpu::TextureFormat::Depth32Float,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::Less,
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState {
+                        color: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::SrcAlpha,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        alpha: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::One,
+                            dst_factor: wgpu::BlendFactor::One,
+                            operation: wgpu::BlendOperation::Max,
+                        },
+                    }),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            multiview_mask: None,
+            cache: None,
+        });
 
         let depth_pipeline = DepthPipeline::new(
             device,
@@ -322,8 +299,7 @@ impl Pipeline {
                 view_formats: &[],
             });
 
-            self.depth_view =
-                text.create_view(&wgpu::TextureViewDescriptor::default());
+            self.depth_view = text.create_view(&wgpu::TextureViewDescriptor::default());
             self.depth_texture_size = size;
 
             self.depth_pipeline.update(device, &text);
@@ -362,34 +338,29 @@ impl Pipeline {
         show_depth: bool,
     ) {
         {
-            let mut pass =
-                encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: Some("cubes.pipeline.pass"),
-                    color_attachments: &[Some(
-                        wgpu::RenderPassColorAttachment {
-                            view: target,
-                            depth_slice: None,
-                            resolve_target: None,
-                            ops: wgpu::Operations {
-                                load: wgpu::LoadOp::Load,
-                                store: wgpu::StoreOp::Store,
-                            },
-                        },
-                    )],
-                    depth_stencil_attachment: Some(
-                        wgpu::RenderPassDepthStencilAttachment {
-                            view: &self.depth_view,
-                            depth_ops: Some(wgpu::Operations {
-                                load: wgpu::LoadOp::Clear(1.0),
-                                store: wgpu::StoreOp::Store,
-                            }),
-                            stencil_ops: None,
-                        },
-                    ),
-                    timestamp_writes: None,
-                    occlusion_query_set: None,
-                    multiview_mask: None,
-                });
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("cubes.pipeline.pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: target,
+                    depth_slice: None,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                    view: &self.depth_view,
+                    depth_ops: Some(wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(1.0),
+                        store: wgpu::StoreOp::Store,
+                    }),
+                    stencil_ops: None,
+                }),
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
 
             pass.set_viewport(
                 clip_bounds.x as f32,
@@ -431,32 +402,27 @@ impl DepthPipeline {
             ..Default::default()
         });
 
-        let bind_group_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("cubes.depth_pipeline.bind_group_layout"),
-                entries: &[
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Sampler(
-                            wgpu::SamplerBindingType::NonFiltering,
-                        ),
-                        count: None,
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("cubes.depth_pipeline.bind_group_layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
                     },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 1,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Texture {
-                            sample_type: wgpu::TextureSampleType::Float {
-                                filterable: false,
-                            },
-                            view_dimension: wgpu::TextureViewDimension::D2,
-                            multisampled: false,
-                        },
-                        count: None,
-                    },
-                ],
-            });
+                    count: None,
+                },
+            ],
+        });
 
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("cubes.depth_pipeline.bind_group"),
@@ -468,62 +434,55 @@ impl DepthPipeline {
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: wgpu::BindingResource::TextureView(
-                        &depth_texture,
-                    ),
+                    resource: wgpu::BindingResource::TextureView(&depth_texture),
                 },
             ],
         });
 
-        let layout =
-            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("cubes.depth_pipeline.layout"),
-                bind_group_layouts: &[&bind_group_layout],
-                immediate_size: 0,
-            });
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("cubes.depth_pipeline.layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            immediate_size: 0,
+        });
 
-        let shader =
-            device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("cubes.depth_pipeline.shader"),
-                source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
-                    include_str!("../shaders/depth.wgsl"),
-                )),
-            });
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("cubes.depth_pipeline.shader"),
+            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(include_str!(
+                "../shaders/depth.wgsl"
+            ))),
+        });
 
-        let pipeline =
-            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("cubes.depth_pipeline.pipeline"),
-                layout: Some(&layout),
-                vertex: wgpu::VertexState {
-                    module: &shader,
-                    entry_point: Some("vs_main"),
-                    buffers: &[],
-                    compilation_options:
-                        wgpu::PipelineCompilationOptions::default(),
-                },
-                primitive: wgpu::PrimitiveState::default(),
-                depth_stencil: Some(wgpu::DepthStencilState {
-                    format: wgpu::TextureFormat::Depth32Float,
-                    depth_write_enabled: false,
-                    depth_compare: wgpu::CompareFunction::Less,
-                    stencil: wgpu::StencilState::default(),
-                    bias: wgpu::DepthBiasState::default(),
-                }),
-                multisample: wgpu::MultisampleState::default(),
-                fragment: Some(wgpu::FragmentState {
-                    module: &shader,
-                    entry_point: Some("fs_main"),
-                    targets: &[Some(wgpu::ColorTargetState {
-                        format,
-                        blend: Some(wgpu::BlendState::REPLACE),
-                        write_mask: wgpu::ColorWrites::ALL,
-                    })],
-                    compilation_options:
-                        wgpu::PipelineCompilationOptions::default(),
-                }),
-                multiview_mask: None,
-                cache: None,
-            });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("cubes.depth_pipeline.pipeline"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: Some(wgpu::DepthStencilState {
+                format: wgpu::TextureFormat::Depth32Float,
+                depth_write_enabled: false,
+                depth_compare: wgpu::CompareFunction::Less,
+                stencil: wgpu::StencilState::default(),
+                bias: wgpu::DepthBiasState::default(),
+            }),
+            multisample: wgpu::MultisampleState::default(),
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            multiview_mask: None,
+            cache: None,
+        });
 
         Self {
             pipeline,
@@ -534,31 +493,23 @@ impl DepthPipeline {
         }
     }
 
-    pub fn update(
-        &mut self,
-        device: &wgpu::Device,
-        depth_texture: &wgpu::Texture,
-    ) {
-        self.depth_view =
-            depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
+    pub fn update(&mut self, device: &wgpu::Device, depth_texture: &wgpu::Texture) {
+        self.depth_view = depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
 
-        self.bind_group =
-            device.create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("cubes.depth_pipeline.bind_group"),
-                layout: &self.bind_group_layout,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: wgpu::BindingResource::Sampler(&self.sampler),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 1,
-                        resource: wgpu::BindingResource::TextureView(
-                            &self.depth_view,
-                        ),
-                    },
-                ],
-            });
+        self.bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("cubes.depth_pipeline.bind_group"),
+            layout: &self.bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&self.depth_view),
+                },
+            ],
+        });
     }
 
     pub fn render(
@@ -578,13 +529,11 @@ impl DepthPipeline {
                     store: wgpu::StoreOp::Store,
                 },
             })],
-            depth_stencil_attachment: Some(
-                wgpu::RenderPassDepthStencilAttachment {
-                    view: &self.depth_view,
-                    depth_ops: None,
-                    stencil_ops: None,
-                },
-            ),
+            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                view: &self.depth_view,
+                depth_ops: None,
+                stencil_ops: None,
+            }),
             timestamp_writes: None,
             occlusion_query_set: None,
             multiview_mask: None,
@@ -615,13 +564,10 @@ fn load_skybox_data() -> Vec<u8> {
     let data: [&[u8]; 6] = [pos_x, neg_x, pos_y, neg_y, pos_z, neg_z];
 
     data.iter().fold(vec![], |mut acc, bytes| {
-        let i = image::load_from_memory_with_format(
-            bytes,
-            image::ImageFormat::Jpeg,
-        )
-        .unwrap()
-        .to_rgba8()
-        .into_raw();
+        let i = image::load_from_memory_with_format(bytes, image::ImageFormat::Jpeg)
+            .unwrap()
+            .to_rgba8()
+            .into_raw();
 
         acc.extend(i);
         acc

--- a/examples/custom_shader/src/scene/pipeline/cube.rs
+++ b/examples/custom_shader/src/scene/pipeline/cube.rs
@@ -46,10 +46,8 @@ impl Cube {
     }
 
     pub fn update(&mut self, size: f32, time: f32) {
-        self.rotation = glam::Quat::from_axis_angle(
-            self.rotation_axis,
-            time / 2.0 * self.rotation_dir,
-        );
+        self.rotation =
+            glam::Quat::from_axis_angle(self.rotation_axis, time / 2.0 * self.rotation_dir);
         self.size = size;
     }
 }

--- a/examples/custom_widget/src/main.rs
+++ b/examples/custom_widget/src/main.rs
@@ -62,8 +62,7 @@ mod circle {
         }
     }
 
-    impl<Message, Theme, Renderer> From<Circle>
-        for Element<'_, Message, Theme, Renderer>
+    impl<Message, Theme, Renderer> From<Circle> for Element<'_, Message, Theme, Renderer>
     where
         Renderer: renderer::Renderer,
     {

--- a/examples/delineate/src/main.rs
+++ b/examples/delineate/src/main.rs
@@ -1,13 +1,8 @@
 use iced::event::{self, Event};
 use iced::mouse;
-use iced::widget::{
-    self, column, container, row, scrollable, selector, space, text,
-};
+use iced::widget::{self, column, container, row, scrollable, selector, space, text};
 use iced::window;
-use iced::{
-    Center, Color, Element, Fill, Font, Point, Rectangle, Subscription, Task,
-    Theme,
-};
+use iced::{Center, Color, Element, Fill, Font, Point, Rectangle, Subscription, Task, Theme};
 
 pub fn main() -> iced::Result {
     iced::application(Example::default, Example::update, Example::view)
@@ -45,14 +40,12 @@ impl Example {
                 selector::find(INNER_CONTAINER).map(Message::InnerFound),
             ]),
             Message::OuterFound(outer) => {
-                self.outer_bounds =
-                    outer.as_ref().and_then(selector::Target::visible_bounds);
+                self.outer_bounds = outer.as_ref().and_then(selector::Target::visible_bounds);
 
                 Task::none()
             }
             Message::InnerFound(inner) => {
-                self.inner_bounds =
-                    inner.as_ref().and_then(selector::Target::visible_bounds);
+                self.inner_bounds = inner.as_ref().and_then(selector::Target::visible_bounds);
 
                 Task::none()
             }
@@ -82,9 +75,7 @@ impl Example {
                 },
                 if bounds
                     .zip(self.mouse_position)
-                    .map(|(bounds, mouse_position)| {
-                        bounds.contains(mouse_position)
-                    })
+                    .map(|(bounds, mouse_position)| bounds.contains(mouse_position))
                     .unwrap_or_default()
                 {
                     Some(Color {
@@ -149,9 +140,7 @@ impl Example {
             Event::Mouse(mouse::Event::CursorMoved { position }) => {
                 Some(Message::MouseMoved(position))
             }
-            Event::Window(window::Event::Resized { .. }) => {
-                Some(Message::WindowResized)
-            }
+            Event::Window(window::Event::Resized { .. }) => Some(Message::WindowResized),
             _ => None,
         })
     }

--- a/examples/download_progress/src/main.rs
+++ b/examples/download_progress/src/main.rs
@@ -50,8 +50,7 @@ impl Example {
                 task.map(Message::DownloadUpdated.with(index))
             }
             Message::DownloadUpdated(id, update) => {
-                if let Some(download) =
-                    self.downloads.iter_mut().find(|download| download.id == id)
+                if let Some(download) = self.downloads.iter_mut().find(|download| download.id == id)
                 {
                     download.update(update);
                 }
@@ -62,15 +61,14 @@ impl Example {
     }
 
     fn view(&self) -> Element<'_, Message> {
-        let downloads =
-            Column::with_children(self.downloads.iter().map(Download::view))
-                .push(
-                    button("Add another download")
-                        .on_press(Message::Add)
-                        .padding(10),
-                )
-                .spacing(20)
-                .align_x(Right);
+        let downloads = Column::with_children(self.downloads.iter().map(Download::view))
+            .push(
+                button("Add another download")
+                    .on_press(Message::Add)
+                    .padding(10),
+            )
+            .spacing(20)
+            .align_x(Right);
 
         center(downloads).padding(20).into()
     }
@@ -166,15 +164,11 @@ impl Download {
             State::Idle => button("Start the download!")
                 .on_press(Message::Download(self.id))
                 .into(),
-            State::Finished => {
-                column!["Download finished!", button("Start again")]
-                    .spacing(10)
-                    .align_x(Center)
-                    .into()
-            }
-            State::Downloading { .. } => {
-                text!("Downloading... {current_progress:.2}%").into()
-            }
+            State::Finished => column!["Download finished!", button("Start again")]
+                .spacing(10)
+                .align_x(Center)
+                .into(),
+            State::Downloading { .. } => text!("Downloading... {current_progress:.2}%").into(),
             State::Errored => column![
                 "Something went wrong :(",
                 button("Try again").on_press(Message::Download(self.id)),

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -1,8 +1,8 @@
 use iced::highlighter;
 use iced::keyboard;
 use iced::widget::{
-    button, center_x, column, container, operation, pick_list, row, space,
-    text, text_editor, toggler, tooltip,
+    button, center_x, column, container, operation, pick_list, row, space, text, text_editor,
+    toggler, tooltip,
 };
 use iced::window;
 use iced::{Center, Element, Fill, Font, Task, Theme, Window};
@@ -54,10 +54,7 @@ impl Editor {
             },
             Task::batch([
                 Task::perform(
-                    load_file(concat!(
-                        env!("CARGO_MANIFEST_DIR"),
-                        "/src/main.rs",
-                    )),
+                    load_file(concat!(env!("CARGO_MANIFEST_DIR"), "/src/main.rs",)),
                     Message::FileOpened,
                 ),
                 operation::focus(EDITOR),
@@ -129,10 +126,7 @@ impl Editor {
                         text.push_str(ending.as_str());
                     }
 
-                    Task::perform(
-                        save_file(self.file.clone(), text),
-                        Message::FileSaved,
-                    )
+                    Task::perform(save_file(self.file.clone(), text), Message::FileSaved)
                 }
             }
             Message::FileSaved(result) => {
@@ -222,12 +216,8 @@ impl Editor {
                 )
                 .key_binding(|key_press| {
                     match key_press.key.as_ref() {
-                        keyboard::Key::Character("s")
-                            if key_press.modifiers.command() =>
-                        {
-                            Some(text_editor::Binding::Custom(
-                                Message::SaveFile,
-                            ))
+                        keyboard::Key::Character("s") if key_press.modifiers.command() => {
+                            Some(text_editor::Binding::Custom(Message::SaveFile))
                         }
                         _ => text_editor::Binding::from_key_press(key_press),
                     }
@@ -262,16 +252,13 @@ fn open_file(
         .set_parent(&window);
 
     async move {
-        let picked_file =
-            dialog.pick_file().await.ok_or(Error::DialogClosed)?;
+        let picked_file = dialog.pick_file().await.ok_or(Error::DialogClosed)?;
 
         load_file(picked_file).await
     }
 }
 
-async fn load_file(
-    path: impl Into<PathBuf>,
-) -> Result<(PathBuf, Arc<String>), Error> {
+async fn load_file(path: impl Into<PathBuf>) -> Result<(PathBuf, Arc<String>), Error> {
     let path = path.into();
 
     let contents = tokio::fs::read_to_string(&path)
@@ -282,10 +269,7 @@ async fn load_file(
     Ok((path, contents))
 }
 
-async fn save_file(
-    path: Option<PathBuf>,
-    contents: String,
-) -> Result<PathBuf, Error> {
+async fn save_file(path: Option<PathBuf>, contents: String) -> Result<PathBuf, Error> {
     let path = if let Some(path) = path {
         path
     } else {

--- a/examples/ferris/src/main.rs
+++ b/examples/ferris/src/main.rs
@@ -1,11 +1,9 @@
 use iced::time::Instant;
-use iced::widget::{
-    center, checkbox, column, container, image, pick_list, row, slider, text,
-};
+use iced::widget::{center, checkbox, column, container, image, pick_list, row, slider, text};
 use iced::window;
 use iced::{
-    Bottom, Center, Color, ContentFit, Degrees, Element, Fill, Radians,
-    Rotation, Subscription, Theme,
+    Bottom, Center, Color, ContentFit, Degrees, Element, Fill, Radians, Rotation, Subscription,
+    Theme,
 };
 
 pub fn main() -> iced::Result {
@@ -46,19 +44,13 @@ impl Image {
             }
             Message::RotationStrategyChanged(strategy) => {
                 self.rotation = match strategy {
-                    RotationStrategy::Floating => {
-                        Rotation::Floating(self.rotation.radians())
-                    }
-                    RotationStrategy::Solid => {
-                        Rotation::Solid(self.rotation.radians())
-                    }
+                    RotationStrategy::Floating => Rotation::Floating(self.rotation.radians()),
+                    RotationStrategy::Solid => Rotation::Solid(self.rotation.radians()),
                 };
             }
             Message::RotationChanged(rotation) => {
                 self.rotation = match self.rotation {
-                    Rotation::Floating(_) => {
-                        Rotation::Floating(rotation.into())
-                    }
+                    Rotation::Floating(_) => Rotation::Floating(rotation.into()),
                     Rotation::Solid(_) => Rotation::Solid(rotation.into()),
                 };
             }
@@ -74,9 +66,8 @@ impl Image {
 
                 let delta = (now - self.last_tick).as_millis() as f32 / 1_000.0;
 
-                *self.rotation.radians_mut() = (self.rotation.radians()
-                    + ROTATION_SPEED * delta)
-                    % (2.0 * Radians::PI);
+                *self.rotation.radians_mut() =
+                    (self.rotation.radians() + ROTATION_SPEED * delta) % (2.0 * Radians::PI);
 
                 self.last_tick = now;
             }
@@ -142,8 +133,7 @@ impl Image {
                 format!("Width: {}px", self.width)
             ),
             with_value(
-                slider(0.0..=1.0, self.opacity, Message::OpacityChanged)
-                    .step(0.01),
+                slider(0.0..=1.0, self.opacity, Message::OpacityChanged).step(0.01),
                 format!("Opacity: {:.2}", self.opacity)
             ),
             with_value(
@@ -201,10 +191,7 @@ impl std::fmt::Display for RotationStrategy {
     }
 }
 
-fn with_value<'a>(
-    control: impl Into<Element<'a, Message>>,
-    value: String,
-) -> Element<'a, Message> {
+fn with_value<'a>(control: impl Into<Element<'a, Message>>, value: String) -> Element<'a, Message> {
     column![control.into(), text(value).size(12).line_height(1.0)]
         .spacing(2)
         .align_x(Center)

--- a/examples/gallery/src/civitai.rs
+++ b/examples/gallery/src/civitai.rs
@@ -45,11 +45,7 @@ impl Image {
             .collect())
     }
 
-    pub async fn blurhash(
-        self,
-        width: u32,
-        height: u32,
-    ) -> Result<Blurhash, Error> {
+    pub async fn blurhash(self, width: u32, height: u32) -> Result<Blurhash, Error> {
         task::spawn_blocking(move || {
             let pixels = blurhash::decode(&self.hash, width, height, 1.0)?;
 
@@ -83,9 +79,7 @@ impl Image {
                         .url
                         .split("/")
                         .map(|part| {
-                            if part.starts_with("width=")
-                                || part.starts_with("original=")
-                            {
+                            if part.starts_with("width=") || part.starts_with("original=") {
                                 format!("width={}", width * 2) // High DPI
                             } else {
                                 part.to_owned()
@@ -105,9 +99,7 @@ impl Image {
     }
 }
 
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
 pub struct Id(u32);
 
 #[derive(Debug, Clone)]

--- a/examples/gallery/src/main.rs
+++ b/examples/gallery/src/main.rs
@@ -10,13 +10,11 @@ use iced::animation;
 use iced::border;
 use iced::time::{Instant, milliseconds};
 use iced::widget::{
-    button, container, float, grid, image, mouse_area, opaque, scrollable,
-    sensor, space, stack,
+    button, container, float, grid, image, mouse_area, opaque, scrollable, sensor, space, stack,
 };
 use iced::window;
 use iced::{
-    Animation, Color, ContentFit, Element, Fill, Function, Shadow,
-    Subscription, Task, Theme, color,
+    Animation, Color, ContentFit, Element, Fill, Function, Shadow, Subscription, Task, Theme, color,
 };
 
 use std::collections::{HashMap, HashSet};
@@ -180,9 +178,7 @@ impl Gallery {
                     return Task::none();
                 }
 
-                let Some(Preview::Ready { thumbnail, .. }) =
-                    self.previews.get_mut(&id)
-                else {
+                let Some(Preview::Ready { thumbnail, .. }) = self.previews.get_mut(&id) else {
                     return Task::none();
                 };
 
@@ -275,9 +271,7 @@ impl Gallery {
             .height(grid::aspect_ratio(Preview::WIDTH, Preview::HEIGHT))
             .spacing(10);
 
-        let content =
-            container(scrollable(gallery).spacing(10).auto_scroll(true))
-                .padding(10);
+        let content = container(scrollable(gallery).spacing(10).auto_scroll(true)).padding(10);
         let viewer = self.viewer.view(self.now);
 
         stack![content, viewer].into()
@@ -290,36 +284,33 @@ fn card<'a>(
     now: Instant,
 ) -> Element<'a, Message> {
     let image = if let Some(preview) = preview {
-        let thumbnail: Element<'_, _> =
-            if let Preview::Ready { thumbnail, .. } = &preview
-                && let Some(allocation) = &thumbnail.allocation
-            {
-                float(
-                    image(allocation.handle())
-                        .width(Fill)
-                        .content_fit(ContentFit::Cover)
-                        .opacity(thumbnail.fade_in.interpolate(0.0, 1.0, now))
-                        .border_radius(BORDER_RADIUS),
-                )
-                .scale(thumbnail.zoom.interpolate(1.0, 1.1, now))
-                .translate(move |bounds, viewport| {
-                    bounds.zoom(1.1).offset(&viewport.shrink(10))
-                        * thumbnail.zoom.interpolate(0.0, 1.0, now)
-                })
-                .style(move |_theme| float::Style {
-                    shadow: Shadow {
-                        color: Color::BLACK.scale_alpha(
-                            thumbnail.zoom.interpolate(0.0, 1.0, now),
-                        ),
-                        blur_radius: thumbnail.zoom.interpolate(0.0, 20.0, now),
-                        ..Shadow::default()
-                    },
-                    shadow_border_radius: border::radius(BORDER_RADIUS),
-                })
-                .into()
-            } else {
-                space::horizontal().into()
-            };
+        let thumbnail: Element<'_, _> = if let Preview::Ready { thumbnail, .. } = &preview
+            && let Some(allocation) = &thumbnail.allocation
+        {
+            float(
+                image(allocation.handle())
+                    .width(Fill)
+                    .content_fit(ContentFit::Cover)
+                    .opacity(thumbnail.fade_in.interpolate(0.0, 1.0, now))
+                    .border_radius(BORDER_RADIUS),
+            )
+            .scale(thumbnail.zoom.interpolate(1.0, 1.1, now))
+            .translate(move |bounds, viewport| {
+                bounds.zoom(1.1).offset(&viewport.shrink(10))
+                    * thumbnail.zoom.interpolate(0.0, 1.0, now)
+            })
+            .style(move |_theme| float::Style {
+                shadow: Shadow {
+                    color: Color::BLACK.scale_alpha(thumbnail.zoom.interpolate(0.0, 1.0, now)),
+                    blur_radius: thumbnail.zoom.interpolate(0.0, 20.0, now),
+                    ..Shadow::default()
+                },
+                shadow_border_radius: border::radius(BORDER_RADIUS),
+            })
+            .into()
+        } else {
+            space::horizontal().into()
+        };
 
         if let Some(blurhash) = preview.blurhash(now) {
             let blurhash = image(&blurhash.handle)
@@ -407,11 +398,7 @@ impl Preview {
                     .duration(milliseconds(700))
                     .easing(animation::Easing::EaseIn)
                     .go(true, now),
-                handle: image::Handle::from_rgba(
-                    rgba.width,
-                    rgba.height,
-                    rgba.pixels,
-                ),
+                handle: image::Handle::from_rgba(rgba.width, rgba.height, rgba.pixels),
             },
         }
     }
@@ -449,9 +436,9 @@ impl Preview {
             } => {
                 thumbnail.fade_in.is_animating(now)
                     || thumbnail.zoom.is_animating(now)
-                    || blurhash.as_ref().is_some_and(|blurhash| {
-                        blurhash.fade_in.is_animating(now)
-                    })
+                    || blurhash
+                        .as_ref()
+                        .is_some_and(|blurhash| blurhash.fade_in.is_animating(now))
             }
         }
     }
@@ -463,9 +450,7 @@ impl Preview {
                 blurhash: Some(blurhash),
                 thumbnail,
                 ..
-            } if !thumbnail.fade_in.value()
-                || thumbnail.fade_in.is_animating(now) =>
-            {
+            } if !thumbnail.fade_in.value() || thumbnail.fade_in.is_animating(now) => {
                 Some(blurhash)
             }
             Self::Ready { .. } => None,
@@ -536,8 +521,7 @@ impl Viewer {
     }
 
     fn is_animating(&self, now: Instant) -> bool {
-        self.background_fade_in.is_animating(now)
-            || self.image_fade_in.is_animating(now)
+        self.background_fade_in.is_animating(now) || self.image_fade_in.is_animating(now)
     }
 
     fn view(&self, now: Instant) -> Option<Element<'_, Message>> {
@@ -560,8 +544,7 @@ impl Viewer {
                 container(image)
                     .center(Fill)
                     .style(move |_theme| {
-                        container::Style::default()
-                            .background(color!(0x000000, opacity))
+                        container::Style::default().background(color!(0x000000, opacity))
                     })
                     .padding(20),
             )
@@ -572,19 +555,13 @@ impl Viewer {
 
 fn to_rgba(bytes: Bytes) -> Task<image::Handle> {
     Task::future(async move {
-        tokio::task::spawn_blocking(move || {
-            match ::image::load_from_memory(bytes.as_slice()) {
-                Ok(image) => {
-                    let rgba = image.to_rgba8();
+        tokio::task::spawn_blocking(move || match ::image::load_from_memory(bytes.as_slice()) {
+            Ok(image) => {
+                let rgba = image.to_rgba8();
 
-                    image::Handle::from_rgba(
-                        rgba.width(),
-                        rgba.height(),
-                        rgba.into_raw(),
-                    )
-                }
-                _ => image::Handle::from_bytes(bytes),
+                image::Handle::from_rgba(rgba.width(), rgba.height(), rgba.into_raw())
             }
+            _ => image::Handle::from_bytes(bytes),
         })
         .await
         .unwrap()

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -6,9 +6,7 @@ use grid::Grid;
 use preset::Preset;
 
 use iced::time::{self, milliseconds};
-use iced::widget::{
-    button, checkbox, column, container, pick_list, row, slider, text,
-};
+use iced::widget::{button, checkbox, column, container, pick_list, row, slider, text};
 use iced::{Center, Element, Fill, Function, Subscription, Task, Theme};
 
 pub fn main() -> iced::Result {
@@ -104,8 +102,7 @@ impl GameOfLife {
 
     fn subscription(&self) -> Subscription<Message> {
         if self.is_playing {
-            time::every(milliseconds(1000 / self.speed as u64))
-                .map(|_| Message::Tick)
+            time::every(milliseconds(1000 / self.speed as u64)).map(|_| Message::Tick)
         } else {
             Subscription::none()
         }
@@ -121,11 +118,8 @@ impl GameOfLife {
             self.grid.preset(),
         );
 
-        let content = column![
-            self.grid.view().map(Message::Grid.with(version)),
-            controls,
-        ]
-        .height(Fill);
+        let content =
+            column![self.grid.view().map(Message::Grid.with(version)), controls,].height(Fill);
 
         container(content).width(Fill).height(Fill).into()
     }
@@ -144,8 +138,7 @@ fn view_controls<'a>(
     preset: Preset,
 ) -> Element<'a, Message> {
     let playback_controls = row![
-        button(if is_playing { "Pause" } else { "Play" })
-            .on_press(Message::TogglePlayback),
+        button(if is_playing { "Pause" } else { "Play" }).on_press(Message::TogglePlayback),
         button("Next")
             .on_press(Message::Next)
             .style(button::secondary),
@@ -186,13 +179,9 @@ mod grid {
     use iced::time::{Duration, Instant};
     use iced::touch;
     use iced::widget::canvas;
-    use iced::widget::canvas::{
-        Cache, Canvas, Event, Frame, Geometry, Path, Text,
-    };
+    use iced::widget::canvas::{Cache, Canvas, Event, Frame, Geometry, Path, Text};
     use iced::widget::text;
-    use iced::{
-        Color, Element, Fill, Point, Rectangle, Renderer, Size, Theme, Vector,
-    };
+    use iced::{Color, Element, Fill, Point, Rectangle, Renderer, Size, Theme, Vector};
     use rustc_hash::{FxHashMap, FxHashSet};
     use std::ops::RangeInclusive;
 
@@ -255,10 +244,7 @@ mod grid {
             }
         }
 
-        pub fn tick(
-            &mut self,
-            amount: usize,
-        ) -> Option<impl Future<Output = Message> + use<>> {
+        pub fn tick(&mut self, amount: usize) -> Option<impl Future<Output = Message> + use<>> {
             let tick = self.state.tick(amount)?;
 
             self.last_queued_ticks = amount;
@@ -447,9 +433,7 @@ mod grid {
                             Interaction::Erasing => unpopulate,
                             Interaction::Panning { translation, start } => {
                                 Some(Message::Translated(
-                                    translation
-                                        + (cursor_position - start)
-                                            * (1.0 / self.scaling),
+                                    translation + (cursor_position - start) * (1.0 / self.scaling),
                                 ))
                             }
                             Interaction::None => None,
@@ -473,38 +457,29 @@ mod grid {
                                 let old_scaling = self.scaling;
 
                                 let scaling = (self.scaling * (1.0 + y / 30.0))
-                                    .clamp(
-                                        Self::MIN_SCALING,
-                                        Self::MAX_SCALING,
-                                    );
+                                    .clamp(Self::MIN_SCALING, Self::MAX_SCALING);
 
-                                let translation =
-                                    if let Some(cursor_to_center) =
-                                        cursor.position_from(bounds.center())
-                                    {
-                                        let factor = scaling - old_scaling;
+                                let translation = if let Some(cursor_to_center) =
+                                    cursor.position_from(bounds.center())
+                                {
+                                    let factor = scaling - old_scaling;
 
-                                        Some(
-                                            self.translation
-                                                - Vector::new(
-                                                    cursor_to_center.x * factor
-                                                        / (old_scaling
-                                                            * old_scaling),
-                                                    cursor_to_center.y * factor
-                                                        / (old_scaling
-                                                            * old_scaling),
-                                                ),
-                                        )
-                                    } else {
-                                        None
-                                    };
+                                    Some(
+                                        self.translation
+                                            - Vector::new(
+                                                cursor_to_center.x * factor
+                                                    / (old_scaling * old_scaling),
+                                                cursor_to_center.y * factor
+                                                    / (old_scaling * old_scaling),
+                                            ),
+                                    )
+                                } else {
+                                    None
+                                };
 
                                 Some(
-                                    canvas::Action::publish(Message::Scaled(
-                                        scaling,
-                                        translation,
-                                    ))
-                                    .and_capture(),
+                                    canvas::Action::publish(Message::Scaled(scaling, translation))
+                                        .and_capture(),
                                 )
                             } else {
                                 Some(canvas::Action::capture())
@@ -552,9 +527,9 @@ mod grid {
             let overlay = {
                 let mut frame = Frame::new(renderer, bounds.size());
 
-                let hovered_cell = cursor.position_in(bounds).map(|position| {
-                    Cell::at(self.project(position, frame.size()))
-                });
+                let hovered_cell = cursor
+                    .position_in(bounds)
+                    .map(|position| Cell::at(self.project(position, frame.size())));
 
                 if let Some(cell) = hovered_cell {
                     frame.with_save(|frame| {
@@ -607,40 +582,38 @@ mod grid {
             };
 
             if self.scaling >= 0.2 && self.show_lines {
-                let grid =
-                    self.grid_cache.draw(renderer, bounds.size(), |frame| {
-                        frame.translate(center);
-                        frame.scale(self.scaling);
-                        frame.translate(self.translation);
-                        frame.scale(Cell::SIZE);
+                let grid = self.grid_cache.draw(renderer, bounds.size(), |frame| {
+                    frame.translate(center);
+                    frame.scale(self.scaling);
+                    frame.translate(self.translation);
+                    frame.scale(Cell::SIZE);
 
-                        let region = self.visible_region(frame.size());
-                        let rows = region.rows();
-                        let columns = region.columns();
-                        let (total_rows, total_columns) =
-                            (rows.clone().count(), columns.clone().count());
-                        let width = 2.0 / Cell::SIZE as f32;
-                        let color = Color::from_rgb8(70, 74, 83);
+                    let region = self.visible_region(frame.size());
+                    let rows = region.rows();
+                    let columns = region.columns();
+                    let (total_rows, total_columns) =
+                        (rows.clone().count(), columns.clone().count());
+                    let width = 2.0 / Cell::SIZE as f32;
+                    let color = Color::from_rgb8(70, 74, 83);
 
-                        frame
-                            .translate(Vector::new(-width / 2.0, -width / 2.0));
+                    frame.translate(Vector::new(-width / 2.0, -width / 2.0));
 
-                        for row in region.rows() {
-                            frame.fill_rectangle(
-                                Point::new(*columns.start() as f32, row as f32),
-                                Size::new(total_columns as f32, width),
-                                color,
-                            );
-                        }
+                    for row in region.rows() {
+                        frame.fill_rectangle(
+                            Point::new(*columns.start() as f32, row as f32),
+                            Size::new(total_columns as f32, width),
+                            color,
+                        );
+                    }
 
-                        for column in region.columns() {
-                            frame.fill_rectangle(
-                                Point::new(column as f32, *rows.start() as f32),
-                                Size::new(width, total_rows as f32),
-                                color,
-                            );
-                        }
-                    });
+                    for column in region.columns() {
+                        frame.fill_rectangle(
+                            Point::new(column as f32, *rows.start() as f32),
+                            Size::new(width, total_rows as f32),
+                            color,
+                        );
+                    }
+                });
 
                 vec![life, grid, overlay]
             } else {
@@ -658,9 +631,7 @@ mod grid {
                 Interaction::Drawing => mouse::Interaction::Crosshair,
                 Interaction::Erasing => mouse::Interaction::Crosshair,
                 Interaction::Panning { .. } => mouse::Interaction::Grabbing,
-                Interaction::None if cursor.is_over(bounds) => {
-                    mouse::Interaction::Crosshair
-                }
+                Interaction::None if cursor.is_over(bounds) => mouse::Interaction::Crosshair,
                 Interaction::None => mouse::Interaction::default(),
             }
         }
@@ -719,8 +690,7 @@ mod grid {
         fn tick(
             &mut self,
             amount: usize,
-        ) -> Option<impl Future<Output = Result<Life, TickError>> + use<>>
-        {
+        ) -> Option<impl Future<Output = Result<Life, TickError>> + use<>> {
             if self.is_ticking {
                 return None;
             }
@@ -856,8 +826,7 @@ mod grid {
         fn rows(&self) -> RangeInclusive<isize> {
             let first_row = (self.y / Cell::SIZE as f32).floor() as isize;
 
-            let visible_rows =
-                (self.height / Cell::SIZE as f32).ceil() as isize;
+            let visible_rows = (self.height / Cell::SIZE as f32).ceil() as isize;
 
             first_row..=first_row + visible_rows
         }
@@ -865,8 +834,7 @@ mod grid {
         fn columns(&self) -> RangeInclusive<isize> {
             let first_column = (self.x / Cell::SIZE as f32).floor() as isize;
 
-            let visible_columns =
-                (self.width / Cell::SIZE as f32).ceil() as isize;
+            let visible_columns = (self.width / Cell::SIZE as f32).ceil() as isize;
 
             first_column..=first_column + visible_columns
         }
@@ -878,9 +846,7 @@ mod grid {
             let rows = self.rows();
             let columns = self.columns();
 
-            cells.filter(move |cell| {
-                rows.contains(&cell.i) && columns.contains(&cell.j)
-            })
+            cells.filter(move |cell| rows.contains(&cell.i) && columns.contains(&cell.j))
         }
     }
 

--- a/examples/game_of_life/src/preset.rs
+++ b/examples/game_of_life/src/preset.rs
@@ -107,9 +107,7 @@ impl Preset {
                     .chars()
                     .enumerate()
                     .filter(|(_, c)| !c.is_whitespace())
-                    .map(move |(j, _)| {
-                        (start_row + i as isize, start_column + j as isize)
-                    })
+                    .map(move |(j, _)| (start_row + i as isize, start_column + j as isize))
             })
             .collect()
     }

--- a/examples/geometry/src/main.rs
+++ b/examples/geometry/src/main.rs
@@ -7,10 +7,7 @@ mod rainbow {
     use iced::advanced::widget::{self, Widget};
     use iced::advanced::{Clipboard, Shell};
     use iced::mouse;
-    use iced::{
-        Element, Event, Length, Rectangle, Renderer, Size, Theme,
-        Transformation, Vector,
-    };
+    use iced::{Element, Event, Length, Rectangle, Renderer, Size, Theme, Transformation, Vector};
 
     #[derive(Debug, Clone, Copy, Default)]
     pub struct Rainbow;
@@ -65,9 +62,7 @@ mod rainbow {
             _viewport: &Rectangle,
         ) {
             use iced::advanced::Renderer as _;
-            use iced::advanced::graphics::mesh::{
-                self, Mesh, Renderer as _, SolidVertex2D,
-            };
+            use iced::advanced::graphics::mesh::{self, Mesh, Renderer as _, SolidVertex2D};
 
             let bounds = layout.bounds();
 
@@ -153,12 +148,9 @@ mod rainbow {
                 clip_bounds: Rectangle::INFINITE,
             };
 
-            renderer.with_translation(
-                Vector::new(bounds.x, bounds.y),
-                |renderer| {
-                    renderer.draw_mesh(mesh);
-                },
-            );
+            renderer.with_translation(Vector::new(bounds.x, bounds.y), |renderer| {
+                renderer.draw_mesh(mesh);
+            });
         }
     }
 

--- a/examples/gradient/src/main.rs
+++ b/examples/gradient/src/main.rs
@@ -70,8 +70,7 @@ impl Gradient {
 
         let angle_picker = row![
             text("Angle").width(64),
-            slider(Radians::RANGE, self.angle, Message::AngleChanged)
-                .step(0.01)
+            slider(Radians::RANGE, self.angle, Message::AngleChanged).step(0.01)
         ]
         .spacing(8)
         .padding(8)
@@ -115,14 +114,10 @@ impl Default for Gradient {
 fn color_picker(label: &str, color: Color) -> Element<'_, Color> {
     row![
         text(label).width(64),
-        slider(0.0..=1.0, color.r, move |r| { Color { r, ..color } })
-            .step(0.01),
-        slider(0.0..=1.0, color.g, move |g| { Color { g, ..color } })
-            .step(0.01),
-        slider(0.0..=1.0, color.b, move |b| { Color { b, ..color } })
-            .step(0.01),
-        slider(0.0..=1.0, color.a, move |a| { Color { a, ..color } })
-            .step(0.01),
+        slider(0.0..=1.0, color.r, move |r| { Color { r, ..color } }).step(0.01),
+        slider(0.0..=1.0, color.g, move |g| { Color { g, ..color } }).step(0.01),
+        slider(0.0..=1.0, color.b, move |b| { Color { b, ..color } }).step(0.01),
+        slider(0.0..=1.0, color.a, move |a| { Color { a, ..color } }).step(0.01),
     ]
     .spacing(8)
     .padding(8)

--- a/examples/layout/src/main.rs
+++ b/examples/layout/src/main.rs
@@ -2,12 +2,12 @@ use iced::border;
 use iced::keyboard;
 use iced::mouse;
 use iced::widget::{
-    button, canvas, center, center_y, checkbox, column, container, pick_list,
-    pin, responsive, row, rule, scrollable, space, stack, text,
+    button, canvas, center, center_y, checkbox, column, container, pick_list, pin, responsive, row,
+    rule, scrollable, space, stack, text,
 };
 use iced::{
-    Center, Element, Fill, Font, Length, Point, Rectangle, Renderer, Shrink,
-    Subscription, Theme, color,
+    Center, Element, Fill, Font, Length, Point, Rectangle, Renderer, Shrink, Subscription, Theme,
+    color,
 };
 
 pub fn main() -> iced::Result {
@@ -69,12 +69,8 @@ impl Layout {
             };
 
             match modified_key {
-                keyboard::Key::Named(key::Named::ArrowLeft) => {
-                    Some(Message::Previous)
-                }
-                keyboard::Key::Named(key::Named::ArrowRight) => {
-                    Some(Message::Next)
-                }
+                keyboard::Key::Named(key::Named::ArrowLeft) => Some(Message::Previous),
+                keyboard::Key::Named(key::Named::ArrowRight) => Some(Message::Next),
                 _ => None,
             }
         })
@@ -87,8 +83,7 @@ impl Layout {
             checkbox(self.explain)
                 .label("Explain")
                 .on_toggle(Message::ExplainToggled),
-            pick_list(Theme::ALL, self.theme.as_ref(), Message::ThemeSelected)
-                .placeholder("Theme"),
+            pick_list(Theme::ALL, self.theme.as_ref(), Message::ThemeSelected).placeholder("Theme"),
         ]
         .spacing(20)
         .align_y(Center);
@@ -182,9 +177,7 @@ impl Example {
     }
 
     fn previous(self) -> Self {
-        let Some(index) =
-            Self::LIST.iter().position(|&example| example == self)
-        else {
+        let Some(index) = Self::LIST.iter().position(|&example| example == self) else {
             return self;
         };
 
@@ -195,9 +188,7 @@ impl Example {
     }
 
     fn next(self) -> Self {
-        let Some(index) =
-            Self::LIST.iter().position(|&example| example == self)
-        else {
+        let Some(index) = Self::LIST.iter().position(|&example| example == self) else {
             return self;
         };
 
@@ -270,8 +261,7 @@ fn application<'a>() -> Element<'a, Message> {
     .style(|theme| {
         let palette = theme.extended_palette();
 
-        container::Style::default()
-            .border(border::color(palette.background.strong.color).width(1))
+        container::Style::default().border(border::color(palette.background.strong.color).width(1))
     });
 
     let sidebar = center_y(
@@ -305,9 +295,7 @@ fn application<'a>() -> Element<'a, Message> {
 }
 
 fn quotes<'a>() -> Element<'a, Message> {
-    fn quote<'a>(
-        content: impl Into<Element<'a, Message>>,
-    ) -> Element<'a, Message> {
+    fn quote<'a>(content: impl Into<Element<'a, Message>>) -> Element<'a, Message> {
         row![rule::vertical(1), content.into()]
             .spacing(10)
             .height(Shrink)
@@ -369,8 +357,7 @@ fn responsive_<'a>() -> Element<'a, Message> {
             let size = size.ratio(16.0 / 9.0);
 
             container(center(
-                text!("{:.0}x{:.0}px (16:9)", size.width, size.height)
-                    .font(Font::MONOSPACE),
+                text!("{:.0}x{:.0}px (16:9)", size.width, size.height).font(Font::MONOSPACE),
             ))
             .clip(true)
             .width(size.width)

--- a/examples/lazy/src/main.rs
+++ b/examples/lazy/src/main.rs
@@ -1,6 +1,4 @@
-use iced::widget::{
-    button, column, lazy, pick_list, row, scrollable, space, text, text_input,
-};
+use iced::widget::{button, column, lazy, pick_list, row, scrollable, space, text, text_input};
 use iced::{Element, Fill};
 
 use std::collections::HashSet;
@@ -158,12 +156,8 @@ impl App {
             let mut items: Vec<_> = self.items.iter().cloned().collect();
 
             items.sort_by(|a, b| match self.order {
-                Order::Ascending => {
-                    a.name.to_lowercase().cmp(&b.name.to_lowercase())
-                }
-                Order::Descending => {
-                    b.name.to_lowercase().cmp(&a.name.to_lowercase())
-                }
+                Order::Ascending => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+                Order::Descending => b.name.to_lowercase().cmp(&a.name.to_lowercase()),
             });
 
             column(items.into_iter().map(|item| {
@@ -191,8 +185,7 @@ impl App {
                 text_input("Add a new option", &self.input)
                     .on_input(Message::InputChanged)
                     .on_submit(Message::AddItem(self.input.clone())),
-                button(text!("Toggle Order ({})", self.order))
-                    .on_press(Message::ToggleOrder)
+                button(text!("Toggle Order ({})", self.order)).on_press(Message::ToggleOrder)
             ]
             .spacing(10)
         ]

--- a/examples/list/src/main.rs
+++ b/examples/list/src/main.rs
@@ -1,6 +1,5 @@
 use iced::widget::{
-    button, center, column, container, list, row, scrollable,
-    space::horizontal, text,
+    button, center, column, container, list, row, scrollable, space::horizontal, text,
 };
 use iced::{Alignment, Element, Length, Task, Theme};
 
@@ -55,8 +54,7 @@ impl List {
                 container(list(&self.content, |index, (id, state)| {
                     row![
                         match state {
-                            State::Idle =>
-                                Element::from(text(format!("I am item {id}!"))),
+                            State::Idle => Element::from(text(format!("I am item {id}!"))),
                             State::Updated => center(
                                 column![
                                     text(format!("I am item {id}!")),
@@ -69,8 +67,7 @@ impl List {
                         },
                         horizontal(),
                         button("Update").on_press_maybe(
-                            matches!(state, State::Idle)
-                                .then_some(Message::Update(index))
+                            matches!(state, State::Idle).then_some(Message::Update(index))
                         ),
                         button("Remove")
                             .on_press(Message::Remove(index))
@@ -93,9 +90,7 @@ impl List {
 impl Default for List {
     fn default() -> Self {
         Self {
-            content: list::Content::from_iter(
-                (0..1_000).map(|id| (id, State::Idle)),
-            ),
+            content: list::Content::from_iter((0..1_000).map(|id| (id, State::Idle))),
         }
     }
 }

--- a/examples/loading_spinners/src/circular.rs
+++ b/examples/loading_spinners/src/circular.rs
@@ -7,10 +7,7 @@ use iced::mouse;
 use iced::time::Instant;
 use iced::widget::canvas;
 use iced::window;
-use iced::{
-    Background, Color, Element, Event, Length, Radians, Rectangle, Renderer,
-    Size, Vector,
-};
+use iced::{Background, Color, Element, Event, Length, Radians, Rectangle, Renderer, Size, Vector};
 
 use super::easing::{self, Easing};
 
@@ -135,12 +132,9 @@ impl Animation {
             Self::Contracting { rotation, .. } => Self::Expanding {
                 start: now,
                 progress: 0.0,
-                rotation: rotation.wrapping_add(
-                    BASE_ROTATION_SPEED.wrapping_add(
-                        (f64::from(WRAP_ANGLE / (2.0 * Radians::PI))
-                            * u32::MAX as f64) as u32,
-                    ),
-                ),
+                rotation: rotation.wrapping_add(BASE_ROTATION_SPEED.wrapping_add(
+                    (f64::from(WRAP_ANGLE / (2.0 * Radians::PI)) * u32::MAX as f64) as u32,
+                )),
                 last: now,
             },
         }
@@ -148,17 +142,13 @@ impl Animation {
 
     fn start(&self) -> Instant {
         match self {
-            Self::Expanding { start, .. } | Self::Contracting { start, .. } => {
-                *start
-            }
+            Self::Expanding { start, .. } | Self::Contracting { start, .. } => *start,
         }
     }
 
     fn last(&self) -> Instant {
         match self {
-            Self::Expanding { last, .. } | Self::Contracting { last, .. } => {
-                *last
-            }
+            Self::Expanding { last, .. } | Self::Contracting { last, .. } => *last,
         }
     }
 
@@ -174,15 +164,8 @@ impl Animation {
             * (u32::MAX) as f32) as u32;
 
         match elapsed {
-            elapsed if elapsed > cycle_duration => {
-                self.next(additional_rotation, now)
-            }
-            _ => self.with_elapsed(
-                cycle_duration,
-                additional_rotation,
-                elapsed,
-                now,
-            ),
+            elapsed if elapsed > cycle_duration => self.next(additional_rotation, now),
+            _ => self.with_elapsed(cycle_duration, additional_rotation, elapsed, now),
         }
     }
 
@@ -216,8 +199,7 @@ impl Animation {
 
     fn rotation(&self) -> f32 {
         match self {
-            Self::Expanding { rotation, .. }
-            | Self::Contracting { rotation, .. } => {
+            Self::Expanding { rotation, .. } | Self::Contracting { rotation, .. } => {
                 *rotation as f32 / u32::MAX as f32
             }
         }
@@ -230,8 +212,7 @@ struct State {
     cache: canvas::Cache,
 }
 
-impl<'a, Message, Theme> Widget<Message, Theme, Renderer>
-    for Circular<'a, Theme>
+impl<'a, Message, Theme> Widget<Message, Theme, Renderer> for Circular<'a, Theme>
 where
     Message: 'a + Clone,
     Theme: StyleSheet,
@@ -274,11 +255,10 @@ where
         let state = tree.state.downcast_mut::<State>();
 
         if let Event::Window(window::Event::RedrawRequested(now)) = event {
-            state.animation = state.animation.timed_transition(
-                self.cycle_duration,
-                self.rotation_duration,
-                *now,
-            );
+            state.animation =
+                state
+                    .animation
+                    .timed_transition(self.cycle_duration, self.rotation_duration, *now);
 
             state.cache.clear();
             shell.request_redraw();
@@ -299,8 +279,7 @@ where
 
         let state = tree.state.downcast_ref::<State>();
         let bounds = layout.bounds();
-        let custom_style =
-            <Theme as StyleSheet>::appearance(theme, &self.style);
+        let custom_style = <Theme as StyleSheet>::appearance(theme, &self.style);
 
         let geometry = state.cache.draw(renderer, bounds.size(), |frame| {
             let track_radius = frame.width() / 2.0 - self.bar_height;
@@ -323,17 +302,14 @@ where
                         center: frame.center(),
                         radius: track_radius,
                         start_angle: start,
-                        end_angle: start
-                            + MIN_ANGLE
-                            + WRAP_ANGLE * (self.easing.y_at_x(progress)),
+                        end_angle: start + MIN_ANGLE + WRAP_ANGLE * (self.easing.y_at_x(progress)),
                     });
                 }
                 Animation::Contracting { progress, .. } => {
                     builder.arc(canvas::path::Arc {
                         center: frame.center(),
                         radius: track_radius,
-                        start_angle: start
-                            + WRAP_ANGLE * (self.easing.y_at_x(progress)),
+                        start_angle: start + WRAP_ANGLE * (self.easing.y_at_x(progress)),
                         end_angle: start + MIN_ANGLE + WRAP_ANGLE,
                     });
                 }
@@ -349,19 +325,15 @@ where
             );
         });
 
-        renderer.with_translation(
-            Vector::new(bounds.x, bounds.y),
-            |renderer| {
-                use iced::advanced::graphics::geometry::Renderer as _;
+        renderer.with_translation(Vector::new(bounds.x, bounds.y), |renderer| {
+            use iced::advanced::graphics::geometry::Renderer as _;
 
-                renderer.draw_geometry(geometry);
-            },
-        );
+            renderer.draw_geometry(geometry);
+        });
     }
 }
 
-impl<'a, Message, Theme> From<Circular<'a, Theme>>
-    for Element<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme> From<Circular<'a, Theme>> for Element<'a, Message, Theme, Renderer>
 where
     Message: Clone + 'a,
     Theme: StyleSheet + 'a,

--- a/examples/loading_spinners/src/easing.rs
+++ b/examples/loading_spinners/src/easing.rs
@@ -53,10 +53,9 @@ impl Easing {
     }
 
     pub fn y_at_x(&self, x: f32) -> f32 {
-        let mut sampler = self.measurements.create_sampler(
-            &self.path,
-            lyon_algorithms::measure::SampleType::Normalized,
-        );
+        let mut sampler = self
+            .measurements
+            .create_sampler(&self.path, lyon_algorithms::measure::SampleType::Normalized);
         let sample = sampler.sample(x);
 
         sample.position().y
@@ -81,11 +80,7 @@ impl Builder {
     }
 
     /// Adds a quadratic bézier curve. Points must be between 0,0 and 1,1
-    pub fn quadratic_bezier_to(
-        mut self,
-        ctrl: impl Into<Point>,
-        to: impl Into<Point>,
-    ) -> Self {
+    pub fn quadratic_bezier_to(mut self, ctrl: impl Into<Point>, to: impl Into<Point>) -> Self {
         self.0
             .quadratic_bezier_to(Self::point(ctrl), Self::point(to));
 
@@ -99,11 +94,8 @@ impl Builder {
         ctrl2: impl Into<Point>,
         to: impl Into<Point>,
     ) -> Self {
-        self.0.cubic_bezier_to(
-            Self::point(ctrl1),
-            Self::point(ctrl2),
-            Self::point(to),
-        );
+        self.0
+            .cubic_bezier_to(Self::point(ctrl1), Self::point(ctrl2), Self::point(to));
 
         self
     }

--- a/examples/loading_spinners/src/linear.rs
+++ b/examples/loading_spinners/src/linear.rs
@@ -109,9 +109,7 @@ impl State {
 
     fn start(&self) -> Instant {
         match self {
-            Self::Expanding { start, .. } | Self::Contracting { start, .. } => {
-                *start
-            }
+            Self::Expanding { start, .. } | Self::Contracting { start, .. } => *start,
         }
     }
 
@@ -124,11 +122,7 @@ impl State {
         }
     }
 
-    fn with_elapsed(
-        &self,
-        cycle_duration: Duration,
-        elapsed: Duration,
-    ) -> Self {
+    fn with_elapsed(&self, cycle_duration: Duration, elapsed: Duration) -> Self {
         let progress = elapsed.as_secs_f32() / cycle_duration.as_secs_f32();
         match self {
             Self::Expanding { start, .. } => Self::Expanding {
@@ -143,8 +137,7 @@ impl State {
     }
 }
 
-impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for Linear<'a, Theme>
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Linear<'a, Theme>
 where
     Message: Clone + 'a,
     Theme: StyleSheet + 'a,
@@ -238,11 +231,9 @@ where
             State::Contracting { progress, .. } => renderer.fill_quad(
                 Quad {
                     bounds: Rectangle {
-                        x: bounds.x
-                            + self.easing.y_at_x(*progress) * bounds.width,
+                        x: bounds.x + self.easing.y_at_x(*progress) * bounds.width,
                         y: bounds.y,
-                        width: (1.0 - self.easing.y_at_x(*progress))
-                            * bounds.width,
+                        width: (1.0 - self.easing.y_at_x(*progress)) * bounds.width,
                         height: bounds.height,
                     },
                     ..renderer::Quad::default()
@@ -253,8 +244,7 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer> From<Linear<'a, Theme>>
-    for Element<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme, Renderer> From<Linear<'a, Theme>> for Element<'a, Message, Theme, Renderer>
 where
     Message: Clone + 'a,
     Theme: StyleSheet + 'a,

--- a/examples/loading_spinners/src/main.rs
+++ b/examples/loading_spinners/src/main.rs
@@ -59,12 +59,12 @@ impl LoadingSpinners {
             column.push(
                 row![
                     text(label).width(250),
-                    Linear::new().easing(easing).cycle_duration(
-                        Duration::from_secs_f32(self.cycle_duration)
-                    ),
-                    Circular::new().easing(easing).cycle_duration(
-                        Duration::from_secs_f32(self.cycle_duration)
-                    )
+                    Linear::new()
+                        .easing(easing)
+                        .cycle_duration(Duration::from_secs_f32(self.cycle_duration)),
+                    Circular::new()
+                        .easing(easing)
+                        .cycle_duration(Duration::from_secs_f32(self.cycle_duration))
                 ]
                 .align_y(Center)
                 .spacing(20.0),

--- a/examples/loupe/src/main.rs
+++ b/examples/loupe/src/main.rs
@@ -51,10 +51,7 @@ mod loupe {
     use iced::advanced::renderer;
     use iced::advanced::widget::{self, Widget};
     use iced::mouse;
-    use iced::{
-        Color, Element, Length, Rectangle, Renderer, Size, Theme,
-        Transformation,
-    };
+    use iced::{Color, Element, Length, Rectangle, Renderer, Size, Theme, Transformation};
 
     pub fn loupe<'a, Message>(
         zoom: f32,
@@ -138,9 +135,9 @@ mod loupe {
                     );
                 });
             } else {
-                self.content.as_widget().draw(
-                    tree, renderer, theme, style, layout, cursor, viewport,
-                );
+                self.content
+                    .as_widget()
+                    .draw(tree, renderer, theme, style, layout, cursor, viewport);
             }
         }
 
@@ -160,8 +157,7 @@ mod loupe {
         }
     }
 
-    impl<'a, Message> From<Loupe<'a, Message>>
-        for Element<'a, Message, Theme, Renderer>
+    impl<'a, Message> From<Loupe<'a, Message>> for Element<'a, Message, Theme, Renderer>
     where
         Message: 'a,
     {

--- a/examples/markdown/src/main.rs
+++ b/examples/markdown/src/main.rs
@@ -5,13 +5,11 @@ use iced::clipboard;
 use iced::highlighter;
 use iced::time::{self, Instant, milliseconds};
 use iced::widget::{
-    button, center_x, container, hover, image, markdown, operation, right, row,
-    scrollable, sensor, space, text_editor, toggler,
+    button, center_x, container, hover, image, markdown, operation, right, row, scrollable, sensor,
+    space, text_editor, toggler,
 };
 use iced::window;
-use iced::{
-    Animation, Element, Fill, Font, Function, Subscription, Task, Theme,
-};
+use iced::{Animation, Element, Fill, Font, Function, Subscription, Task, Theme};
 
 use std::collections::HashMap;
 use std::io;
@@ -216,9 +214,7 @@ impl Markdown {
     fn subscription(&self) -> Subscription<Message> {
         let listen_stream = match self.mode {
             Mode::Preview => Subscription::none(),
-            Mode::Stream { .. } => {
-                time::every(milliseconds(10)).map(|_| Message::NextToken)
-            }
+            Mode::Stream { .. } => time::every(milliseconds(10)).map(|_| Message::NextToken),
         };
 
         let animate = {
@@ -278,8 +274,7 @@ impl<'a> markdown::Viewer<'a, Message> for CustomViewer<'a> {
         code: &'a str,
         lines: &'a [markdown::Text],
     ) -> Element<'a, Message> {
-        let code_block =
-            markdown::code_block(settings, lines, Message::LinkClicked);
+        let code_block = markdown::code_block(settings, lines, Message::LinkClicked);
 
         let copy = button(icon::copy().size(12))
             .padding(2)
@@ -288,8 +283,7 @@ impl<'a> markdown::Viewer<'a, Message> for CustomViewer<'a> {
 
         hover(
             code_block,
-            right(container(copy).style(container::dark))
-                .padding(settings.spacing / 2),
+            right(container(copy).style(container::dark)).padding(settings.spacing / 2),
         )
     }
 }

--- a/examples/modal/src/main.rs
+++ b/examples/modal/src/main.rs
@@ -2,8 +2,8 @@ use iced::event::{self, Event};
 use iced::keyboard;
 use iced::keyboard::key;
 use iced::widget::{
-    button, center, column, container, mouse_area, opaque, operation,
-    pick_list, row, space, stack, text, text_input,
+    button, center, column, container, mouse_area, opaque, operation, pick_list, row, space, stack,
+    text, text_input,
 };
 use iced::{Bottom, Color, Element, Fill, Subscription, Task};
 
@@ -95,8 +95,7 @@ impl App {
     fn view(&self) -> Element<'_, Message> {
         let content = container(
             column![
-                row![text("Top Left"), space::horizontal(), text("Top Right")]
-                    .height(Fill),
+                row![text("Top Left"), space::horizontal(), text("Top Right")].height(Fill),
                 center(button(text("Show Modal")).on_press(Message::ShowModal)),
                 row![
                     text("Bottom Left"),
@@ -134,12 +133,7 @@ impl App {
                         .spacing(5),
                         column![
                             text("Plan").size(12),
-                            pick_list(
-                                Plan::ALL,
-                                Some(self.plan),
-                                Message::Plan
-                            )
-                            .padding(5),
+                            pick_list(Plan::ALL, Some(self.plan), Message::Plan).padding(5),
                         ]
                         .spacing(5),
                         button(text("Submit")).on_press(Message::HideModal),
@@ -176,8 +170,7 @@ enum Plan {
 }
 
 impl Plan {
-    pub const ALL: &'static [Self] =
-        &[Self::Basic, Self::Pro, Self::Enterprise];
+    pub const ALL: &'static [Self] = &[Self::Basic, Self::Pro, Self::Enterprise];
 }
 
 impl fmt::Display for Plan {

--- a/examples/multi_window/src/main.rs
+++ b/examples/multi_window/src/main.rs
@@ -1,11 +1,8 @@
 use iced::widget::{
-    button, center, center_x, column, container, operation, scrollable, space,
-    text, text_input,
+    button, center, center_x, column, container, operation, scrollable, space, text, text_input,
 };
 use iced::window;
-use iced::{
-    Center, Element, Fill, Function, Subscription, Task, Theme, Vector,
-};
+use iced::{Center, Element, Fill, Function, Subscription, Task, Theme, Vector};
 
 use std::collections::BTreeMap;
 
@@ -69,14 +66,10 @@ impl Example {
 
                 window::position(*last_window)
                     .then(|last_position| {
-                        let position = last_position.map_or(
-                            window::Position::Default,
-                            |last_position| {
-                                window::Position::Specific(
-                                    last_position + Vector::new(20.0, 20.0),
-                                )
-                            },
-                        );
+                        let position =
+                            last_position.map_or(window::Position::Default, |last_position| {
+                                window::Position::Specific(last_position + Vector::new(20.0, 20.0))
+                            });
 
                         let (_, open) = window::open(window::Settings {
                             position,
@@ -171,10 +164,7 @@ impl Window {
             text("Window scale factor:"),
             text_input("Window Scale", &self.scale_input)
                 .on_input(Message::ScaleInputChanged.with(id))
-                .on_submit(Message::ScaleChanged(
-                    id,
-                    self.scale_input.to_string()
-                ))
+                .on_submit(Message::ScaleChanged(id, self.scale_input.to_string()))
         ];
 
         let title_input = column![
@@ -184,8 +174,7 @@ impl Window {
                 .id(format!("input-{id}"))
         ];
 
-        let new_window_button =
-            button(text("New Window")).on_press(Message::OpenWindow);
+        let new_window_button = button(text("New Window")).on_press(Message::OpenWindow);
 
         let content = column![scale_input, title_input, new_window_button]
             .spacing(50)

--- a/examples/multitouch/src/main.rs
+++ b/examples/multitouch/src/main.rs
@@ -64,8 +64,7 @@ impl canvas::Program<Message> for Multitouch {
                 | touch::Event::FingerMoved { id, position },
             ) => Some(Message::FingerPressed { id, position }),
             Event::Touch(
-                touch::Event::FingerLifted { id, .. }
-                | touch::Event::FingerLost { id, .. },
+                touch::Event::FingerLifted { id, .. } | touch::Event::FingerLost { id, .. },
             ) => Some(Message::FingerLifted { id }),
             _ => None,
         };
@@ -101,14 +100,9 @@ impl canvas::Program<Message> for Multitouch {
                 .map(|(_, p)| (f64::from(p.x), f64::from(p.y)))
                 .collect();
 
-            let diagram: voronator::VoronoiDiagram<
-                voronator::delaunator::Point,
-            > = voronator::VoronoiDiagram::from_tuple(
-                &(0.0, 0.0),
-                &(700.0, 700.0),
-                &vpoints,
-            )
-            .expect("Generate Voronoi diagram");
+            let diagram: voronator::VoronoiDiagram<voronator::delaunator::Point> =
+                voronator::VoronoiDiagram::from_tuple(&(0.0, 0.0), &(700.0, 700.0), &vpoints)
+                    .expect("Generate Voronoi diagram");
 
             for (cell, zone) in diagram.cells().iter().zip(zones) {
                 let mut builder = canvas::path::Builder::new();

--- a/examples/pane_grid/src/main.rs
+++ b/examples/pane_grid/src/main.rs
@@ -1,8 +1,6 @@
 use iced::keyboard;
 use iced::widget::pane_grid::{self, PaneGrid};
-use iced::widget::{
-    button, center_y, column, container, responsive, row, scrollable, text,
-};
+use iced::widget::{button, center_y, column, container, responsive, row, scrollable, text};
 use iced::{Center, Color, Element, Fill, Size, Subscription};
 
 pub fn main() -> iced::Result {
@@ -46,8 +44,7 @@ impl Example {
     fn update(&mut self, message: Message) {
         match message {
             Message::Split(axis, pane) => {
-                let result =
-                    self.panes.split(axis, pane, Pane::new(self.panes_created));
+                let result = self.panes.split(axis, pane, Pane::new(self.panes_created));
 
                 if let Some((pane, _)) = result {
                     self.focus = Some(pane);
@@ -57,11 +54,7 @@ impl Example {
             }
             Message::SplitFocused(axis) => {
                 if let Some(pane) = self.focus {
-                    let result = self.panes.split(
-                        axis,
-                        pane,
-                        Pane::new(self.panes_created),
-                    );
+                    let result = self.panes.split(axis, pane, Pane::new(self.panes_created));
 
                     if let Some((pane, _)) = result {
                         self.focus = Some(pane);
@@ -83,10 +76,7 @@ impl Example {
             Message::Resized(pane_grid::ResizeEvent { split, ratio }) => {
                 self.panes.resize(split, ratio);
             }
-            Message::Dragged(pane_grid::DragEvent::Dropped {
-                pane,
-                target,
-            }) => {
+            Message::Dragged(pane_grid::DragEvent::Dropped { pane, target }) => {
                 self.panes.drop(pane, target);
             }
             Message::Dragged(_) => {}
@@ -118,8 +108,7 @@ impl Example {
 
     fn subscription(&self) -> Subscription<Message> {
         keyboard::listen().filter_map(|event| {
-            let keyboard::Event::KeyPressed { key, modifiers, .. } = event
-            else {
+            let keyboard::Event::KeyPressed { key, modifiers, .. } = event else {
                 return None;
             };
 
@@ -138,11 +127,9 @@ impl Example {
         let pane_grid = PaneGrid::new(&self.panes, |id, pane, is_maximized| {
             let is_focused = focus == Some(id);
 
-            let pin_button = button(
-                text(if pane.is_pinned { "Unpin" } else { "Pin" }).size(14),
-            )
-            .on_press(Message::TogglePin(id))
-            .padding(3);
+            let pin_button = button(text(if pane.is_pinned { "Unpin" } else { "Pin" }).size(14))
+                .on_press(Message::TogglePin(id))
+                .padding(3);
 
             let title = row![
                 pin_button,
@@ -157,22 +144,15 @@ impl Example {
 
             let title_bar = pane_grid::TitleBar::new(title)
                 .controls(pane_grid::Controls::dynamic(
-                    view_controls(
-                        id,
-                        total_panes,
-                        pane.is_pinned,
-                        is_maximized,
-                    ),
+                    view_controls(id, total_panes, pane.is_pinned, is_maximized),
                     button(text("X").size(14))
                         .style(button::danger)
                         .padding(3)
-                        .on_press_maybe(
-                            if total_panes > 1 && !pane.is_pinned {
-                                Some(Message::Close(id))
-                            } else {
-                                None
-                            },
-                        ),
+                        .on_press_maybe(if total_panes > 1 && !pane.is_pinned {
+                            Some(Message::Close(id))
+                        } else {
+                            None
+                        }),
                 ))
                 .padding(10)
                 .style(if is_focused {
@@ -288,10 +268,9 @@ fn view_content<'a>(
     .spacing(5)
     .max_width(160);
 
-    let content =
-        column![text!("{}x{}", size.width, size.height).size(24), controls,]
-            .spacing(10)
-            .align_x(Center);
+    let content = column![text!("{}x{}", size.width, size.height).size(24), controls,]
+        .spacing(10)
+        .align_x(Center);
 
     center_y(scrollable(content)).padding(5).into()
 }

--- a/examples/pokedex/src/main.rs
+++ b/examples/pokedex/src/main.rs
@@ -65,9 +65,7 @@ impl Pokedex {
 
     fn view(&self) -> Element<'_, Message> {
         let content: Element<_> = match self {
-            Pokedex::Loading => {
-                text("Searching for Pokémon...").size(40).into()
-            }
+            Pokedex::Loading => text("Searching for Pokémon...").size(40).into(),
             Pokedex::Loaded { pokemon } => column![
                 pokemon.view(),
                 button("Keep searching!").on_press(Message::Search)
@@ -153,8 +151,7 @@ impl Pokemon {
         };
 
         let (entry, image): (Entry, _) =
-            futures::future::try_join(fetch_entry, Self::fetch_image(id))
-                .await?;
+            futures::future::try_join(fetch_entry, Self::fetch_image(id)).await?;
 
         let description = entry
             .flavor_text_entries

--- a/examples/progress_bar/src/main.rs
+++ b/examples/progress_bar/src/main.rs
@@ -1,7 +1,6 @@
 use iced::Element;
 use iced::widget::{
-    center, center_x, checkbox, column, progress_bar, row, slider,
-    vertical_slider,
+    center, center_x, checkbox, column, progress_bar, row, slider, vertical_slider,
 };
 
 pub fn main() -> iced::Result {
@@ -24,9 +23,7 @@ impl Progress {
     fn update(&mut self, message: Message) {
         match message {
             Message::SliderChanged(x) => self.value = x,
-            Message::ToggleVertical(is_vertical) => {
-                self.is_vertical = is_vertical
-            }
+            Message::ToggleVertical(is_vertical) => self.is_vertical = is_vertical,
         }
     }
 
@@ -38,12 +35,7 @@ impl Progress {
                 center(
                     row![
                         bar.vertical(),
-                        vertical_slider(
-                            0.0..=100.0,
-                            self.value,
-                            Message::SliderChanged
-                        )
-                        .step(0.01)
+                        vertical_slider(0.0..=100.0, self.value, Message::SliderChanged).step(0.01)
                     ]
                     .spacing(20),
                 )
@@ -51,8 +43,7 @@ impl Progress {
                 center(
                     column![
                         bar,
-                        slider(0.0..=100.0, self.value, Message::SliderChanged)
-                            .step(0.01)
+                        slider(0.0..=100.0, self.value, Message::SliderChanged).step(0.01)
                     ]
                     .spacing(20),
                 )

--- a/examples/qr_code/src/main.rs
+++ b/examples/qr_code/src/main.rs
@@ -1,18 +1,12 @@
-use iced::widget::{
-    center, column, pick_list, qr_code, row, slider, text, text_input, toggler,
-};
+use iced::widget::{center, column, pick_list, qr_code, row, slider, text, text_input, toggler};
 use iced::{Center, Element, Theme};
 
 use std::ops::RangeInclusive;
 
 pub fn main() -> iced::Result {
-    iced::application(
-        QRGenerator::default,
-        QRGenerator::update,
-        QRGenerator::view,
-    )
-    .theme(QRGenerator::theme)
-    .run()
+    iced::application(QRGenerator::default, QRGenerator::update, QRGenerator::view)
+        .theme(QRGenerator::theme)
+        .run()
 }
 
 #[derive(Default)]
@@ -50,8 +44,7 @@ impl QRGenerator {
             Message::ToggleTotalSize(enabled) => {
                 self.total_size = enabled.then_some(
                     Self::SIZE_RANGE.start()
-                        + (Self::SIZE_RANGE.end() - Self::SIZE_RANGE.start())
-                            / 2.0,
+                        + (Self::SIZE_RANGE.end() - Self::SIZE_RANGE.start()) / 2.0,
                 );
             }
             Message::TotalSizeChanged(total_size) => {
@@ -66,11 +59,10 @@ impl QRGenerator {
     fn view(&self) -> Element<'_, Message> {
         let title = text("QR Code Generator").size(70);
 
-        let input =
-            text_input("Type the data of your QR code here...", &self.data)
-                .on_input(Message::DataChanged)
-                .size(30)
-                .padding(15);
+        let input = text_input("Type the data of your QR code here...", &self.data)
+            .on_input(Message::DataChanged)
+            .size(30)
+            .padding(15);
 
         let toggle_total_size = toggler(self.total_size.is_some())
             .on_toggle(Message::ToggleTotalSize)
@@ -78,8 +70,7 @@ impl QRGenerator {
 
         let choose_theme = row![
             text("Theme:"),
-            pick_list(Theme::ALL, self.theme.as_ref(), Message::ThemeChanged)
-                .placeholder("Theme")
+            pick_list(Theme::ALL, self.theme.as_ref(), Message::ThemeChanged).placeholder("Theme")
         ]
         .spacing(10)
         .align_y(Center);

--- a/examples/screenshot/src/main.rs
+++ b/examples/screenshot/src/main.rs
@@ -1,13 +1,8 @@
 use iced::keyboard;
-use iced::widget::{
-    button, center_y, column, container, image, row, text, text_input,
-};
+use iced::widget::{button, center_y, column, container, image, row, text, text_input};
 use iced::window;
 use iced::window::screenshot::{self, Screenshot};
-use iced::{
-    Center, ContentFit, Element, Fill, FillPortion, Rectangle, Subscription,
-    Task,
-};
+use iced::{Center, ContentFit, Element, Fill, FillPortion, Rectangle, Subscription, Task};
 
 use ::image as img;
 use ::image::ColorType;
@@ -67,10 +62,7 @@ impl Example {
                 if let Some((screenshot, _handle)) = &self.screenshot {
                     self.png_saving = true;
 
-                    return Task::perform(
-                        save_to_png(screenshot.clone()),
-                        Message::PngSaved,
-                    );
+                    return Task::perform(save_to_png(screenshot.clone()), Message::PngSaved);
                 }
             }
             Message::PngSaved(res) => {
@@ -122,16 +114,15 @@ impl Example {
     }
 
     fn view(&self) -> Element<'_, Message> {
-        let image: Element<Message> =
-            if let Some((_screenshot, handle)) = &self.screenshot {
-                image(handle)
-                    .content_fit(ContentFit::Contain)
-                    .width(Fill)
-                    .height(Fill)
-                    .into()
-            } else {
-                text("Press the button to take a screenshot!").into()
-            };
+        let image: Element<Message> = if let Some((_screenshot, handle)) = &self.screenshot {
+            image(handle)
+                .content_fit(ContentFit::Contain)
+                .width(Fill)
+                .height(Fill)
+                .into()
+        } else {
+            text("Press the button to take a screenshot!").into()
+        };
 
         let image = center_y(image)
             .height(FillPortion(2))
@@ -149,11 +140,9 @@ impl Example {
 
         let crop_dimension_controls = row![
             text("W:").width(30),
-            numeric_input("0", self.width_input_value)
-                .map(Message::WidthInputChanged),
+            numeric_input("0", self.width_input_value).map(Message::WidthInputChanged),
             text("H:").width(30),
-            numeric_input("0", self.height_input_value)
-                .map(Message::HeightInputChanged)
+            numeric_input("0", self.height_input_value).map(Message::HeightInputChanged)
         ]
         .spacing(10)
         .align_y(Center);
@@ -169,15 +158,15 @@ impl Example {
         .align_x(Center);
 
         let controls = {
-            let save_result =
-                self.saved_png_path.as_ref().map(
-                    |png_result| match png_result {
-                        Ok(path) => format!("Png saved as: {path:?}!"),
-                        Err(PngError(error)) => {
-                            format!("Png could not be saved due to:\n{error}")
-                        }
-                    },
-                );
+            let save_result = self
+                .saved_png_path
+                .as_ref()
+                .map(|png_result| match png_result {
+                    Ok(path) => format!("Png saved as: {path:?}!"),
+                    Err(PngError(error)) => {
+                        format!("Png could not be saved due to:\n{error}")
+                    }
+                });
 
             column![
                 column![
@@ -186,12 +175,10 @@ impl Example {
                         .width(Fill)
                         .on_press(Message::Screenshot),
                     if !self.png_saving {
-                        button(centered_text("Save as png")).on_press_maybe(
-                            self.screenshot.is_some().then(|| Message::Png),
-                        )
+                        button(centered_text("Save as png"))
+                            .on_press_maybe(self.screenshot.is_some().then(|| Message::Png))
                     } else {
-                        button(centered_text("Saving..."))
-                            .style(button::secondary)
+                        button(centered_text("Saving...")).style(button::secondary)
                     }
                     .style(button::secondary)
                     .padding([10, 20])
@@ -262,10 +249,7 @@ async fn save_to_png(screenshot: Screenshot) -> Result<String, PngError> {
 #[derive(Clone, Debug)]
 struct PngError(String);
 
-fn numeric_input(
-    placeholder: &str,
-    value: Option<u32>,
-) -> Element<'_, Option<u32>> {
+fn numeric_input(placeholder: &str, value: Option<u32>) -> Element<'_, Option<u32>> {
     text_input(
         placeholder,
         &value.as_ref().map(ToString::to_string).unwrap_or_default(),

--- a/examples/scrollable/src/main.rs
+++ b/examples/scrollable/src/main.rs
@@ -1,7 +1,6 @@
 use iced::widget::scrollable::{self, Properties, Scrollbar, Scroller};
 use iced::widget::{
-    button, column, container, operation, progress_bar, radio, row, scrollable,
-    slider, space, text,
+    button, column, container, operation, progress_bar, radio, row, scrollable, slider, space, text,
 };
 use iced::{Border, Center, Color, Element, Fill, Task, Theme};
 use iced_core::id::Id;
@@ -104,11 +103,8 @@ impl ScrollableDemo {
     }
 
     fn view(&self) -> Element<'_, Message> {
-        let scrollbar_width_slider = slider(
-            0..=15,
-            self.scrollbar_width,
-            Message::ScrollbarWidthChanged,
-        );
+        let scrollbar_width_slider =
+            slider(0..=15, self.scrollbar_width, Message::ScrollbarWidthChanged);
         let scrollbar_margin_slider = slider(
             0..=15,
             self.scrollbar_margin,
@@ -186,120 +182,112 @@ impl ScrollableDemo {
                 .on_press(Message::ScrollToBeginning)
         };
 
-        let scrollable_content: Element<Message> =
-            Element::from(match self.scrollable_direction {
-                Direction::Vertical => scrollable(
+        let scrollable_content: Element<Message> = Element::from(match self.scrollable_direction {
+            Direction::Vertical => scrollable(
+                column![
+                    scroll_to_end_button(),
+                    text("Beginning!"),
+                    space().height(1200),
+                    text("Middle!"),
+                    space().height(1200),
+                    text("End!"),
+                    scroll_to_beginning_button(),
+                ]
+                .align_x(Center)
+                .padding([40, 0])
+                .spacing(40),
+            )
+            .direction(scrollable::Direction::Vertical(
+                scrollable::Scrollbar::new()
+                    .width(self.scrollbar_width)
+                    .margin(self.scrollbar_margin)
+                    .scroller_width(self.scroller_width)
+                    .anchor(self.anchor),
+            ))
+            .width(Fill)
+            .height(Fill)
+            .id(SCROLLABLE)
+            .on_scroll(Message::Scrolled)
+            .auto_scroll(true),
+            Direction::Horizontal => scrollable(
+                row![
+                    scroll_to_end_button(),
+                    text("Beginning!"),
+                    space().width(1200),
+                    text("Middle!"),
+                    space().width(1200),
+                    text("End!"),
+                    scroll_to_beginning_button(),
+                ]
+                .height(450)
+                .align_y(Center)
+                .padding([0, 40])
+                .spacing(40),
+            )
+            .direction(scrollable::Direction::Horizontal(
+                scrollable::Scrollbar::new()
+                    .width(self.scrollbar_width)
+                    .margin(self.scrollbar_margin)
+                    .scroller_width(self.scroller_width)
+                    .anchor(self.anchor),
+            ))
+            .width(Fill)
+            .height(Fill)
+            .id(SCROLLABLE)
+            .on_scroll(Message::Scrolled)
+            .auto_scroll(true),
+            Direction::Multi => scrollable(
+                //horizontal content
+                row![
+                    column![text("Let's do some scrolling!"), space().height(2400)],
+                    scroll_to_end_button(),
+                    text("Horizontal - Beginning!"),
+                    space().width(1200),
+                    //vertical content
                     column![
+                        text("Horizontal - Middle!"),
                         scroll_to_end_button(),
-                        text("Beginning!"),
+                        text("Vertical - Beginning!"),
                         space().height(1200),
-                        text("Middle!"),
+                        text("Vertical - Middle!"),
                         space().height(1200),
-                        text("End!"),
+                        text("Vertical - End!"),
                         scroll_to_beginning_button(),
+                        space().height(40),
                     ]
-                    .align_x(Center)
-                    .padding([40, 0])
                     .spacing(40),
-                )
-                .direction(scrollable::Direction::Vertical(
-                    scrollable::Scrollbar::new()
-                        .width(self.scrollbar_width)
-                        .margin(self.scrollbar_margin)
-                        .scroller_width(self.scroller_width)
-                        .anchor(self.anchor),
-                ))
-                .width(Fill)
-                .height(Fill)
-                .id(SCROLLABLE)
-                .on_scroll(Message::Scrolled)
-                .auto_scroll(true),
-                Direction::Horizontal => scrollable(
-                    row![
-                        scroll_to_end_button(),
-                        text("Beginning!"),
-                        space().width(1200),
-                        text("Middle!"),
-                        space().width(1200),
-                        text("End!"),
-                        scroll_to_beginning_button(),
-                    ]
-                    .height(450)
-                    .align_y(Center)
-                    .padding([0, 40])
-                    .spacing(40),
-                )
-                .direction(scrollable::Direction::Horizontal(
-                    scrollable::Scrollbar::new()
-                        .width(self.scrollbar_width)
-                        .margin(self.scrollbar_margin)
-                        .scroller_width(self.scroller_width)
-                        .anchor(self.anchor),
-                ))
-                .width(Fill)
-                .height(Fill)
-                .id(SCROLLABLE)
-                .on_scroll(Message::Scrolled)
-                .auto_scroll(true),
-                Direction::Multi => scrollable(
-                    //horizontal content
-                    row![
-                        column![
-                            text("Let's do some scrolling!"),
-                            space().height(2400)
-                        ],
-                        scroll_to_end_button(),
-                        text("Horizontal - Beginning!"),
-                        space().width(1200),
-                        //vertical content
-                        column![
-                            text("Horizontal - Middle!"),
-                            scroll_to_end_button(),
-                            text("Vertical - Beginning!"),
-                            space().height(1200),
-                            text("Vertical - Middle!"),
-                            space().height(1200),
-                            text("Vertical - End!"),
-                            scroll_to_beginning_button(),
-                            space().height(40),
-                        ]
-                        .spacing(40),
-                        space().width(1200),
-                        text("Horizontal - End!"),
-                        scroll_to_beginning_button(),
-                    ]
-                    .align_y(Center)
-                    .padding([0, 40])
-                    .spacing(40),
-                )
-                .direction({
-                    let scrollbar = scrollable::Scrollbar::new()
-                        .width(self.scrollbar_width)
-                        .margin(self.scrollbar_margin)
-                        .scroller_width(self.scroller_width)
-                        .anchor(self.anchor);
+                    space().width(1200),
+                    text("Horizontal - End!"),
+                    scroll_to_beginning_button(),
+                ]
+                .align_y(Center)
+                .padding([0, 40])
+                .spacing(40),
+            )
+            .direction({
+                let scrollbar = scrollable::Scrollbar::new()
+                    .width(self.scrollbar_width)
+                    .margin(self.scrollbar_margin)
+                    .scroller_width(self.scroller_width)
+                    .anchor(self.anchor);
 
-                    scrollable::Direction::Both {
-                        horizontal: scrollbar,
-                        vertical: scrollbar,
-                    }
-                })
-                .width(Fill)
-                .height(Fill)
-                .id(SCROLLABLE)
-                .on_scroll(Message::Scrolled)
-                .auto_scroll(true),
-            });
+                scrollable::Direction::Both {
+                    horizontal: scrollbar,
+                    vertical: scrollbar,
+                }
+            })
+            .width(Fill)
+            .height(Fill)
+            .id(SCROLLABLE)
+            .on_scroll(Message::Scrolled)
+            .auto_scroll(true),
+        });
 
         let progress_bars: Element<Message> = match self.scrollable_direction {
-            Direction::Vertical => {
-                progress_bar(0.0..=1.0, self.current_scroll_offset.y).into()
-            }
-            Direction::Horizontal => {
-                progress_bar(0.0..=1.0, self.current_scroll_offset.x)
-                    .style(progress_bar_custom_style)
-                    .into()
-            }
+            Direction::Vertical => progress_bar(0.0..=1.0, self.current_scroll_offset.y).into(),
+            Direction::Horizontal => progress_bar(0.0..=1.0, self.current_scroll_offset.x)
+                .style(progress_bar_custom_style)
+                .into(),
             Direction::Multi => column![
                 progress_bar(0.0..=1.0, self.current_scroll_offset.y),
                 progress_bar(0.0..=1.0, self.current_scroll_offset.x)
@@ -309,11 +297,10 @@ impl ScrollableDemo {
             .into(),
         };
 
-        let content: Element<Message> =
-            column![scroll_controls, scrollable_content, progress_bars]
-                .align_x(Center)
-                .spacing(10)
-                .into();
+        let content: Element<Message> = column![scroll_controls, scrollable_content, progress_bars]
+            .align_x(Center)
+            .spacing(10)
+            .into();
 
         container(content).padding(20).into()
     }

--- a/examples/sctk_drag/src/dnd_destination.rs
+++ b/examples/sctk_drag/src/dnd_destination.rs
@@ -3,20 +3,20 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-use iced::{Element, id::Id};
 use iced::{
-    Event, Length, Rectangle,
     clipboard::{
         dnd::{self, DndAction, DndDestinationRectangle, DndEvent, OfferEvent},
         mime::AllowedMimeTypes,
     },
     event,
     id::Internal,
-    mouse, overlay,
+    mouse, overlay, Event, Length, Rectangle,
 };
+use iced::{id::Id, Element};
 use iced_core::{
-    self, Clipboard, Layout, Shell, Widget, layout,
-    widget::{Tree, tree},
+    self, layout,
+    widget::{tree, Tree},
+    Clipboard, Layout, Shell, Widget,
 };
 
 pub fn dnd_destination<'a, Message: 'static>(
@@ -40,10 +40,7 @@ pub struct DragId(pub u128);
 
 impl DragId {
     pub fn new() -> Self {
-        DragId(
-            u128::from(u64::MAX)
-                + u128::from(DRAG_ID_COUNTER.fetch_add(1, Ordering::Relaxed)),
-        )
+        DragId(u128::from(u64::MAX) + u128::from(DRAG_ID_COUNTER.fetch_add(1, Ordering::Relaxed)))
     }
 }
 
@@ -69,15 +66,11 @@ pub struct DndDestination<'a, Message> {
     on_motion: Option<Box<dyn Fn(f64, f64) -> Message>>,
     on_action_selected: Option<Box<dyn Fn(DndAction) -> Message>>,
     on_data_received: Option<Box<dyn Fn(String, Vec<u8>) -> Message>>,
-    on_finish:
-        Option<Box<dyn Fn(String, Vec<u8>, DndAction, f64, f64) -> Message>>,
+    on_finish: Option<Box<dyn Fn(String, Vec<u8>, DndAction, f64, f64) -> Message>>,
 }
 
 impl<'a, Message: 'static> DndDestination<'a, Message> {
-    pub fn new(
-        child: impl Into<Element<'a, Message>>,
-        mimes: Vec<Cow<'static, str>>,
-    ) -> Self {
+    pub fn new(child: impl Into<Element<'a, Message>>, mimes: Vec<Cow<'static, str>>) -> Self {
         Self {
             id: Id::unique(),
             drag_id: None,
@@ -127,10 +120,9 @@ impl<'a, Message: 'static> DndDestination<'a, Message> {
         mut self,
         f: impl Fn(Option<T>) -> Message + 'static,
     ) -> Self {
-        self.on_data_received =
-            Some(Box::new(
-                move |mime, data| f(T::try_from((data, mime)).ok()),
-            ));
+        self.on_data_received = Some(Box::new(
+            move |mime, data| f(T::try_from((data, mime)).ok()),
+        ));
         self
     }
 
@@ -183,28 +175,19 @@ impl<'a, Message: 'static> DndDestination<'a, Message> {
     }
 
     #[must_use]
-    pub fn on_hold(
-        mut self,
-        f: impl Fn(f64, f64) -> Message + 'static,
-    ) -> Self {
+    pub fn on_hold(mut self, f: impl Fn(f64, f64) -> Message + 'static) -> Self {
         self.on_hold = Some(Box::new(f));
         self
     }
 
     #[must_use]
-    pub fn on_drop(
-        mut self,
-        f: impl Fn(f64, f64) -> Message + 'static,
-    ) -> Self {
+    pub fn on_drop(mut self, f: impl Fn(f64, f64) -> Message + 'static) -> Self {
         self.on_drop = Some(Box::new(f));
         self
     }
 
     #[must_use]
-    pub fn on_enter(
-        mut self,
-        f: impl Fn(f64, f64, Vec<String>) -> Message + 'static,
-    ) -> Self {
+    pub fn on_enter(mut self, f: impl Fn(f64, f64, Vec<String>) -> Message + 'static) -> Self {
         self.on_enter = Some(Box::new(f));
         self
     }
@@ -225,28 +208,19 @@ impl<'a, Message: 'static> DndDestination<'a, Message> {
     }
 
     #[must_use]
-    pub fn on_motion(
-        mut self,
-        f: impl Fn(f64, f64) -> Message + 'static,
-    ) -> Self {
+    pub fn on_motion(mut self, f: impl Fn(f64, f64) -> Message + 'static) -> Self {
         self.on_motion = Some(Box::new(f));
         self
     }
 
     #[must_use]
-    pub fn on_action_selected(
-        mut self,
-        f: impl Fn(DndAction) -> Message + 'static,
-    ) -> Self {
+    pub fn on_action_selected(mut self, f: impl Fn(DndAction) -> Message + 'static) -> Self {
         self.on_action_selected = Some(Box::new(f));
         self
     }
 
     #[must_use]
-    pub fn on_data_received(
-        mut self,
-        f: impl Fn(String, Vec<u8>) -> Message + 'static,
-    ) -> Self {
+    pub fn on_data_received(mut self, f: impl Fn(String, Vec<u8>) -> Message + 'static) -> Self {
         self.on_data_received = Some(Box::new(f));
         self
     }
@@ -295,11 +269,9 @@ impl<'a, Message: 'static> Widget<Message, iced::Theme, iced::Renderer>
         renderer: &iced::Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        self.container.as_widget().layout(
-            &mut tree.children[0],
-            renderer,
-            limits,
-        )
+        self.container
+            .as_widget()
+            .layout(&mut tree.children[0], renderer, limits)
     }
 
     fn operate(
@@ -309,12 +281,9 @@ impl<'a, Message: 'static> Widget<Message, iced::Theme, iced::Renderer>
         renderer: &iced::Renderer,
         operation: &mut dyn iced_core::widget::Operation<()>,
     ) {
-        self.container.as_widget().operate(
-            &mut tree.children[0],
-            layout,
-            renderer,
-            operation,
-        );
+        self.container
+            .as_widget()
+            .operate(&mut tree.children[0], layout, renderer, operation);
     }
 
     #[allow(clippy::too_many_lines)]
@@ -366,8 +335,7 @@ impl<'a, Message: 'static> Widget<Message, iced::Theme, iced::Renderer>
                 }
                 if self.forward_drag_as_cursor {
                     #[allow(clippy::cast_possible_truncation)]
-                    let drag_cursor =
-                        mouse::Cursor::Available((x as f32, y as f32).into());
+                    let drag_cursor = mouse::Cursor::Available((x as f32, y as f32).into());
                     let event = Event::Mouse(mouse::Event::CursorMoved {
                         position: drag_cursor.position().unwrap(),
                     });
@@ -385,12 +353,8 @@ impl<'a, Message: 'static> Widget<Message, iced::Theme, iced::Renderer>
                 shell.capture_event();
                 return;
             }
-            Event::Dnd(DndEvent::Offer(id, OfferEvent::Leave))
-                if id == Some(my_id) =>
-            {
-                state.on_leave(
-                    self.on_leave.as_ref().map(std::convert::AsRef::as_ref),
-                );
+            Event::Dnd(DndEvent::Offer(id, OfferEvent::Leave)) if id == Some(my_id) => {
+                state.on_leave(self.on_leave.as_ref().map(std::convert::AsRef::as_ref));
 
                 if self.forward_drag_as_cursor {
                     let drag_cursor = mouse::Cursor::Unavailable;
@@ -409,9 +373,7 @@ impl<'a, Message: 'static> Widget<Message, iced::Theme, iced::Renderer>
                 shell.capture_event();
                 return;
             }
-            Event::Dnd(DndEvent::Offer(id, OfferEvent::Motion { x, y }))
-                if id == Some(my_id) =>
-            {
+            Event::Dnd(DndEvent::Offer(id, OfferEvent::Motion { x, y })) if id == Some(my_id) => {
                 if let Some(msg) = state.on_motion(
                     x,
                     y,
@@ -424,8 +386,7 @@ impl<'a, Message: 'static> Widget<Message, iced::Theme, iced::Renderer>
 
                 if self.forward_drag_as_cursor {
                     #[allow(clippy::cast_possible_truncation)]
-                    let drag_cursor =
-                        mouse::Cursor::Available((x as f32, y as f32).into());
+                    let drag_cursor = mouse::Cursor::Available((x as f32, y as f32).into());
                     let event = Event::Mouse(mouse::Event::CursorMoved {
                         position: drag_cursor.position().unwrap(),
                     });
@@ -443,32 +404,27 @@ impl<'a, Message: 'static> Widget<Message, iced::Theme, iced::Renderer>
                 shell.capture_event();
                 return;
             }
-            Event::Dnd(DndEvent::Offer(id, OfferEvent::LeaveDestination))
-                if id == Some(my_id) =>
-            {
-                if let Some(msg) = state.on_leave(
-                    self.on_leave.as_ref().map(std::convert::AsRef::as_ref),
-                ) {
+            Event::Dnd(DndEvent::Offer(id, OfferEvent::LeaveDestination)) if id == Some(my_id) => {
+                if let Some(msg) =
+                    state.on_leave(self.on_leave.as_ref().map(std::convert::AsRef::as_ref))
+                {
                     shell.publish(msg);
                 }
                 shell.capture_event();
                 return;
             }
-            Event::Dnd(DndEvent::Offer(id, OfferEvent::Drop))
-                if id == Some(my_id) =>
-            {
-                if let Some(msg) = state.on_drop(
-                    self.on_drop.as_ref().map(std::convert::AsRef::as_ref),
-                ) {
+            Event::Dnd(DndEvent::Offer(id, OfferEvent::Drop)) if id == Some(my_id) => {
+                if let Some(msg) =
+                    state.on_drop(self.on_drop.as_ref().map(std::convert::AsRef::as_ref))
+                {
                     shell.publish(msg);
                 }
                 shell.capture_event();
                 return;
             }
-            Event::Dnd(DndEvent::Offer(
-                id,
-                OfferEvent::SelectedAction(action),
-            )) if id == Some(my_id) => {
+            Event::Dnd(DndEvent::Offer(id, OfferEvent::SelectedAction(action)))
+                if id == Some(my_id) =>
+            {
                 if let Some(msg) = state.on_action_selected(
                     action,
                     self.on_action_selected
@@ -480,10 +436,9 @@ impl<'a, Message: 'static> Widget<Message, iced::Theme, iced::Renderer>
                 shell.capture_event();
                 return;
             }
-            Event::Dnd(DndEvent::Offer(
-                id,
-                OfferEvent::Data { data, mime_type },
-            )) if id == Some(my_id) => {
+            Event::Dnd(DndEvent::Offer(id, OfferEvent::Data { data, mime_type }))
+                if id == Some(my_id) =>
+            {
                 if let (Some(msg), ret) = state.on_data_received(
                     mime_type,
                     data,
@@ -547,8 +502,7 @@ impl<'a, Message: 'static> Widget<Message, iced::Theme, iced::Renderer>
         layout: Layout<'_>,
         renderer: &iced::Renderer,
         translation: iced::Vector,
-    ) -> Option<overlay::Element<'b, Message, iced::Theme, iced::Renderer>>
-    {
+    ) -> Option<overlay::Element<'b, Message, iced::Theme, iced::Renderer>> {
         None
     }
 
@@ -629,10 +583,7 @@ impl<T> State<T> {
         on_enter.map(|f| f(x, y, mime_types))
     }
 
-    pub fn on_leave<Message>(
-        &mut self,
-        on_leave: Option<&dyn Fn() -> Message>,
-    ) -> Option<Message> {
+    pub fn on_leave<Message>(&mut self, on_leave: Option<&dyn Fn() -> Message>) -> Option<Message> {
         if self.drag_offer.as_ref().is_some_and(|d| !d.dropped) {
             self.drag_offer = None;
             on_leave.map(|f| f())
@@ -700,9 +651,7 @@ impl<T> State<T> {
         mime: String,
         data: Vec<u8>,
         on_data_received: Option<impl Fn(String, Vec<u8>) -> Message>,
-        on_finish: Option<
-            impl Fn(String, Vec<u8>, DndAction, f64, f64) -> Message,
-        >,
+        on_finish: Option<impl Fn(String, Vec<u8>, DndAction, f64, f64) -> Message>,
     ) -> (Option<Message>, event::Status) {
         let Some(dnd) = self.drag_offer.as_ref() else {
             self.drag_offer = None;
@@ -711,8 +660,7 @@ impl<T> State<T> {
 
         if dnd.dropped {
             let ret = (
-                on_finish
-                    .map(|f| f(mime, data, dnd.selected_action, dnd.x, dnd.y)),
+                on_finish.map(|f| f(mime, data, dnd.selected_action, dnd.x, dnd.y)),
                 event::Status::Captured,
             );
             self.drag_offer = None;
@@ -725,9 +673,7 @@ impl<T> State<T> {
     }
 }
 
-impl<'a, Message: 'static> From<DndDestination<'a, Message>>
-    for Element<'a, Message>
-{
+impl<'a, Message: 'static> From<DndDestination<'a, Message>> for Element<'a, Message> {
     fn from(wrapper: DndDestination<'a, Message>) -> Self {
         Element::new(wrapper)
     }

--- a/examples/sctk_drag/src/dnd_source.rs
+++ b/examples/sctk_drag/src/dnd_source.rs
@@ -1,16 +1,16 @@
 use std::any::Any;
 
-use iced::Element;
 use iced::id::Id;
 use iced::widget::container;
+use iced::Element;
 use iced::{
-    Event, Length, Point, Rectangle,
     clipboard::dnd::{DndAction, DndEvent, SourceEvent},
-    event, mouse, overlay,
+    event, mouse, overlay, Event, Length, Point, Rectangle,
 };
 use iced_core::{
-    Clipboard, Shell, layout, renderer,
-    widget::{Tree, tree},
+    layout, renderer,
+    widget::{tree, Tree},
+    Clipboard, Shell,
 };
 use iced_core::{Layout, Widget};
 
@@ -30,18 +30,17 @@ pub struct DndSource<'a, Message, AppMessage, D> {
     action: DndAction,
     container: Element<'a, Message>,
     drag_content: Option<Box<dyn Fn() -> D>>,
-    drag_icon:
-        Option<Box<dyn Fn() -> (Element<'static, AppMessage>, tree::State)>>,
+    drag_icon: Option<Box<dyn Fn() -> (Element<'static, AppMessage>, tree::State)>>,
     drag_threshold: f32,
     _phantom: std::marker::PhantomData<AppMessage>,
 }
 
 impl<
-    'a,
-    Message: 'static,
-    AppMessage: 'static,
-    D: iced::clipboard::mime::AsMimeTypes + std::marker::Send + 'static,
-> DndSource<'a, Message, AppMessage, D>
+        'a,
+        Message: 'static,
+        AppMessage: 'static,
+        D: iced::clipboard::mime::AsMimeTypes + std::marker::Send + 'static,
+    > DndSource<'a, Message, AppMessage, D>
 {
     pub fn new(child: impl Into<Element<'a, Message>>) -> Self {
         Self {
@@ -119,12 +118,11 @@ impl<
 }
 
 impl<
-    'a,
-    Message: 'static,
-    AppMessage: 'static,
-    D: iced::clipboard::mime::AsMimeTypes + std::marker::Send + 'static,
-> Widget<Message, iced::Theme, iced::Renderer>
-    for DndSource<'a, Message, AppMessage, D>
+        'a,
+        Message: 'static,
+        AppMessage: 'static,
+        D: iced::clipboard::mime::AsMimeTypes + std::marker::Send + 'static,
+    > Widget<Message, iced::Theme, iced::Renderer> for DndSource<'a, Message, AppMessage, D>
 {
     fn children(&self) -> Vec<Tree> {
         vec![Tree::new(&self.container)]
@@ -153,11 +151,10 @@ impl<
         limits: &layout::Limits,
     ) -> layout::Node {
         let state = tree.state.downcast_mut::<State>();
-        let node = self.container.as_widget().layout(
-            &mut tree.children[0],
-            renderer,
-            limits,
-        );
+        let node = self
+            .container
+            .as_widget()
+            .layout(&mut tree.children[0], renderer, limits);
         state.cached_bounds = node.bounds();
         node
     }
@@ -170,18 +167,11 @@ impl<
         operation: &mut dyn iced_core::widget::Operation<()>,
     ) {
         operation.custom((&mut tree.state) as &mut dyn Any, Some(&self.id));
-        operation.container(
-            Some(&self.id),
-            layout.bounds(),
-            &mut |operation| {
-                self.container.as_widget().operate(
-                    &mut tree.children[0],
-                    layout,
-                    renderer,
-                    operation,
-                )
-            },
-        );
+        operation.container(Some(&self.id), layout.bounds(), &mut |operation| {
+            self.container
+                .as_widget()
+                .operate(&mut tree.children[0], layout, renderer, operation)
+        });
     }
 
     fn update(
@@ -236,16 +226,9 @@ impl<
                                 state.left_pressed_position = None;
                                 return ret;
                             }
-                            if let Some(left_pressed_position) =
-                                state.left_pressed_position
-                            {
-                                if position.distance(left_pressed_position)
-                                    > self.drag_threshold
-                                {
-                                    self.start_dnd(
-                                        clipboard,
-                                        state.cached_bounds,
-                                    );
+                            if let Some(left_pressed_position) = state.left_pressed_position {
+                                if position.distance(left_pressed_position) > self.drag_threshold {
+                                    self.start_dnd(clipboard, state.cached_bounds);
                                     state.is_dragging = true;
                                     state.left_pressed_position = None;
                                 }
@@ -264,9 +247,7 @@ impl<
                 }
                 _ => return ret,
             },
-            Event::Dnd(DndEvent::Source(
-                SourceEvent::Cancelled | SourceEvent::Finished,
-            )) => {
+            Event::Dnd(DndEvent::Source(SourceEvent::Cancelled | SourceEvent::Finished)) => {
                 if state.is_dragging {
                     state.is_dragging = false;
                     shell.capture_event();
@@ -327,8 +308,7 @@ impl<
         layout: Layout<'_>,
         renderer: &iced::Renderer,
         translation: iced::Vector,
-    ) -> Option<overlay::Element<'b, Message, iced::Theme, iced::Renderer>>
-    {
+    ) -> Option<overlay::Element<'b, Message, iced::Theme, iced::Renderer>> {
         None
     }
 
@@ -357,11 +337,11 @@ impl<
 }
 
 impl<
-    'a,
-    Message: 'static,
-    AppMessage: 'static,
-    D: iced::clipboard::mime::AsMimeTypes + std::marker::Send + 'static,
-> From<DndSource<'a, Message, AppMessage, D>> for Element<'a, Message>
+        'a,
+        Message: 'static,
+        AppMessage: 'static,
+        D: iced::clipboard::mime::AsMimeTypes + std::marker::Send + 'static,
+    > From<DndSource<'a, Message, AppMessage, D>> for Element<'a, Message>
 {
     fn from(e: DndSource<'a, Message, AppMessage, D>) -> Element<'a, Message> {
         Element::new(e)

--- a/examples/sctk_drag/src/main.rs
+++ b/examples/sctk_drag/src/main.rs
@@ -19,8 +19,7 @@ use iced_core::{
 };
 
 fn main() -> iced::Result {
-    iced::daemon(DndTest::title, DndTest::update, DndTest::view)
-        .run_with(DndTest::new)
+    iced::daemon(DndTest::title, DndTest::update, DndTest::view).run_with(DndTest::new)
     // iced::application(Todos::title, Todos::update, Todos::view)
     // .subscription(Todos::subscription)
     // .font(include_bytes!("../fonts/icons.ttf").as_slice())
@@ -75,10 +74,7 @@ impl AsMimeTypes for MyDndString {
         ])
     }
 
-    fn as_bytes(
-        &self,
-        _mime_type: &str,
-    ) -> Option<std::borrow::Cow<'static, [u8]>> {
+    fn as_bytes(&self, _mime_type: &str) -> Option<std::borrow::Cow<'static, [u8]>> {
         Some(Cow::Owned(self.0.clone().into_bytes()))
     }
 }
@@ -136,13 +132,10 @@ impl DndTest {
         let s2 = s.clone();
         column![
             dnd_destination::dnd_destination_for_data::<MyDndString, Message>(
-                container(text(format!(
-                    "Drag text here: {}",
-                    &self.current_text
-                )))
-                .width(Length::Fill)
-                .height(Length::FillPortion(1))
-                .padding(20),
+                container(text(format!("Drag text here: {}", &self.current_text)))
+                    .width(Length::Fill)
+                    .height(Length::FillPortion(1))
+                    .padding(20),
                 |data, _| {
                     dbg!("got data");
                     Message::DndData(data.unwrap_or_default())
@@ -176,8 +169,7 @@ impl DndTest {
             )
             .drag_threshold(5.0)
             .drag_icon(move || {
-                let t: Text<'static, iced::Theme, iced::Renderer> =
-                    text(s.clone());
+                let t: Text<'static, iced::Theme, iced::Renderer> = text(s.clone());
                 let state = <iced_core::widget::Text<
                     'static,
                     iced::Theme,
@@ -186,9 +178,7 @@ impl DndTest {
                     &t,
                 );
                 (
-                    Element::<'static, (), iced::Theme, iced::Renderer>::from(
-                        t,
-                    ),
+                    Element::<'static, (), iced::Theme, iced::Renderer>::from(t),
                     state,
                 )
             })

--- a/examples/sctk_lazy/src/main.rs
+++ b/examples/sctk_lazy/src/main.rs
@@ -5,8 +5,7 @@ use iced::platform_specific::shell::commands::layer_surface::{
 };
 
 use iced::widget::{
-    button, column, horizontal_space, lazy, pick_list, row, scrollable, text,
-    text_input,
+    button, column, horizontal_space, lazy, pick_list, row, scrollable, text, text_input,
 };
 use iced::window::Id;
 use iced::Task;
@@ -131,8 +130,7 @@ enum Message {
 impl App {
     fn new() -> (App, Task<Message>) {
         let mut initial_surface = SctkLayerSurfaceSettings::default();
-        initial_surface.keyboard_interactivity =
-            KeyboardInteractivity::OnDemand;
+        initial_surface.keyboard_interactivity = KeyboardInteractivity::OnDemand;
         initial_surface.size_limits = Limits::NONE
             .min_width(1.0)
             .min_height(1.0)
@@ -184,17 +182,12 @@ impl App {
             let mut items: Vec<_> = self.items.iter().cloned().collect();
 
             items.sort_by(|a, b| match self.order {
-                Order::Ascending => {
-                    a.name.to_lowercase().cmp(&b.name.to_lowercase())
-                }
-                Order::Descending => {
-                    b.name.to_lowercase().cmp(&a.name.to_lowercase())
-                }
+                Order::Ascending => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+                Order::Descending => b.name.to_lowercase().cmp(&a.name.to_lowercase()),
             });
 
             column(items.into_iter().map(|item| {
-                let button = button("Delete")
-                    .on_press(Message::DeleteItem(item.clone()));
+                let button = button("Delete").on_press(Message::DeleteItem(item.clone()));
 
                 row![
                     text(item.name.clone()),

--- a/examples/sctk_session_lock/src/main.rs
+++ b/examples/sctk_session_lock/src/main.rs
@@ -44,10 +44,7 @@ impl Locker {
             Message::WaylandEvent(evt) => match evt {
                 WaylandEvent::Output(evt, output) => match evt {
                     OutputEvent::Created(_) => {
-                        return session_lock::get_lock_surface(
-                            window::Id::unique(),
-                            output,
-                        );
+                        return session_lock::get_lock_surface(window::Id::unique(), output);
                     }
                     OutputEvent::Removed => {}
                     _ => {}
@@ -55,9 +52,7 @@ impl Locker {
                 WaylandEvent::SessionLock(evt) => match evt {
                     SessionLockEvent::Locked => {
                         return iced::Task::perform(
-                            async_std::task::sleep(
-                                std::time::Duration::from_secs(5),
-                            ),
+                            async_std::task::sleep(std::time::Duration::from_secs(5)),
                             |_| Message::TimeUp,
                         );
                     }
@@ -83,9 +78,7 @@ impl Locker {
 
     fn subscription(&self) -> Subscription<Message> {
         listen_raw(|evt, _, _| {
-            if let iced::Event::PlatformSpecific(
-                iced::event::PlatformSpecific::Wayland(evt),
-            ) = evt
+            if let iced::Event::PlatformSpecific(iced::event::PlatformSpecific::Wayland(evt)) = evt
             {
                 Some(Message::WaylandEvent(evt))
             } else {

--- a/examples/sctk_subsurface/src/main.rs
+++ b/examples/sctk_subsurface/src/main.rs
@@ -7,7 +7,6 @@ use cctk::sctk::reexports::{
 
 use iced::platform_specific::shell::commands::subsurface::get_subsurface;
 use iced::{
-    Element, Length, Subscription, Task,
     event::wayland::Event as WaylandEvent,
     platform_specific::{
         runtime::wayland::subsurface::SctkSubsurfaceSettings,
@@ -15,6 +14,7 @@ use iced::{
     },
     widget::{button, column, text, text_input},
     window::{self, Id, Settings},
+    Element, Length, Subscription, Task,
 };
 use std::sync::{Arc, Mutex};
 
@@ -74,8 +74,7 @@ impl SubsurfaceApp {
                 WaylandEvent::Output(_evt, output) => {
                     if self.connection.is_none() {
                         if let Some(backend) = output.backend().upgrade() {
-                            self.connection =
-                                Some(Connection::from_backend(backend));
+                            self.connection = Some(Connection::from_backend(backend));
                         }
                     }
                 }
@@ -130,28 +129,22 @@ impl SubsurfaceApp {
                             .width(Length::Fill)
                             .height(Length::Fill)
                             .push(
-                                subsurface_widget::Subsurface::new(
-                                    red_buffer.clone()
-                                )
-                                .width(Length::Fill)
-                                .height(Length::Fill)
-                                .z(0)
+                                subsurface_widget::Subsurface::new(red_buffer.clone())
+                                    .width(Length::Fill)
+                                    .height(Length::Fill)
+                                    .z(0)
                             )
                             .push(
-                                subsurface_widget::Subsurface::new(
-                                    green_buffer.clone()
-                                )
-                                .width(Length::Fixed(1920.))
-                                .height(Length::Fixed(200.))
-                                .z(1)
+                                subsurface_widget::Subsurface::new(green_buffer.clone())
+                                    .width(Length::Fixed(1920.))
+                                    .height(Length::Fixed(200.))
+                                    .z(1)
                             )
                             .push(
-                                subsurface_widget::Subsurface::new(
-                                    red_buffer.clone()
-                                )
-                                .width(Length::Fill)
-                                .height(Length::Fixed(100.))
-                                .z(2)
+                                subsurface_widget::Subsurface::new(red_buffer.clone())
+                                    .width(Length::Fill)
+                                    .height(Length::Fixed(100.))
+                                    .z(2)
                             )
                     )
                     .width(Length::Fill)
@@ -176,12 +169,9 @@ impl SubsurfaceApp {
 
     fn subscription(&self) -> Subscription<Message> {
         let mut subscriptions = vec![iced::event::listen_with(|evt, _, _| {
-            if let iced::Event::PlatformSpecific(
-                iced::event::PlatformSpecific::Wayland(WaylandEvent::Output(
-                    evt,
-                    output,
-                )),
-            ) = evt
+            if let iced::Event::PlatformSpecific(iced::event::PlatformSpecific::Wayland(
+                WaylandEvent::Output(evt, output),
+            )) = evt
             {
                 Some(Message::WaylandEvent(WaylandEvent::Output(evt, output)))
             } else {
@@ -189,8 +179,7 @@ impl SubsurfaceApp {
             }
         })];
         if let Some(connection) = &self.connection {
-            subscriptions
-                .push(wayland::subscription(connection).map(Message::Wayland));
+            subscriptions.push(wayland::subscription(connection).map(Message::Wayland));
         }
         Subscription::batch(subscriptions)
     }

--- a/examples/sctk_subsurface/src/subsurface_container.rs
+++ b/examples/sctk_subsurface/src/subsurface_container.rs
@@ -7,8 +7,7 @@ use iced::core::overlay;
 use iced::core::renderer;
 use iced::core::widget::{Operation, Tree};
 use iced::core::{
-    Clipboard, Element, Layout, Length, Padding, Pixels, Rectangle, Shell,
-    Size, Vector, Widget,
+    Clipboard, Element, Layout, Length, Padding, Pixels, Rectangle, Shell, Size, Vector, Widget,
 };
 
 /// A container that distributes its contents vertically.
@@ -34,12 +33,7 @@ use iced::core::{
 /// }
 /// ```
 #[allow(missing_debug_implementations)]
-pub struct SubsurfaceContainer<
-    'a,
-    Message,
-    Theme = iced::Theme,
-    Renderer = iced::Renderer,
-> {
+pub struct SubsurfaceContainer<'a, Message, Theme = iced::Theme, Renderer = iced::Renderer> {
     spacing: f32,
     padding: Padding,
     width: Length,
@@ -50,8 +44,7 @@ pub struct SubsurfaceContainer<
     children: Vec<Element<'a, Message, Theme, Renderer>>,
 }
 
-impl<'a, Message, Theme, Renderer>
-    SubsurfaceContainer<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme, Renderer> SubsurfaceContainer<'a, Message, Theme, Renderer>
 where
     Renderer: iced::core::Renderer,
 {
@@ -81,9 +74,7 @@ where
     ///
     /// If any of the children have a [`Length::Fill`] strategy, you will need to
     /// call [`SubsurfaceContainer::width`] or [`SubsurfaceContainer::height`] accordingly.
-    pub fn from_vec(
-        children: Vec<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn from_vec(children: Vec<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             spacing: 0.0,
             padding: Padding::ZERO,
@@ -144,10 +135,7 @@ where
     }
 
     /// Adds an element to the [`SubsurfaceContainer`].
-    pub fn push(
-        mut self,
-        child: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn push(mut self, child: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         let child = child.into();
         let child_size = child.as_widget().size_hint();
 
@@ -179,8 +167,7 @@ where
     }
 }
 
-impl<'a, Message, Renderer> Default
-    for SubsurfaceContainer<'a, Message, Renderer>
+impl<'a, Message, Renderer> Default for SubsurfaceContainer<'a, Message, Renderer>
 where
     Renderer: iced::core::Renderer,
 {
@@ -193,11 +180,7 @@ impl<'a, Message, Theme, Renderer: iced::core::Renderer>
     FromIterator<Element<'a, Message, Theme, Renderer>>
     for SubsurfaceContainer<'a, Message, Theme, Renderer>
 {
-    fn from_iter<
-        T: IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
-    >(
-        iter: T,
-    ) -> Self {
+    fn from_iter<T: IntoIterator<Item = Element<'a, Message, Theme, Renderer>>>(iter: T) -> Self {
         Self::with_children(iter)
     }
 }
@@ -241,9 +224,7 @@ where
                     size.height,
                     self.padding,
                     |limits| c.0.as_widget().layout(c.1, renderer, limits),
-                    |content, size| {
-                        content.align(self.align, Alignment::Start, size)
-                    },
+                    |content, size| content.align(self.align, Alignment::Start, size),
                 )
             })
             .collect();
@@ -316,9 +297,9 @@ where
             .zip(&tree.children)
             .zip(layout.children())
             .map(|((child, state), layout)| {
-                child.as_widget().mouse_interaction(
-                    state, layout, cursor, viewport, renderer,
-                )
+                child
+                    .as_widget()
+                    .mouse_interaction(state, layout, cursor, viewport, renderer)
             })
             .max()
             .unwrap_or_default()
@@ -348,9 +329,9 @@ where
                 .zip(layout.children())
                 .filter(|(_, layout)| layout.bounds().intersects(viewport))
             {
-                child.as_widget().draw(
-                    state, renderer, theme, style, layout, cursor, viewport,
-                );
+                child
+                    .as_widget()
+                    .draw(state, renderer, theme, style, layout, cursor, viewport);
             }
         }
     }
@@ -362,13 +343,7 @@ where
         renderer: &Renderer,
         translation: Vector,
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
-        overlay::from_children(
-            &mut self.children,
-            tree,
-            layout,
-            renderer,
-            translation,
-        )
+        overlay::from_children(&mut self.children, tree, layout, renderer, translation)
     }
 
     #[cfg(feature = "a11y")]
@@ -385,9 +360,7 @@ where
                 .iter()
                 .zip(layout.children())
                 .zip(state.children.iter())
-                .map(|((c, c_layout), state)| {
-                    c.as_widget().a11y_nodes(c_layout, state, cursor)
-                }),
+                .map(|((c, c_layout), state)| c.as_widget().a11y_nodes(c_layout, state, cursor)),
         )
     }
 
@@ -404,27 +377,20 @@ where
             .zip(layout.children())
             .zip(state.children.iter())
         {
-            e.as_widget().drag_destinations(
-                state,
-                layout,
-                renderer,
-                dnd_rectangles,
-            );
+            e.as_widget()
+                .drag_destinations(state, layout, renderer, dnd_rectangles);
         }
     }
 }
 
-impl<'a, Message, Theme, Renderer>
-    From<SubsurfaceContainer<'a, Message, Theme, Renderer>>
+impl<'a, Message, Theme, Renderer> From<SubsurfaceContainer<'a, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
     Theme: 'a,
     Renderer: iced::core::Renderer + 'a,
 {
-    fn from(
-        SubsurfaceContainer: SubsurfaceContainer<'a, Message, Theme, Renderer>,
-    ) -> Self {
+    fn from(SubsurfaceContainer: SubsurfaceContainer<'a, Message, Theme, Renderer>) -> Self {
         Self::new(SubsurfaceContainer)
     }
 }

--- a/examples/sctk_subsurface/src/wayland.rs
+++ b/examples/sctk_subsurface/src/wayland.rs
@@ -123,9 +123,7 @@ fn create_memfile() -> rustix::io::Result<OwnedFd> {
             time.duration_since(UNIX_EPOCH).unwrap().subsec_nanos()
         );
 
-        match rustix::io::retry_on_intr(|| {
-            rustix::shm::shm_open(&name, flags, 0600.into())
-        }) {
+        match rustix::io::retry_on_intr(|| rustix::shm::shm_open(&name, flags, 0600.into())) {
             Ok(fd) => match rustix::shm::shm_unlink(&name) {
                 Ok(_) => return Ok(fd),
                 Err(errno) => {

--- a/examples/sctk_subsurface_gst/src/pipewire.rs
+++ b/examples/sctk_subsurface_gst/src/pipewire.rs
@@ -62,10 +62,7 @@ pub fn subscription(path: &str) -> iced::Subscription<Event> {
     )
 }
 
-fn pipewire_thread(
-    path: &str,
-    mut sender: futures_channel::mpsc::Sender<Event>,
-) {
+fn pipewire_thread(path: &str, mut sender: futures_channel::mpsc::Sender<Event>) {
     gst::init().unwrap();
 
     let pipeline = gst::parse::launch(&format!(
@@ -114,8 +111,7 @@ fn pipewire_thread(
     appsink.set_callbacks(
         gst_app::AppSinkCallbacks::builder()
             .new_sample(move |appsink| {
-                let sample =
-                    appsink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
+                let sample = appsink.pull_sample().map_err(|_| gst::FlowError::Eos)?;
 
                 let buffer = sample.buffer().unwrap();
                 let meta = buffer.meta::<gst_video::VideoMeta>().unwrap();
@@ -166,8 +162,7 @@ fn pipewire_thread(
                     buffer_source
                 };
 
-                let (buffer, new_subsurface_release) =
-                    SubsurfaceBuffer::new(buffer_source);
+                let (buffer, new_subsurface_release) = SubsurfaceBuffer::new(buffer_source);
                 block_on(sender.send(Event::Frame(buffer))).unwrap();
 
                 // Wait for server to release other buffer

--- a/examples/sctk_subsurface_img/Cargo.toml
+++ b/examples/sctk_subsurface_img/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 iced = { path = "../..", default-features = false, features = [
     "tokio",
-    "wayland",
+    "cctk",
     "winit",
     "debug",
     "tiny-skia",

--- a/examples/sctk_subsurface_img/src/main.rs
+++ b/examples/sctk_subsurface_img/src/main.rs
@@ -1,8 +1,6 @@
 use cctk::sctk::reexports::client::protocol::wl_shm;
 use iced::{
-    platform_specific::shell::subsurface_widget::{
-        self, Shmbuf, SubsurfaceBuffer,
-    },
+    platform_specific::shell::subsurface_widget::{self, Shmbuf, SubsurfaceBuffer},
     window::{self, Id, Settings},
     Element, Subscription, Task,
 };
@@ -29,12 +27,13 @@ fn main() -> iced::Result {
     }
 
     iced::daemon(
-        SubsurfaceApp::title,
+        move || SubsurfaceApp::new(path.clone()),
         SubsurfaceApp::update,
         SubsurfaceApp::view,
     )
+    .title(SubsurfaceApp::title)
     .subscription(SubsurfaceApp::subscription)
-    .run_with(|| SubsurfaceApp::new(path))
+    .run()
 }
 
 #[derive(Debug, Clone)]
@@ -105,7 +104,7 @@ impl SubsurfaceApp {
         Task::none()
     }
 
-    fn view(&self, _id: window::Id) -> Element<Message> {
+    fn view(&self, _id: window::Id) -> Element<'_, Message> {
         let image: Element<_> = if self.use_subsurface {
             subsurface_widget::Subsurface::new(self.buffer.clone())
                 .content_fit(iced::ContentFit::None)
@@ -120,15 +119,12 @@ impl SubsurfaceApp {
 
     fn subscription(&self) -> Subscription<Message> {
         iced::event::listen_with(|evt, _status, _id| match evt {
-            iced::Event::Keyboard(iced::keyboard::Event::KeyReleased {
-                key,
-                ..
-            }) => match key {
-                iced::keyboard::Key::Character(
-                    " ".into()
-                ) => Some(Message::Toggle),
-                _ => None,
-            },
+            iced::Event::Keyboard(iced::keyboard::Event::KeyReleased { key, .. }) => {
+                match key.as_ref() {
+                    iced::keyboard::Key::Character(" ") => Some(Message::Toggle),
+                    _ => None,
+                }
+            }
             _ => None,
         })
     }
@@ -144,9 +140,7 @@ fn create_memfile() -> rustix::io::Result<OwnedFd> {
             time.duration_since(UNIX_EPOCH).unwrap().subsec_nanos()
         );
 
-        match rustix::io::retry_on_intr(|| {
-            rustix::shm::shm_open(&name, flags, 0600.into())
-        }) {
+        match rustix::io::retry_on_intr(|| rustix::shm::shm_open(&name, flags, 0600.into())) {
             Ok(fd) => match rustix::shm::shm_unlink(&name) {
                 Ok(_) => return Ok(fd),
                 Err(errno) => {

--- a/examples/sctk_todos/src/main.rs
+++ b/examples/sctk_todos/src/main.rs
@@ -7,8 +7,7 @@ use iced::platform_specific::shell::commands::{
 };
 use iced::theme::{self, Theme};
 use iced::widget::{
-    self, button, checkbox, column, container, row, scrollable, text,
-    text_input, Text,
+    self, button, checkbox, column, container, row, scrollable, text, text_input, Text,
 };
 use iced::window::Settings;
 use iced::{window, Application, Element, Program, Task};
@@ -149,9 +148,7 @@ impl Todos {
                     }
                     Message::CreateTask => {
                         if !state.input_value.is_empty() {
-                            state
-                                .tasks
-                                .push(MyTask::new(state.input_value.clone()));
+                            state.tasks.push(MyTask::new(state.input_value.clone()));
                             state.input_value.clear();
                         }
                         Task::none()
@@ -168,8 +165,7 @@ impl Todos {
                     }
                     Message::TaskMessage(i, task_message) => {
                         if let Some(task) = state.tasks.get_mut(i) {
-                            let should_focus =
-                                matches!(task_message, TaskMessage::Edit);
+                            let should_focus = matches!(task_message, TaskMessage::Edit);
 
                             task.update(task_message);
 
@@ -255,8 +251,7 @@ impl Todos {
                     .on_paste(Message::InputChanged);
 
                 let controls = view_controls(tasks, *filter);
-                let filtered_tasks =
-                    tasks.iter().filter(|task| filter.matches(task));
+                let filtered_tasks = tasks.iter().filter(|task| filter.matches(task));
 
                 let tasks: Element<_> = if filtered_tasks.count() > 0 {
                     column(
@@ -265,9 +260,8 @@ impl Todos {
                             .enumerate()
                             .filter(|(_, task)| filter.matches(task))
                             .map(|(i, task)| {
-                                task.view(i).map(move |message| {
-                                    Message::TaskMessage(i, message)
-                                })
+                                task.view(i)
+                                    .map(move |message| Message::TaskMessage(i, message))
                             })
                             .collect::<Vec<_>>(),
                     )
@@ -277,9 +271,7 @@ impl Todos {
                     empty_message(match filter {
                         Filter::All => "You have not created a task yet...",
                         Filter::Active => "All your tasks are done! :D",
-                        Filter::Completed => {
-                            "You have not completed a task yet..."
-                        }
+                        Filter::Completed => "You have not completed a task yet...",
                     })
                 };
 
@@ -421,13 +413,12 @@ impl MyTask {
                 .into()
             }
             TaskState::Editing => {
-                let text_input =
-                    text_input("Describe your task...", &self.description)
-                        .id(Self::text_input_id(i))
-                        .on_submit(TaskMessage::FinishEdition)
-                        .on_input(TaskMessage::DescriptionEdited)
-                        .on_paste(TaskMessage::DescriptionEdited)
-                        .padding(10);
+                let text_input = text_input("Describe your task...", &self.description)
+                    .id(Self::text_input_id(i))
+                    .on_submit(TaskMessage::FinishEdition)
+                    .on_input(TaskMessage::DescriptionEdited)
+                    .on_paste(TaskMessage::DescriptionEdited)
+                    .padding(10);
 
                 row![
                     text_input,
@@ -598,8 +589,7 @@ impl SavedState {
     async fn save(self) -> Result<(), SaveError> {
         use async_std::prelude::*;
 
-        let json = serde_json::to_string_pretty(&self)
-            .map_err(|_| SaveError::Format)?;
+        let json = serde_json::to_string_pretty(&self).map_err(|_| SaveError::Format)?;
 
         let path = Self::path();
 
@@ -648,8 +638,7 @@ impl SavedState {
     async fn save(self) -> Result<(), SaveError> {
         let storage = Self::storage().ok_or(SaveError::File)?;
 
-        let json = serde_json::to_string_pretty(&self)
-            .map_err(|_| SaveError::Format)?;
+        let json = serde_json::to_string_pretty(&self).map_err(|_| SaveError::Format)?;
 
         storage
             .set_item("state", &json)

--- a/examples/sierpinski_triangle/src/main.rs
+++ b/examples/sierpinski_triangle/src/main.rs
@@ -1,9 +1,7 @@
 use iced::mouse;
 use iced::widget::canvas::{self, Canvas, Event, Geometry};
 use iced::widget::{column, row, slider, text};
-use iced::{
-    Center, Color, Element, Fill, Point, Rectangle, Renderer, Size, Theme,
-};
+use iced::{Center, Color, Element, Fill, Point, Rectangle, Renderer, Size, Theme};
 
 use rand::Rng;
 use std::fmt::Debug;
@@ -85,12 +83,10 @@ impl canvas::Program<Message> for SierpinskiGraph {
 
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(button)) => match button {
-                mouse::Button::Left => Some(canvas::Action::publish(
-                    Message::PointAdded(cursor_position),
-                )),
-                mouse::Button::Right => {
-                    Some(canvas::Action::publish(Message::PointRemoved))
-                }
+                mouse::Button::Left => Some(canvas::Action::publish(Message::PointAdded(
+                    cursor_position,
+                ))),
+                mouse::Button::Right => Some(canvas::Action::publish(Message::PointRemoved)),
                 _ => None,
             },
             _ => None,
@@ -143,8 +139,7 @@ impl SierpinskiGraph {
     }
 
     fn gen_rand_point(&self, last: Option<Point>) -> Point {
-        let dest_point_idx =
-            rand::thread_rng().gen_range(0..self.fix_points.len());
+        let dest_point_idx = rand::thread_rng().gen_range(0..self.fix_points.len());
 
         let dest_point = self.fix_points[dest_point_idx];
         let cur_point = last.or_else(|| Some(self.fix_points[0])).unwrap();

--- a/examples/solar_system/src/main.rs
+++ b/examples/solar_system/src/main.rs
@@ -11,10 +11,7 @@ use iced::widget::canvas::stroke::{self, Stroke};
 use iced::widget::canvas::{Geometry, Path};
 use iced::widget::{canvas, image};
 use iced::window;
-use iced::{
-    Color, Element, Fill, Point, Rectangle, Renderer, Size, Subscription,
-    Theme, Vector,
-};
+use iced::{Color, Element, Fill, Point, Rectangle, Renderer, Size, Subscription, Theme, Vector};
 
 use std::time::Instant;
 
@@ -92,15 +89,9 @@ impl State {
         let size = window::Settings::default().size;
 
         State {
-            sun: image::Handle::from_bytes(
-                include_bytes!("../assets/sun.png").as_slice(),
-            ),
-            earth: image::Handle::from_bytes(
-                include_bytes!("../assets/earth.png").as_slice(),
-            ),
-            moon: image::Handle::from_bytes(
-                include_bytes!("../assets/moon.png").as_slice(),
-            ),
+            sun: image::Handle::from_bytes(include_bytes!("../assets/sun.png").as_slice()),
+            earth: image::Handle::from_bytes(include_bytes!("../assets/earth.png").as_slice()),
+            moon: image::Handle::from_bytes(include_bytes!("../assets/moon.png").as_slice()),
             space_cache: canvas::Cache::default(),
             system_cache: canvas::Cache::default(),
             start: now,
@@ -147,28 +138,24 @@ impl<Message> canvas::Program<Message> for State {
     ) -> Vec<Geometry> {
         use std::f32::consts::PI;
 
-        let background =
-            self.space_cache.draw(renderer, bounds.size(), |frame| {
-                frame.fill_rectangle(Point::ORIGIN, frame.size(), Color::BLACK);
+        let background = self.space_cache.draw(renderer, bounds.size(), |frame| {
+            frame.fill_rectangle(Point::ORIGIN, frame.size(), Color::BLACK);
 
-                let stars = Path::new(|path| {
-                    for (p, size) in &self.stars {
-                        path.rectangle(*p, Size::new(*size, *size));
-                    }
-                });
-
-                frame.translate(frame.center() - Point::ORIGIN);
-                frame.fill(&stars, Color::WHITE);
+            let stars = Path::new(|path| {
+                for (p, size) in &self.stars {
+                    path.rectangle(*p, Size::new(*size, *size));
+                }
             });
+
+            frame.translate(frame.center() - Point::ORIGIN);
+            frame.fill(&stars, Color::WHITE);
+        });
 
         let system = self.system_cache.draw(renderer, bounds.size(), |frame| {
             let center = frame.center();
             frame.translate(Vector::new(center.x, center.y));
 
-            frame.draw_image(
-                Rectangle::with_radius(Self::SUN_RADIUS),
-                &self.sun,
-            );
+            frame.draw_image(Rectangle::with_radius(Self::SUN_RADIUS), &self.sun);
 
             let orbit = Path::circle(Point::ORIGIN, Self::ORBIT_RADIUS);
             frame.stroke(
@@ -199,10 +186,7 @@ impl<Message> canvas::Program<Message> for State {
             frame.rotate(rotation * 10.0);
             frame.translate(Vector::new(0.0, Self::MOON_DISTANCE));
 
-            frame.draw_image(
-                Rectangle::with_radius(Self::MOON_RADIUS),
-                &self.moon,
-            );
+            frame.draw_image(Rectangle::with_radius(Self::MOON_RADIUS), &self.moon);
         });
 
         vec![background, system]

--- a/examples/stopwatch/src/main.rs
+++ b/examples/stopwatch/src/main.rs
@@ -59,9 +59,7 @@ impl Stopwatch {
     fn subscription(&self) -> Subscription<Message> {
         let tick = match self.state {
             State::Idle => Subscription::none(),
-            State::Ticking { .. } => {
-                time::every(milliseconds(10)).map(Message::Tick)
-            }
+            State::Ticking { .. } => time::every(milliseconds(10)).map(Message::Tick),
         };
 
         fn handle_hotkey(event: keyboard::Event) -> Option<Message> {
@@ -72,18 +70,13 @@ impl Stopwatch {
             };
 
             match modified_key.as_ref() {
-                keyboard::Key::Named(key::Named::Space) => {
-                    Some(Message::Toggle)
-                }
+                keyboard::Key::Named(key::Named::Space) => Some(Message::Toggle),
                 keyboard::Key::Character("r") => Some(Message::Reset),
                 _ => None,
             }
         }
 
-        Subscription::batch(vec![
-            tick,
-            keyboard::listen().filter_map(handle_hotkey),
-        ])
+        Subscription::batch(vec![tick, keyboard::listen().filter_map(handle_hotkey)])
     }
 
     fn view(&self) -> Element<'_, Message> {
@@ -101,8 +94,7 @@ impl Stopwatch {
         )
         .size(40);
 
-        let button =
-            |label| button(text(label).align_x(Center)).padding(10).width(80);
+        let button = |label| button(text(label).align_x(Center)).padding(10).width(80);
 
         let toggle_button = {
             let label = match self.state {

--- a/examples/styling/src/main.rs
+++ b/examples/styling/src/main.rs
@@ -1,8 +1,7 @@
 use iced::keyboard;
 use iced::widget::{
-    button, center_x, center_y, checkbox, column, container, pick_list,
-    progress_bar, row, rule, scrollable, slider, space, text, text_input,
-    toggler,
+    button, center_x, center_y, checkbox, column, container, pick_list, progress_bar, row, rule,
+    scrollable, slider, space, text, text_input, toggler,
 };
 use iced::{Center, Element, Fill, Shrink, Subscription, Theme};
 
@@ -47,14 +46,13 @@ impl Styling {
             Message::CheckboxToggled(value) => self.checkbox_value = value,
             Message::TogglerToggled(value) => self.toggler_value = value,
             Message::PreviousTheme | Message::NextTheme => {
-                let current = Theme::ALL.iter().position(|candidate| {
-                    self.theme.as_ref() == Some(candidate)
-                });
+                let current = Theme::ALL
+                    .iter()
+                    .position(|candidate| self.theme.as_ref() == Some(candidate));
 
                 self.theme = Some(if matches!(message, Message::NextTheme) {
-                    Theme::ALL[current.map(|current| current + 1).unwrap_or(0)
-                        % Theme::ALL.len()]
-                    .clone()
+                    Theme::ALL[current.map(|current| current + 1).unwrap_or(0) % Theme::ALL.len()]
+                        .clone()
                 } else {
                     let current = current.unwrap_or(0);
 
@@ -97,42 +95,32 @@ impl Styling {
                 ("Danger", button::danger),
             ];
 
-            let styled_button =
-                |label| button(text(label).width(Fill).center()).padding(10);
+            let styled_button = |label| button(text(label).width(Fill).center()).padding(10);
 
             column![
-                row(styles.into_iter().map(|(name, style)| styled_button(
-                    name
-                )
-                .on_press(Message::ButtonPressed)
-                .style(style)
-                .into()))
+                row(styles.into_iter().map(|(name, style)| styled_button(name)
+                    .on_press(Message::ButtonPressed)
+                    .style(style)
+                    .into()))
                 .spacing(10)
                 .align_y(Center),
-                row(styles.into_iter().map(|(name, style)| styled_button(
-                    name
-                )
-                .style(style)
-                .into()))
+                row(styles
+                    .into_iter()
+                    .map(|(name, style)| styled_button(name).style(style).into()))
                 .spacing(10)
                 .align_y(Center),
             ]
             .spacing(10)
         };
 
-        let slider =
-            || slider(0.0..=100.0, self.slider_value, Message::SliderChanged);
+        let slider = || slider(0.0..=100.0, self.slider_value, Message::SliderChanged);
 
         let progress_bar = || progress_bar(0.0..=100.0, self.slider_value);
 
-        let scroll_me = scrollable(column![
-            "Scroll me!",
-            space().height(800),
-            "You did it!"
-        ])
-        .width(Fill)
-        .height(Fill)
-        .auto_scroll(true);
+        let scroll_me = scrollable(column!["Scroll me!", space().height(800), "You did it!"])
+            .width(Fill)
+            .height(Fill)
+            .auto_scroll(true);
 
         let check = checkbox(self.checkbox_value)
             .label("Check me!")
@@ -145,21 +133,13 @@ impl Styling {
             .on_toggle(Message::TogglerToggled)
             .spacing(10);
 
-        let disabled_toggle =
-            toggler(self.toggler_value).label("Disabled").spacing(10);
+        let disabled_toggle = toggler(self.toggler_value).label("Disabled").spacing(10);
 
         let card = {
-            container(
-                column![
-                    text("Card Example").size(24),
-                    slider(),
-                    progress_bar(),
-                ]
-                .spacing(20),
-            )
-            .width(Fill)
-            .padding(20)
-            .style(container::bordered_box)
+            container(column![text("Card Example").size(24), slider(), progress_bar(),].spacing(20))
+                .width(Fill)
+                .padding(20)
+                .style(container::bordered_box)
         };
 
         let content = column![
@@ -172,8 +152,7 @@ impl Styling {
             row![
                 scroll_me,
                 rule::vertical(1),
-                column![check, check_disabled, toggle, disabled_toggle]
-                    .spacing(10)
+                column![check, check_disabled, toggle, disabled_toggle].spacing(10)
             ]
             .spacing(10)
             .height(Shrink)
@@ -201,12 +180,12 @@ impl Styling {
             };
 
             match modified_key {
-                keyboard::key::Named::ArrowUp
-                | keyboard::key::Named::ArrowLeft => {
+                keyboard::key::Named::ArrowUp | keyboard::key::Named::ArrowLeft => {
                     Some(Message::PreviousTheme)
                 }
-                keyboard::key::Named::ArrowDown
-                | keyboard::key::Named::ArrowRight => Some(Message::NextTheme),
+                keyboard::key::Named::ArrowDown | keyboard::key::Named::ArrowRight => {
+                    Some(Message::NextTheme)
+                }
                 keyboard::key::Named::Space => Some(Message::ClearTheme),
                 _ => None,
             }
@@ -241,10 +220,7 @@ mod tests {
                 assert!(
                     snapshot.matches_hash(format!(
                         "snapshots/{theme}",
-                        theme = theme
-                            .to_string()
-                            .to_ascii_lowercase()
-                            .replace(" ", "_")
+                        theme = theme.to_string().to_ascii_lowercase().replace(" ", "_")
                     ))?,
                     "snapshots for {theme} should match!"
                 );

--- a/examples/svg/src/main.rs
+++ b/examples/svg/src/main.rs
@@ -25,17 +25,16 @@ impl Tiger {
     }
 
     fn view(&self) -> Element<'_, Message> {
-        let svg =
-            svg(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/tiger.svg"))
-                .width(Fill)
-                .height(Fill)
-                .style(|_theme, _status| svg::Style {
-                    color: if self.apply_color_filter {
-                        Some(color!(0x0000ff))
-                    } else {
-                        None
-                    },
-                });
+        let svg = svg(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/tiger.svg"))
+            .width(Fill)
+            .height(Fill)
+            .style(|_theme, _status| svg::Style {
+                color: if self.apply_color_filter {
+                    Some(color!(0x0000ff))
+                } else {
+                    None
+                },
+            });
 
         let apply_color_filter = checkbox(self.apply_color_filter)
             .label("Apply a color filter")

--- a/examples/table/src/main.rs
+++ b/examples/table/src/main.rs
@@ -1,8 +1,7 @@
 use iced::font;
 use iced::time::{Duration, hours, minutes};
 use iced::widget::{
-    center_x, center_y, column, container, row, scrollable, slider, table,
-    text, tooltip,
+    center_x, center_y, column, container, row, scrollable, slider, table, text, tooltip,
 };
 use iced::{Center, Element, Fill, Font, Right, Theme};
 
@@ -64,13 +63,11 @@ impl Table {
                 .align_y(Center),
                 table::column(bold("Price"), |event: &Event| {
                     if event.price > 0.0 {
-                        text!("${:.2}", event.price).style(
-                            if event.price > 100.0 {
-                                text::warning
-                            } else {
-                                text::default
-                            },
-                        )
+                        text!("${:.2}", event.price).style(if event.price > 100.0 {
+                            text::warning
+                        } else {
+                            text::default
+                        })
                     } else {
                         text("Free").style(text::success).width(Fill).center()
                     }
@@ -121,12 +118,7 @@ impl Table {
                 };
 
             column![
-                labeled_slider(
-                    "Padding",
-                    0.0..=30.0,
-                    self.padding,
-                    Message::PaddingChanged
-                ),
+                labeled_slider("Padding", 0.0..=30.0, self.padding, Message::PaddingChanged),
                 labeled_slider(
                     "Separator",
                     0.0..=5.0,
@@ -205,8 +197,7 @@ impl Event {
                 rating: 4.7,
             },
             Event {
-                name: "Try to order at a secret ramen place with no sign"
-                    .to_owned(),
+                name: "Try to order at a secret ramen place with no sign".to_owned(),
                 duration: minutes(50),
                 price: 14.0,
                 rating: 4.6,

--- a/examples/the_matrix/src/main.rs
+++ b/examples/the_matrix/src/main.rs
@@ -1,9 +1,7 @@
 use iced::mouse;
 use iced::time::{self, milliseconds};
 use iced::widget::canvas;
-use iced::{
-    Color, Element, Fill, Font, Point, Rectangle, Renderer, Subscription, Theme,
-};
+use iced::{Color, Element, Fill, Font, Point, Rectangle, Renderer, Subscription, Theme};
 
 use std::cell::RefCell;
 
@@ -67,10 +65,8 @@ impl<Message> canvas::Program<Message> for TheMatrix {
             caches.resize_with(30, || canvas::Cache::with_group(group));
         }
 
-        vec![caches[self.tick % caches.len()].draw(
-            renderer,
-            bounds.size(),
-            |frame| {
+        vec![
+            caches[self.tick % caches.len()].draw(renderer, bounds.size(), |frame| {
                 frame.fill_rectangle(Point::ORIGIN, frame.size(), Color::BLACK);
 
                 let mut rng = rand::thread_rng();
@@ -79,16 +75,13 @@ impl<Message> canvas::Program<Message> for TheMatrix {
 
                 for row in 0..rows {
                     for column in 0..columns {
-                        let position = Point::new(
-                            column as f32 * CELL_SIZE,
-                            row as f32 * CELL_SIZE,
-                        );
+                        let position =
+                            Point::new(column as f32 * CELL_SIZE, row as f32 * CELL_SIZE);
 
                         let alphas = [0.05, 0.1, 0.2, 0.5];
                         let weights = [10, 4, 2, 1];
-                        let distribution =
-                            rand::distributions::WeightedIndex::new(weights)
-                                .expect("Create distribution");
+                        let distribution = rand::distributions::WeightedIndex::new(weights)
+                            .expect("Create distribution");
 
                         frame.fill_text(canvas::Text {
                             content: rng.gen_range('!'..'z').to_string(),
@@ -104,7 +97,7 @@ impl<Message> canvas::Program<Message> for TheMatrix {
                         });
                     }
                 }
-            },
-        )]
+            }),
+        ]
     }
 }

--- a/examples/toast/src/main.rs
+++ b/examples/toast/src/main.rs
@@ -1,9 +1,7 @@
 use iced::event::{self, Event};
 use iced::keyboard;
 use iced::keyboard::key;
-use iced::widget::{
-    button, center, column, operation, pick_list, row, slider, text, text_input,
-};
+use iced::widget::{button, center, column, operation, pick_list, row, slider, text, text_input};
 use iced::{Center, Element, Fill, Subscription, Task};
 
 use toast::{Status, Toast};
@@ -52,9 +50,7 @@ impl App {
     fn update(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::Add => {
-                if !self.editing.title.is_empty()
-                    && !self.editing.body.is_empty()
-                {
+                if !self.editing.title.is_empty() && !self.editing.body.is_empty() {
                     self.toasts.push(std::mem::take(&mut self.editing));
                 }
                 Task::none()
@@ -132,12 +128,7 @@ impl App {
                     "Timeout",
                     row![
                         text!("{:0>2} sec", self.timeout_secs),
-                        slider(
-                            1.0..=30.0,
-                            self.timeout_secs as f64,
-                            Message::Timeout
-                        )
-                        .step(1.0)
+                        slider(1.0..=30.0, self.timeout_secs as f64, Message::Timeout).step(1.0)
                     ]
                     .spacing(5)
                     .into()
@@ -166,17 +157,15 @@ mod toast {
     use iced::advanced::layout::{self, Layout};
     use iced::advanced::overlay;
     use iced::advanced::renderer;
-    use iced::advanced::widget::{
-        self, Operation, OperationOutputWrapper, Tree,
-    };
+    use iced::advanced::widget::{self, Operation, OperationOutputWrapper, Tree};
     use iced::advanced::{Clipboard, Shell, Widget};
     use iced::mouse;
     use iced::time::{self, Duration, Instant};
     use iced::widget::{button, column, container, row, rule, space, text};
     use iced::window;
     use iced::{
-        Alignment, Center, Element, Event, Fill, Length, Point, Rectangle,
-        Renderer, Size, Theme, Vector,
+        Alignment, Center, Element, Event, Fill, Length, Point, Rectangle, Renderer, Size, Theme,
+        Vector,
     };
 
     pub const DEFAULT_TIMEOUT: u64 = 5;
@@ -246,9 +235,7 @@ mod toast {
                             row![
                                 text(toast.title.as_str()),
                                 space::horizontal(),
-                                button("X")
-                                    .on_press((on_close)(index))
-                                    .padding(3),
+                                button("X").on_press((on_close)(index)).padding(3),
                             ]
                             .align_y(Center)
                         )
@@ -299,11 +286,9 @@ mod toast {
             renderer: &Renderer,
             limits: &layout::Limits,
         ) -> layout::Node {
-            self.content.as_widget_mut().layout(
-                &mut tree.children[0],
-                renderer,
-                limits,
-            )
+            self.content
+                .as_widget_mut()
+                .layout(&mut tree.children[0], renderer, limits)
         }
 
         fn tag(&self) -> widget::tree::Tag {
@@ -334,10 +319,7 @@ mod toast {
                     instants.truncate(new);
                 }
                 (old, new) if old < new => {
-                    instants.extend(std::iter::repeat_n(
-                        Some(Instant::now()),
-                        new - old,
-                    ));
+                    instants.extend(std::iter::repeat_n(Some(Instant::now()), new - old));
                 }
                 _ => {}
             }
@@ -459,11 +441,9 @@ mod toast {
                     timeout_secs: self.timeout_secs,
                 }))
             });
-            let overlays =
-                content.into_iter().chain(toasts).collect::<Vec<_>>();
+            let overlays = content.into_iter().chain(toasts).collect::<Vec<_>>();
 
-            (!overlays.is_empty())
-                .then(|| overlay::Group::with_children(overlays).overlay())
+            (!overlays.is_empty()).then(|| overlay::Group::with_children(overlays).overlay())
         }
     }
 
@@ -477,14 +457,8 @@ mod toast {
         timeout_secs: u64,
     }
 
-    impl<Message> overlay::Overlay<Message, Theme, Renderer>
-        for Overlay<'_, '_, Message>
-    {
-        fn layout(
-            &mut self,
-            renderer: &Renderer,
-            bounds: Size,
-        ) -> layout::Node {
+    impl<Message> overlay::Overlay<Message, Theme, Renderer> for Overlay<'_, '_, Message> {
+        fn layout(&mut self, renderer: &Renderer, bounds: Size) -> layout::Node {
             let limits = layout::Limits::new(Size::ZERO, bounds);
 
             layout::flex::resolve(
@@ -512,11 +486,13 @@ mod toast {
             shell: &mut Shell<'_, Message>,
         ) {
             if let Event::Window(window::Event::RedrawRequested(now)) = &event {
-                self.instants.iter_mut().enumerate().for_each(
-                    |(index, maybe_instant)| {
+                self.instants
+                    .iter_mut()
+                    .enumerate()
+                    .for_each(|(index, maybe_instant)| {
                         if let Some(instant) = maybe_instant.as_mut() {
-                            let remaining = time::seconds(self.timeout_secs)
-                                .saturating_sub(instant.elapsed());
+                            let remaining =
+                                time::seconds(self.timeout_secs).saturating_sub(instant.elapsed());
 
                             if remaining == Duration::ZERO {
                                 maybe_instant.take();
@@ -525,8 +501,7 @@ mod toast {
                                 shell.request_redraw_at(*now + remaining);
                             }
                         }
-                    },
-                );
+                    });
             }
 
             let viewport = layout.bounds();
@@ -576,9 +551,9 @@ mod toast {
                 .zip(self.trees.iter())
                 .zip(layout.children())
             {
-                child.as_widget().draw(
-                    tree, renderer, theme, style, layout, cursor, &viewport,
-                );
+                child
+                    .as_widget()
+                    .draw(tree, renderer, theme, style, layout, cursor, &viewport);
             }
         }
 
@@ -615,13 +590,7 @@ mod toast {
                 .map(|((child, state), layout)| {
                     child
                         .as_widget()
-                        .mouse_interaction(
-                            state,
-                            layout,
-                            cursor,
-                            &self.viewport,
-                            renderer,
-                        )
+                        .mouse_interaction(state, layout, cursor, &self.viewport, renderer)
                         .max(if cursor.is_over(layout.bounds()) {
                             mouse::Interaction::Idle
                         } else {

--- a/examples/todos/src/main.rs
+++ b/examples/todos/src/main.rs
@@ -1,12 +1,12 @@
 use iced::keyboard;
 use iced::widget::{
-    self, Text, button, center, center_x, checkbox, column, keyed_column,
-    operation, row, scrollable, text, text_input,
+    self, Text, button, center, center_x, checkbox, column, keyed_column, operation, row,
+    scrollable, text, text_input,
 };
 use iced::window;
 use iced::{
-    Center, Element, Fill, Font, Function, Preset, Program, Subscription,
-    Task as Command, Theme, application::Application,
+    Center, Element, Fill, Font, Function, Preset, Program, Subscription, Task as Command, Theme,
+    application::Application,
 };
 
 use serde::{Deserialize, Serialize};
@@ -19,8 +19,7 @@ pub fn main() -> iced::Result {
     application().run()
 }
 
-fn application() -> Application<impl Program<Message = Message, Theme = Theme>>
-{
+fn application() -> Application<impl Program<Message = Message, Theme = Theme>> {
     iced::application(Todos::new, Todos::update, Todos::view)
         .subscription(Todos::subscription)
         .title(Todos::title)
@@ -106,9 +105,7 @@ impl Todos {
                     }
                     Message::CreateTask => {
                         if !state.input_value.is_empty() {
-                            state
-                                .tasks
-                                .push(Task::new(state.input_value.clone()));
+                            state.tasks.push(Task::new(state.input_value.clone()));
                             state.input_value.clear();
                         }
 
@@ -126,8 +123,7 @@ impl Todos {
                     }
                     Message::TaskMessage(i, task_message) => {
                         if let Some(task) = state.tasks.get_mut(i) {
-                            let should_focus =
-                                matches!(task_message, TaskMessage::Edit);
+                            let should_focus = matches!(task_message, TaskMessage::Edit);
 
                             task.update(task_message);
 
@@ -157,8 +153,9 @@ impl Todos {
                             operation::focus_next()
                         }
                     }
-                    Message::ToggleFullscreen(mode) => window::latest()
-                        .and_then(move |window| window::set_mode(window, mode)),
+                    Message::ToggleFullscreen(mode) => {
+                        window::latest().and_then(move |window| window::set_mode(window, mode))
+                    }
                     Message::Loaded(_) => Command::none(),
                 };
 
@@ -212,8 +209,7 @@ impl Todos {
                     .align_x(Center);
 
                 let controls = view_controls(tasks, *filter);
-                let filtered_tasks =
-                    tasks.iter().filter(|task| filter.matches(task));
+                let filtered_tasks = tasks.iter().filter(|task| filter.matches(task));
 
                 let tasks: Element<_> = if filtered_tasks.count() > 0 {
                     keyed_column(
@@ -222,11 +218,7 @@ impl Todos {
                             .enumerate()
                             .filter(|(_, task)| filter.matches(task))
                             .map(|(i, task)| {
-                                (
-                                    task.id,
-                                    task.view(i)
-                                        .map(Message::TaskMessage.with(i)),
-                                )
+                                (task.id, task.view(i).map(Message::TaskMessage.with(i)))
                             }),
                     )
                     .spacing(10)
@@ -235,9 +227,7 @@ impl Todos {
                     empty_message(match filter {
                         Filter::All => "You have not created a task yet...",
                         Filter::Active => "All your tasks are done! :D",
-                        Filter::Completed => {
-                            "You have not completed a task yet..."
-                        }
+                        Filter::Completed => "You have not completed a task yet...",
                     })
                 };
 
@@ -358,23 +348,18 @@ impl Task {
                 .into()
             }
             TaskState::Editing => {
-                let text_input =
-                    text_input("Describe your task...", &self.description)
-                        .id(Self::text_input_id(i))
-                        .on_input(TaskMessage::DescriptionEdited)
-                        .on_submit(TaskMessage::FinishEdition)
-                        .padding(10);
+                let text_input = text_input("Describe your task...", &self.description)
+                    .id(Self::text_input_id(i))
+                    .on_input(TaskMessage::DescriptionEdited)
+                    .on_submit(TaskMessage::FinishEdition)
+                    .padding(10);
 
                 row![
                     text_input,
-                    button(
-                        row![delete_icon(), "Delete"]
-                            .spacing(10)
-                            .align_y(Center)
-                    )
-                    .on_press(TaskMessage::Delete)
-                    .padding(10)
-                    .style(button::danger)
+                    button(row![delete_icon(), "Delete"].spacing(10).align_y(Center))
+                        .on_press(TaskMessage::Delete)
+                        .padding(10)
+                        .style(button::danger)
                 ]
                 .spacing(20)
                 .align_y(Center)
@@ -384,10 +369,7 @@ impl Task {
     }
 }
 
-fn view_controls(
-    tasks: &[Task],
-    current_filter: Filter,
-) -> Element<'_, Message> {
+fn view_controls(tasks: &[Task], current_filter: Filter) -> Element<'_, Message> {
     let tasks_left = tasks.iter().filter(|task| !task.completed).count();
 
     let filter_button = |label, filter, current_filter| {
@@ -420,9 +402,7 @@ fn view_controls(
     .into()
 }
 
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum Filter {
     #[default]
     All,
@@ -503,13 +483,12 @@ enum SaveError {
 #[cfg(not(target_arch = "wasm32"))]
 impl SavedState {
     fn path() -> std::path::PathBuf {
-        let mut path = if let Some(project_dirs) =
-            directories::ProjectDirs::from("rs", "Iced", "Todos")
-        {
-            project_dirs.data_dir().into()
-        } else {
-            std::env::current_dir().unwrap_or_default()
-        };
+        let mut path =
+            if let Some(project_dirs) = directories::ProjectDirs::from("rs", "Iced", "Todos") {
+                project_dirs.data_dir().into()
+            } else {
+                std::env::current_dir().unwrap_or_default()
+            };
 
         path.push("todos.json");
 
@@ -527,8 +506,7 @@ impl SavedState {
     async fn save(self) -> Result<(), SaveError> {
         use iced::time::milliseconds;
 
-        let json = serde_json::to_string_pretty(&self)
-            .map_err(|_| SaveError::Format)?;
+        let json = serde_json::to_string_pretty(&self).map_err(|_| SaveError::Format)?;
 
         let path = Self::path();
 
@@ -573,15 +551,13 @@ impl SavedState {
     async fn save(self) -> Result<(), SaveError> {
         let storage = Self::storage().ok_or(SaveError::Write)?;
 
-        let json = serde_json::to_string_pretty(&self)
-            .map_err(|_| SaveError::Format)?;
+        let json = serde_json::to_string_pretty(&self).map_err(|_| SaveError::Format)?;
 
         storage
             .set_item("state", &json)
             .map_err(|_| SaveError::Write)?;
 
-        let _ =
-            wasmtimer::tokio::sleep(std::time::Duration::from_secs(2)).await;
+        let _ = wasmtimer::tokio::sleep(std::time::Duration::from_secs(2)).await;
 
         Ok(())
     }

--- a/examples/tooltip/src/main.rs
+++ b/examples/tooltip/src/main.rs
@@ -42,8 +42,7 @@ impl Tooltip {
 
     fn view(&self) -> Element<'_, Message> {
         let tooltip = tooltip(
-            button("Press to change position")
-                .on_press(Message::ChangePosition),
+            button("Press to change position").on_press(Message::ChangePosition),
             position_to_text(self.position),
             self.position,
         )

--- a/examples/tour/src/main.rs
+++ b/examples/tour/src/main.rs
@@ -1,7 +1,7 @@
 use iced::widget::{Button, Column, Container, Slider};
 use iced::widget::{
-    button, center_x, center_y, checkbox, column, image, radio, rich_text, row,
-    scrollable, slider, space, span, text, text_input, toggler,
+    button, center_x, center_y, checkbox, column, image, radio, rich_text, row, scrollable, slider,
+    space, span, text, text_input, toggler,
 };
 use iced::{Center, Color, Element, Fill, Font, Pixels, color};
 
@@ -147,9 +147,8 @@ impl Tour {
                     .style(button::secondary)
             }),
             space::horizontal(),
-            self.can_continue().then(|| {
-                padded_button("Next").on_press(Message::NextPressed)
-            })
+            self.can_continue()
+                .then(|| { padded_button("Next").on_press(Message::NextPressed) })
         ];
 
         let screen = match self.screen {
@@ -166,8 +165,7 @@ impl Tour {
             Screen::End => self.end(),
         };
 
-        let content: Element<_> =
-            column![screen, controls].max_width(540).spacing(20).into();
+        let content: Element<_> = column![screen, controls].max_width(540).spacing(20).into();
 
         let scrollable = scrollable(center_x(if self.debug {
             content.explain(Color::BLACK)
@@ -264,9 +262,7 @@ impl Tour {
         );
 
         let layout_section: Element<_> = match self.layout {
-            Layout::Row => {
-                row![row_radio, column_radio].spacing(self.spacing).into()
-            }
+            Layout::Row => row![row_radio, column_radio].spacing(self.spacing).into(),
             Layout::Column => column![row_radio, column_radio]
                 .spacing(self.spacing)
                 .into(),
@@ -337,12 +333,7 @@ impl Tour {
                     .iter()
                     .copied()
                     .map(|language| {
-                        radio(
-                            language,
-                            language,
-                            self.language,
-                            Message::LanguageSelected,
-                        )
+                        radio(language, language, self.language, Message::LanguageSelected)
                     })
                     .map(Element::from)
             )
@@ -400,10 +391,7 @@ impl Tour {
                 "Iced supports scrollable content. Try it out! Find the \
                  button further below.",
             )
-            .push(
-                text("Tip: You can use the scrollbar to scroll down faster!")
-                    .size(16),
-            )
+            .push(text("Tip: You can use the scrollbar to scroll down faster!").size(16))
             .push(space().height(4096))
             .push(
                 text("You are halfway there!")
@@ -551,10 +539,7 @@ impl Screen {
     }
 }
 
-fn ferris<'a>(
-    width: u32,
-    filter_method: image::FilterMethod,
-) -> Container<'a, Message> {
+fn ferris<'a>(width: u32, filter_method: image::FilterMethod) -> Container<'a, Message> {
     center_x(
         // This should go away once we unify resource loading on native
         // platforms

--- a/examples/websocket/src/echo.rs
+++ b/examples/websocket/src/echo.rs
@@ -17,8 +17,7 @@ pub fn connect() -> impl Sipper<Never, Event> {
             const ECHO_SERVER: &str = "ws://127.0.0.1:3030";
 
             let (mut websocket, mut input) =
-                match async_tungstenite::tokio::connect_async(ECHO_SERVER).await
-                {
+                match async_tungstenite::tokio::connect_async(ECHO_SERVER).await {
                     Ok((websocket, _)) => {
                         let (sender, receiver) = mpsc::channel(100);
 
@@ -27,8 +26,7 @@ pub fn connect() -> impl Sipper<Never, Event> {
                         (websocket.fuse(), receiver)
                     }
                     Err(_) => {
-                        tokio::time::sleep(tokio::time::Duration::from_secs(1))
-                            .await;
+                        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
                         continue;
                     }

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -1,8 +1,6 @@
 mod echo;
 
-use iced::widget::{
-    button, center, column, operation, row, scrollable, text, text_input,
-};
+use iced::widget::{button, center, column, operation, row, scrollable, text, text_input};
 use iced::{Center, Element, Fill, Subscription, Task, color};
 
 pub fn main() -> iced::Result {
@@ -87,20 +85,13 @@ impl WebSocket {
 
     fn view(&self) -> Element<'_, Message> {
         let message_log: Element<_> = if self.messages.is_empty() {
-            center(
-                text("Your messages will appear here...")
-                    .color(color!(0x888888)),
-            )
-            .into()
+            center(text("Your messages will appear here...").color(color!(0x888888))).into()
         } else {
-            scrollable(
-                column(self.messages.iter().map(text).map(Element::from))
-                    .spacing(10),
-            )
-            .id(MESSAGE_LOG)
-            .height(Fill)
-            .spacing(10)
-            .into()
+            scrollable(column(self.messages.iter().map(text).map(Element::from)).spacing(10))
+                .id(MESSAGE_LOG)
+                .height(Fill)
+                .spacing(10)
+                .into()
         };
 
         let new_message_input = {
@@ -108,8 +99,7 @@ impl WebSocket {
                 .on_input(Message::NewMessageChanged)
                 .padding(10);
 
-            let mut button = button(text("Send").height(40).align_y(Center))
-                .padding([0, 20]);
+            let mut button = button(text("Send").height(40).align_y(Center)).padding([0, 20]);
 
             if matches!(self.state, State::Connected(_))
                 && let Some(message) = echo::Message::new(&self.new_message)

--- a/futures/src/backend/default.rs
+++ b/futures/src/backend/default.rs
@@ -15,17 +15,10 @@ mod platform {
     #[cfg(all(feature = "smol", not(feature = "tokio"),))]
     pub use crate::backend::native::smol::*;
 
-    #[cfg(all(
-        feature = "thread-pool",
-        not(any(feature = "tokio", feature = "smol"))
-    ))]
+    #[cfg(all(feature = "thread-pool", not(any(feature = "tokio", feature = "smol"))))]
     pub use crate::backend::native::thread_pool::*;
 
-    #[cfg(not(any(
-        feature = "tokio",
-        feature = "smol",
-        feature = "thread-pool"
-    )))]
+    #[cfg(not(any(feature = "tokio", feature = "smol", feature = "thread-pool")))]
     pub use crate::backend::null::*;
 }
 

--- a/futures/src/backend/native/smol.rs
+++ b/futures/src/backend/native/smol.rs
@@ -26,9 +26,7 @@ pub mod time {
     ///
     /// The first message is produced after a `duration`, and then continues to
     /// produce more messages every `duration` after that.
-    pub fn every(
-        duration: std::time::Duration,
-    ) -> Subscription<std::time::Instant> {
+    pub fn every(duration: std::time::Duration) -> Subscription<std::time::Instant> {
         subscription::from_recipe(Every(duration))
     }
 

--- a/futures/src/backend/native/tokio.rs
+++ b/futures/src/backend/native/tokio.rs
@@ -42,9 +42,7 @@ pub mod time {
             let start = tokio::time::Instant::now() + *duration;
 
             let mut interval = tokio::time::interval_at(start, *duration);
-            interval.set_missed_tick_behavior(
-                tokio::time::MissedTickBehavior::Skip,
-            );
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
             let stream = {
                 futures::stream::unfold(interval, |mut interval| async move {

--- a/futures/src/backend/wasm/wasm_bindgen.rs
+++ b/futures/src/backend/wasm/wasm_bindgen.rs
@@ -29,9 +29,7 @@ pub mod time {
             use futures::stream::StreamExt;
 
             let mut interval = wasmtimer::tokio::interval(*duration);
-            interval.set_missed_tick_behavior(
-                wasmtimer::tokio::MissedTickBehavior::Skip,
-            );
+            interval.set_missed_tick_behavior(wasmtimer::tokio::MissedTickBehavior::Skip);
 
             let stream = {
                 futures::stream::unfold(interval, |mut interval| async move {

--- a/futures/src/runtime.rs
+++ b/futures/src/runtime.rs
@@ -22,11 +22,7 @@ pub struct Runtime<Executor, Sender, Message> {
 impl<Executor, Sender, Message> Runtime<Executor, Sender, Message>
 where
     Executor: self::Executor,
-    Sender: Sink<Message, Error = mpsc::SendError>
-        + Unpin
-        + MaybeSend
-        + Clone
-        + 'static,
+    Sender: Sink<Message, Error = mpsc::SendError> + Unpin + MaybeSend + Clone + 'static,
     Message: MaybeSend + 'static,
 {
     /// Creates a new empty [`Runtime`].
@@ -66,15 +62,12 @@ where
         use futures::{FutureExt, StreamExt};
 
         let sender = self.sender.clone();
-        let future =
-            stream.map(Ok).forward(sender).map(|result| match result {
-                Ok(()) => {}
-                Err(error) => {
-                    log::warn!(
-                        "Stream could not run until completion: {error}"
-                    );
-                }
-            });
+        let future = stream.map(Ok).forward(sender).map(|result| match result {
+            Ok(()) => {}
+            Err(error) => {
+                log::warn!("Stream could not run until completion: {error}");
+            }
+        });
 
         self.executor.spawn(future);
     }
@@ -97,9 +90,7 @@ where
     /// [`Subscription`]: crate::Subscription
     pub fn track(
         &mut self,
-        recipes: impl IntoIterator<
-            Item = Box<dyn subscription::Recipe<Output = Message>>,
-        >,
+        recipes: impl IntoIterator<Item = Box<dyn subscription::Recipe<Output = Message>>>,
     ) {
         let Runtime {
             executor,
@@ -108,9 +99,7 @@ where
             ..
         } = self;
 
-        let futures = executor.enter(|| {
-            subscriptions.update(recipes.into_iter(), sender.clone())
-        });
+        let futures = executor.enter(|| subscriptions.update(recipes.into_iter(), sender.clone()));
 
         for future in futures {
             executor.spawn(future);

--- a/futures/src/stream.rs
+++ b/futures/src/stream.rs
@@ -8,10 +8,7 @@ use futures::stream::{self, Stream, StreamExt};
 /// This is a more ergonomic [`stream::unfold`], which allows you to go
 /// from the "world of futures" to the "world of streams" by simply looping
 /// and publishing to an async channel from inside a [`Future`].
-pub fn channel<T>(
-    size: usize,
-    f: impl AsyncFnOnce(mpsc::Sender<T>),
-) -> impl Stream<Item = T> {
+pub fn channel<T>(size: usize, f: impl AsyncFnOnce(mpsc::Sender<T>)) -> impl Stream<Item = T> {
     let (sender, receiver) = mpsc::channel(size);
 
     let runner = stream::once(f(sender)).filter_map(|_| async { None });

--- a/futures/src/subscription.rs
+++ b/futures/src/subscription.rs
@@ -209,9 +209,7 @@ impl<T> Subscription<T> {
 
     /// Batches all the provided subscriptions and returns the resulting
     /// [`Subscription`].
-    pub fn batch(
-        subscriptions: impl IntoIterator<Item = Subscription<T>>,
-    ) -> Self {
+    pub fn batch(subscriptions: impl IntoIterator<Item = Subscription<T>>) -> Self {
         Self {
             recipes: subscriptions
                 .into_iter()
@@ -246,10 +244,7 @@ impl<T> Subscription<T> {
                 self.recipe.hash(state);
             }
 
-            fn stream(
-                self: Box<Self>,
-                input: EventStream,
-            ) -> BoxStream<Self::Output> {
+            fn stream(self: Box<Self>, input: EventStream) -> BoxStream<Self::Output> {
                 use futures::StreamExt;
 
                 let value = self.value;
@@ -310,10 +305,7 @@ impl<T> Subscription<T> {
                 self.recipe.hash(state);
             }
 
-            fn stream(
-                self: Box<Self>,
-                input: EventStream,
-            ) -> BoxStream<Self::Output> {
+            fn stream(self: Box<Self>, input: EventStream) -> BoxStream<Self::Output> {
                 use futures::StreamExt;
 
                 Box::pin(self.recipe.stream(input).map(self.mapper))
@@ -369,10 +361,7 @@ impl<T> Subscription<T> {
                 self.recipe.hash(state);
             }
 
-            fn stream(
-                self: Box<Self>,
-                input: EventStream,
-            ) -> BoxStream<Self::Output> {
+            fn stream(self: Box<Self>, input: EventStream) -> BoxStream<Self::Output> {
                 use futures::StreamExt;
                 use futures::future;
 
@@ -407,18 +396,14 @@ impl<T> Subscription<T> {
 }
 
 /// Creates a [`Subscription`] from a [`Recipe`] describing it.
-pub fn from_recipe<T>(
-    recipe: impl Recipe<Output = T> + 'static,
-) -> Subscription<T> {
+pub fn from_recipe<T>(recipe: impl Recipe<Output = T> + 'static) -> Subscription<T> {
     Subscription {
         recipes: vec![Box::new(recipe)],
     }
 }
 
 /// Returns the different recipes of the [`Subscription`].
-pub fn into_recipes<T>(
-    subscription: Subscription<T>,
-) -> Vec<Box<dyn Recipe<Output = T>>> {
+pub fn into_recipes<T>(subscription: Subscription<T>) -> Vec<Box<dyn Recipe<Output = T>>> {
     subscription.recipes
 }
 

--- a/futures/src/subscription/tracker.rs
+++ b/futures/src/subscription/tracker.rs
@@ -59,11 +59,7 @@ impl Tracker {
     ) -> Vec<BoxFuture<()>>
     where
         Message: 'static + MaybeSend,
-        Receiver: 'static
-            + Sink<Message, Error = mpsc::SendError>
-            + Unpin
-            + MaybeSend
-            + Clone,
+        Receiver: 'static + Sink<Message, Error = mpsc::SendError> + Unpin + MaybeSend + Clone,
     {
         use futures::stream::StreamExt;
 
@@ -87,16 +83,14 @@ impl Tracker {
             let (cancel, mut canceled) = futures::channel::oneshot::channel();
 
             // TODO: Use bus if/when it supports async
-            let (event_sender, event_receiver) =
-                futures::channel::mpsc::channel(100);
+            let (event_sender, event_receiver) = futures::channel::mpsc::channel(100);
 
             let mut receiver = receiver.clone();
             let mut stream = recipe.stream(event_receiver.boxed());
 
             let future = async move {
                 loop {
-                    let select =
-                        futures::future::select(&mut canceled, stream.next());
+                    let select = futures::future::select(&mut canceled, stream.next());
 
                     match select.await {
                         futures::future::Either::Left(_)
@@ -144,9 +138,7 @@ impl Tracker {
             .filter_map(|connection| connection.listener.as_mut())
             .for_each(|listener| {
                 if let Err(error) = listener.try_send(event.clone()) {
-                    log::warn!(
-                        "Error sending event to subscription: {error:?}"
-                    );
+                    log::warn!("Error sending event to subscription: {error:?}");
                 }
             });
     }

--- a/graphics/src/cache.rs
+++ b/graphics/src/cache.rs
@@ -62,8 +62,7 @@ impl<T> Cache<T> {
     pub fn clear(&self) {
         let mut state = self.state.borrow_mut();
 
-        let previous =
-            mem::replace(&mut *state, State::Empty { previous: None });
+        let previous = mem::replace(&mut *state, State::Empty { previous: None });
 
         let previous = match previous {
             State::Empty { previous } => previous,
@@ -181,10 +180,5 @@ impl Cached for () {
 
     fn load(_cache: &Self::Cache) -> Self {}
 
-    fn cache(
-        self,
-        _group: Group,
-        _previous: Option<Self::Cache>,
-    ) -> Self::Cache {
-    }
+    fn cache(self, _group: Group, _previous: Option<Self::Cache>) -> Self::Cache {}
 }

--- a/graphics/src/compositor.rs
+++ b/graphics/src/compositor.rs
@@ -55,12 +55,7 @@ pub trait Compositor: Sized {
     /// Configures a new [`Surface`] with the given dimensions.
     ///
     /// [`Surface`]: Self::Surface
-    fn configure_surface(
-        &mut self,
-        surface: &mut Self::Surface,
-        width: u32,
-        height: u32,
-    );
+    fn configure_surface(&mut self, surface: &mut Self::Surface, width: u32, height: u32);
 
     /// Returns [`Information`] used by this [`Compositor`].
     fn information(&self) -> Information;
@@ -102,15 +97,9 @@ pub trait Compositor: Sized {
 ///
 /// This is just a convenient super trait of the `raw-window-handle`
 /// traits.
-pub trait Window:
-    HasWindowHandle + HasDisplayHandle + MaybeSend + MaybeSync + 'static
-{
-}
+pub trait Window: HasWindowHandle + HasDisplayHandle + MaybeSend + MaybeSync + 'static {}
 
-impl<T> Window for T where
-    T: HasWindowHandle + HasDisplayHandle + MaybeSend + MaybeSync + 'static
-{
-}
+impl<T> Window for T where T: HasWindowHandle + HasDisplayHandle + MaybeSend + MaybeSync + 'static {}
 
 /// An owned display handle that can be used in a [`Compositor`].
 ///
@@ -133,9 +122,7 @@ pub enum SurfaceError {
     #[error("A timeout was encountered while trying to acquire the next frame")]
     Timeout,
     /// The underlying surface has changed, and therefore the surface must be updated.
-    #[error(
-        "The underlying surface has changed, and therefore the surface must be updated."
-    )]
+    #[error("The underlying surface has changed, and therefore the surface must be updated.")]
     Outdated,
     /// The swap chain has been lost and needs to be recreated.
     #[error("The surface has been lost and needs to be recreated")]
@@ -194,13 +181,7 @@ impl Compositor for () {
     ) -> Self::Surface {
     }
 
-    fn configure_surface(
-        &mut self,
-        _surface: &mut Self::Surface,
-        _width: u32,
-        _height: u32,
-    ) {
-    }
+    fn configure_surface(&mut self, _surface: &mut Self::Surface, _width: u32, _height: u32) {}
 
     fn load_font(&mut self, _font: Cow<'static, [u8]>) {}
 

--- a/graphics/src/geometry/cache.rs
+++ b/graphics/src/geometry/cache.rs
@@ -84,9 +84,7 @@ where
         let state = self.raw.state();
 
         let previous = match state.borrow().deref() {
-            cache::State::Empty { previous } => {
-                previous.as_ref().map(|data| data.geometry.clone())
-            }
+            cache::State::Empty { previous } => previous.as_ref().map(|data| data.geometry.clone()),
             cache::State::Filled { current } => {
                 if current.bounds == bounds {
                     return Cached::load(&current.geometry);

--- a/graphics/src/geometry/frame.rs
+++ b/graphics/src/geometry/frame.rs
@@ -57,12 +57,7 @@ where
 
     /// Draws an axis-aligned rectangle given its top-left corner coordinate and
     /// its `Size` on the [`Frame`] by filling it with the provided style.
-    pub fn fill_rectangle(
-        &mut self,
-        top_left: Point,
-        size: Size,
-        fill: impl Into<Fill>,
-    ) {
+    pub fn fill_rectangle(&mut self, top_left: Point, size: Size, fill: impl Into<Fill>) {
         self.raw.fill_rectangle(top_left, size, fill);
     }
 
@@ -138,11 +133,7 @@ where
     /// This method is useful to perform drawing operations that need to be
     /// clipped.
     #[inline]
-    pub fn with_clip<R>(
-        &mut self,
-        region: Rectangle,
-        f: impl FnOnce(&mut Self) -> R,
-    ) -> R {
+    pub fn with_clip<R>(&mut self, region: Rectangle, f: impl FnOnce(&mut Self) -> R) -> R {
         let mut frame = self.draft(region);
 
         let result = f(&mut frame);
@@ -218,26 +209,12 @@ pub trait Backend: Sized {
     fn paste(&mut self, frame: Self);
 
     fn stroke<'a>(&mut self, path: &Path, stroke: impl Into<Stroke<'a>>);
-    fn stroke_rectangle<'a>(
-        &mut self,
-        top_left: Point,
-        size: Size,
-        stroke: impl Into<Stroke<'a>>,
-    );
-    fn stroke_text<'a>(
-        &mut self,
-        text: impl Into<Text>,
-        stroke: impl Into<Stroke<'a>>,
-    );
+    fn stroke_rectangle<'a>(&mut self, top_left: Point, size: Size, stroke: impl Into<Stroke<'a>>);
+    fn stroke_text<'a>(&mut self, text: impl Into<Text>, stroke: impl Into<Stroke<'a>>);
 
     fn fill(&mut self, path: &Path, fill: impl Into<Fill>);
     fn fill_text(&mut self, text: impl Into<Text>);
-    fn fill_rectangle(
-        &mut self,
-        top_left: Point,
-        size: Size,
-        fill: impl Into<Fill>,
-    );
+    fn fill_rectangle(&mut self, top_left: Point, size: Size, fill: impl Into<Fill>);
 
     fn draw_image(&mut self, bounds: Rectangle, image: impl Into<Image>);
     fn draw_svg(&mut self, bounds: Rectangle, svg: impl Into<Svg>);
@@ -284,22 +261,11 @@ impl Backend for () {
         _stroke: impl Into<Stroke<'a>>,
     ) {
     }
-    fn stroke_text<'a>(
-        &mut self,
-        _text: impl Into<Text>,
-        _stroke: impl Into<Stroke<'a>>,
-    ) {
-    }
+    fn stroke_text<'a>(&mut self, _text: impl Into<Text>, _stroke: impl Into<Stroke<'a>>) {}
 
     fn fill(&mut self, _path: &Path, _fill: impl Into<Fill>) {}
     fn fill_text(&mut self, _text: impl Into<Text>) {}
-    fn fill_rectangle(
-        &mut self,
-        _top_left: Point,
-        _size: Size,
-        _fill: impl Into<Fill>,
-    ) {
-    }
+    fn fill_rectangle(&mut self, _top_left: Point, _size: Size, _fill: impl Into<Fill>) {}
 
     fn draw_image(&mut self, _bounds: Rectangle, _image: impl Into<Image>) {}
     fn draw_svg(&mut self, _bounds: Rectangle, _svg: impl Into<Svg>) {}

--- a/graphics/src/geometry/path.rs
+++ b/graphics/src/geometry/path.rs
@@ -50,11 +50,7 @@ impl Path {
 
     /// Creates a new [`Path`] representing a rounded rectangle given its top-left
     /// corner coordinate, its [`Size`] and [`border::Radius`].
-    pub fn rounded_rectangle(
-        top_left: Point,
-        size: Size,
-        radius: border::Radius,
-    ) -> Self {
+    pub fn rounded_rectangle(top_left: Point, size: Size, radius: border::Radius) -> Self {
         Self::new(|p| p.rounded_rectangle(top_left, size, radius))
     }
 

--- a/graphics/src/geometry/path/builder.rs
+++ b/graphics/src/geometry/path/builder.rs
@@ -65,9 +65,8 @@ impl Builder {
             return;
         }
 
-        let double_area = start.x * (mid.y - end.y)
-            + mid.x * (end.y - start.y)
-            + end.x * (start.y - mid.y);
+        let double_area =
+            start.x * (mid.y - end.y) + mid.x * (end.y - start.y) + end.x * (start.y - mid.y);
 
         if double_area == 0.0 {
             let _ = self.raw.line_to(mid);
@@ -108,9 +107,7 @@ impl Builder {
             radii: math::Vector::new(arc.radii.x, arc.radii.y),
             x_rotation: math::Angle::radians(arc.rotation.0),
             start_angle: math::Angle::radians(arc.start_angle.0),
-            sweep_angle: math::Angle::radians(
-                (arc.end_angle - arc.start_angle).0,
-            ),
+            sweep_angle: math::Angle::radians((arc.end_angle - arc.start_angle).0),
         };
 
         let _ = self.raw.move_to(arc.sample(0.0));
@@ -124,12 +121,7 @@ impl Builder {
     /// Adds a cubic Bézier curve to the [`Path`] given its two control points
     /// and its end point.
     #[inline]
-    pub fn bezier_curve_to(
-        &mut self,
-        control_a: Point,
-        control_b: Point,
-        to: Point,
-    ) {
+    pub fn bezier_curve_to(&mut self, control_a: Point, control_b: Point, to: Point) {
         let _ = self.raw.cubic_bezier_to(
             math::Point::new(control_a.x, control_a.y),
             math::Point::new(control_b.x, control_b.y),
@@ -164,12 +156,7 @@ impl Builder {
     /// Adds a rounded rectangle to the [`Path`] given its top-left
     /// corner coordinate its [`Size`] and [`border::Radius`].
     #[inline]
-    pub fn rounded_rectangle(
-        &mut self,
-        top_left: Point,
-        size: Size,
-        radius: border::Radius,
-    ) {
+    pub fn rounded_rectangle(&mut self, top_left: Point, size: Size, radius: border::Radius) {
         let min_size = (size.height / 2.0).min(size.width / 2.0);
         let [
             top_left_corner,

--- a/graphics/src/geometry/text.rs
+++ b/graphics/src/geometry/text.rs
@@ -79,9 +79,7 @@ impl Text {
         );
 
         let translation_x = match self.align_x {
-            Alignment::Left | Alignment::Default | Alignment::Justified => {
-                self.position.x
-            }
+            Alignment::Left | Alignment::Default | Alignment::Justified => self.position.x,
             Alignment::Center | Alignment::Right => {
                 let mut line_width = 0.0f32;
 
@@ -100,12 +98,8 @@ impl Text {
         let translation_y = {
             match self.align_y {
                 alignment::Vertical::Top => self.position.y,
-                alignment::Vertical::Center => {
-                    self.position.y - paragraph.min_height() / 2.0
-                }
-                alignment::Vertical::Bottom => {
-                    self.position.y - paragraph.min_height()
-                }
+                alignment::Vertical::Center => self.position.y - paragraph.min_height() / 2.0,
+                alignment::Vertical::Bottom => self.position.y - paragraph.min_height(),
             }
         };
 
@@ -120,38 +114,30 @@ impl Text {
                 let start_y = translation_y + glyph.y_offset + run.line_y;
                 let offset = Vector::new(start_x, start_y);
 
-                if let Some(commands) = swash_cache.get_outline_commands(
-                    font_system.raw(),
-                    physical_glyph.cache_key,
-                ) {
+                if let Some(commands) =
+                    swash_cache.get_outline_commands(font_system.raw(), physical_glyph.cache_key)
+                {
                     let glyph = Path::new(|path| {
                         use cosmic_text::Command;
 
                         for command in commands {
                             match command {
                                 Command::MoveTo(p) => {
-                                    path.move_to(
-                                        Point::new(p.x, -p.y) + offset,
-                                    );
+                                    path.move_to(Point::new(p.x, -p.y) + offset);
                                 }
                                 Command::LineTo(p) => {
-                                    path.line_to(
-                                        Point::new(p.x, -p.y) + offset,
-                                    );
+                                    path.line_to(Point::new(p.x, -p.y) + offset);
                                 }
                                 Command::CurveTo(control_a, control_b, to) => {
                                     path.bezier_curve_to(
-                                        Point::new(control_a.x, -control_a.y)
-                                            + offset,
-                                        Point::new(control_b.x, -control_b.y)
-                                            + offset,
+                                        Point::new(control_a.x, -control_a.y) + offset,
+                                        Point::new(control_b.x, -control_b.y) + offset,
                                         Point::new(to.x, -to.y) + offset,
                                     );
                                 }
                                 Command::QuadTo(control, to) => {
                                     path.quadratic_curve_to(
-                                        Point::new(control.x, -control.y)
-                                            + offset,
+                                        Point::new(control.x, -control.y) + offset,
                                         Point::new(to.x, -to.y) + offset,
                                     );
                                 }

--- a/graphics/src/gradient.rs
+++ b/graphics/src/gradient.rs
@@ -64,11 +64,10 @@ impl Linear {
     /// Any stop added after the 8th will be silently ignored.
     pub fn add_stop(mut self, offset: f32, color: Color) -> Self {
         if offset.is_finite() && (0.0..=1.0).contains(&offset) {
-            let (Ok(index) | Err(index)) =
-                self.stops.binary_search_by(|stop| match stop {
-                    None => Ordering::Greater,
-                    Some(stop) => stop.offset.total_cmp(&offset),
-                });
+            let (Ok(index) | Err(index)) = self.stops.binary_search_by(|stop| match stop {
+                None => Ordering::Greater,
+                Some(stop) => stop.offset.total_cmp(&offset),
+            });
 
             if index < 8 {
                 self.stops[index] = Some(ColorStop { offset, color });
@@ -83,10 +82,7 @@ impl Linear {
     /// Adds multiple [`ColorStop`]s to the gradient.
     ///
     /// Any stop added after the 8th will be silently ignored.
-    pub fn add_stops(
-        mut self,
-        stops: impl IntoIterator<Item = ColorStop>,
-    ) -> Self {
+    pub fn add_stops(mut self, stops: impl IntoIterator<Item = ColorStop>) -> Self {
         for stop in stops {
             self = self.add_stop(stop.offset, stop.color);
         }
@@ -100,17 +96,14 @@ impl Linear {
         let mut offsets = [f16::from(0u8); 8];
 
         for (index, stop) in self.stops.iter().enumerate() {
-            let [r, g, b, a] =
-                color::pack(stop.map_or(Color::default(), |s| s.color))
-                    .components();
+            let [r, g, b, a] = color::pack(stop.map_or(Color::default(), |s| s.color)).components();
 
             colors[index] = [
                 pack_f16s([f16::from_f32(r), f16::from_f32(g)]),
                 pack_f16s([f16::from_f32(b), f16::from_f32(a)]),
             ];
 
-            offsets[index] =
-                stop.map_or(f16::from_f32(2.0), |s| f16::from_f32(s.offset));
+            offsets[index] = stop.map_or(f16::from_f32(2.0), |s| f16::from_f32(s.offset));
         }
 
         let offsets = [
@@ -150,16 +143,14 @@ pub fn pack(gradient: &core::Gradient, bounds: Rectangle) -> Packed {
 
             for (index, stop) in linear.stops.iter().enumerate() {
                 let [r, g, b, a] =
-                    color::pack(stop.map_or(Color::default(), |s| s.color))
-                        .components();
+                    color::pack(stop.map_or(Color::default(), |s| s.color)).components();
 
                 colors[index] = [
                     pack_f16s([f16::from_f32(r), f16::from_f32(g)]),
                     pack_f16s([f16::from_f32(b), f16::from_f32(a)]),
                 ];
 
-                offsets[index] = stop
-                    .map_or(f16::from_f32(2.0), |s| f16::from_f32(s.offset));
+                offsets[index] = stop.map_or(f16::from_f32(2.0), |s| f16::from_f32(s.offset));
             }
 
             let offsets = [

--- a/graphics/src/image.rs
+++ b/graphics/src/image.rs
@@ -31,9 +31,7 @@ impl Image {
     /// Returns the bounds of the [`Image`].
     pub fn bounds(&self) -> Rectangle {
         match self {
-            Image::Raster { image, bounds, .. } => {
-                bounds.rotate(image.rotation)
-            }
+            Image::Raster { image, bounds, .. } => bounds.rotate(image.rotation),
             Image::Vector { svg, bounds, .. } => bounds.rotate(svg.rotation),
         }
     }
@@ -87,10 +85,7 @@ pub fn load(handle: &image::Handle) -> Result<Buffer, image::Error> {
                 .unwrap_or_else(Self::empty))
         }
 
-        fn perform(
-            self,
-            mut image: ::image::DynamicImage,
-        ) -> ::image::DynamicImage {
+        fn perform(self, mut image: ::image::DynamicImage) -> ::image::DynamicImage {
             use ::image::imageops;
 
             if self.contains(Operation::ROTATE_90) {
@@ -141,10 +136,9 @@ pub fn load(handle: &image::Handle) -> Result<Buffer, image::Error> {
         image::Handle::Bytes(_, bytes) => {
             let image = ::image::load_from_memory(bytes).map_err(to_error)?;
 
-            let operation =
-                Operation::from_exif(&mut std::io::Cursor::new(bytes))
-                    .ok()
-                    .unwrap_or_else(Operation::empty);
+            let operation = Operation::from_exif(&mut std::io::Cursor::new(bytes))
+                .ok()
+                .unwrap_or_else(Operation::empty);
 
             let rgba = operation.perform(image).into_rgba8();
 
@@ -162,9 +156,7 @@ pub fn load(handle: &image::Handle) -> Result<Buffer, image::Error> {
         Ok(image)
     } else {
         Err(to_error(::image::error::ImageError::Limits(
-            ::image::error::LimitError::from_kind(
-                ::image::error::LimitErrorKind::DimensionError,
-            ),
+            ::image::error::LimitError::from_kind(::image::error::LimitErrorKind::DimensionError),
         )))
     }
 }
@@ -174,9 +166,7 @@ fn to_error(error: ::image::ImageError) -> image::Error {
     use std::sync::Arc;
 
     match error {
-        ::image::ImageError::IoError(error) => {
-            image::Error::Inaccessible(Arc::new(error))
-        }
+        ::image::ImageError::IoError(error) => image::Error::Inaccessible(Arc::new(error)),
         error => image::Error::Invalid(Arc::new(error)),
     }
 }

--- a/graphics/src/mesh.rs
+++ b/graphics/src/mesh.rs
@@ -47,8 +47,9 @@ impl Mesh {
     /// Returns the [`Transformation`] of the [`Mesh`].
     pub fn transformation(&self) -> Transformation {
         match self {
-            Self::Solid { transformation, .. }
-            | Self::Gradient { transformation, .. } => *transformation,
+            Self::Solid { transformation, .. } | Self::Gradient { transformation, .. } => {
+                *transformation
+            }
         }
     }
 

--- a/graphics/src/settings.rs
+++ b/graphics/src/settings.rs
@@ -37,10 +37,8 @@ impl Default for Settings {
 impl From<core::Settings> for Settings {
     fn from(settings: core::Settings) -> Self {
         Self {
-            default_font: if cfg!(all(
-                target_arch = "wasm32",
-                feature = "fira-sans"
-            )) && settings.default_font == Font::default()
+            default_font: if cfg!(all(target_arch = "wasm32", feature = "fira-sans"))
+                && settings.default_font == Font::default()
             {
                 Font::with_name("Fira Sans")
             } else {

--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -124,8 +124,7 @@ impl Text {
 ///
 /// [Fira Sans]: https://mozilla.github.io/Fira/
 #[cfg(feature = "fira-sans")]
-pub const FIRA_SANS_REGULAR: &[u8] =
-    include_bytes!("../fonts/FiraSans-Regular.ttf").as_slice();
+pub const FIRA_SANS_REGULAR: &[u8] = include_bytes!("../fonts/FiraSans-Regular.ttf").as_slice();
 
 /// Returns the global [`FontSystem`].
 pub fn font_system() -> &'static RwLock<FontSystem> {
@@ -171,9 +170,12 @@ impl FontSystem {
             }
         }
 
-        let _ = self.raw.db_mut().load_font_source(
-            cosmic_text::fontdb::Source::Binary(Arc::new(bytes.into_owned())),
-        );
+        let _ = self
+            .raw
+            .db_mut()
+            .load_font_source(cosmic_text::fontdb::Source::Binary(Arc::new(
+                bytes.into_owned(),
+            )));
 
         self.version = Version(self.version.0 + 1);
     }
@@ -215,16 +217,16 @@ impl PartialEq for Raw {
 
 /// Measures the dimensions of the given [`cosmic_text::Buffer`].
 pub fn measure(buffer: &cosmic_text::Buffer) -> (Size, bool) {
-    let (width, height, has_rtl) = buffer.layout_runs().fold(
-        (0.0, 0.0, false),
-        |(width, height, has_rtl), run| {
-            (
-                run.line_w.max(width),
-                height + run.line_height,
-                has_rtl || run.rtl,
-            )
-        },
-    );
+    let (width, height, has_rtl) =
+        buffer
+            .layout_runs()
+            .fold((0.0, 0.0, false), |(width, height, has_rtl), run| {
+                (
+                    run.line_w.max(width),
+                    height + run.line_height,
+                    has_rtl || run.rtl,
+                )
+            });
 
     (Size::new(width, height), has_rtl)
 }
@@ -241,9 +243,10 @@ pub fn align(
 
     if let Some(align) = to_align(alignment) {
         let has_multiple_lines = buffer.lines.len() > 1
-            || buffer.lines.first().is_some_and(|line| {
-                line.layout_opt().is_some_and(|layout| layout.len() > 1)
-            });
+            || buffer
+                .lines
+                .first()
+                .is_some_and(|line| line.layout_opt().is_some_and(|layout| layout.len() > 1));
 
         if has_multiple_lines {
             for line in &mut buffer.lines {
@@ -339,10 +342,7 @@ pub fn to_shaping(shaping: Shaping, text: &str) -> cosmic_text::Shaping {
 
 #[inline]
 /// Converts some [`Shaping`] strategy to a [`cosmic_text::Shaping`] strategy.
-pub fn to_shaping_ascii(
-    shaping: Shaping,
-    is_ascii: bool,
-) -> cosmic_text::Shaping {
+pub fn to_shaping_ascii(shaping: Shaping, is_ascii: bool) -> cosmic_text::Shaping {
     match shaping {
         Shaping::Auto => {
             if is_ascii {
@@ -367,9 +367,7 @@ pub fn to_wrap(wrapping: Wrapping) -> cosmic_text::Wrap {
 }
 
 /// Converts some [`Ellipsize`] strategy to a [`cosmic_text::Ellipsize`] strategy.
-pub fn to_ellipsize(
-    ellipsize: crate::core::text::Ellipsize,
-) -> cosmic_text::Ellipsize {
+pub fn to_ellipsize(ellipsize: crate::core::text::Ellipsize) -> cosmic_text::Ellipsize {
     match ellipsize {
         crate::core::text::Ellipsize::None => cosmic_text::Ellipsize::None,
         crate::core::text::Ellipsize::Start(limit) => {

--- a/graphics/src/text/cache.rs
+++ b/graphics/src/text/cache.rs
@@ -40,10 +40,8 @@ impl Cache {
         }
 
         if let hash_map::Entry::Vacant(entry) = self.entries.entry(hash) {
-            let metrics = cosmic_text::Metrics::new(
-                key.size,
-                key.line_height.max(f32::MIN_POSITIVE),
-            );
+            let metrics =
+                cosmic_text::Metrics::new(key.size, key.line_height.max(f32::MIN_POSITIVE));
             let mut buffer = cosmic_text::Buffer::new(font_system, metrics);
 
             buffer.set_size(
@@ -73,10 +71,9 @@ impl Cache {
                 },
             ] {
                 if key.bounds != bounds {
-                    let _ = self.aliases.insert(
-                        Key { bounds, ..key }.hash(FxHasher::default()),
-                        hash,
-                    );
+                    let _ = self
+                        .aliases
+                        .insert(Key { bounds, ..key }.hash(FxHasher::default()), hash);
                 }
             }
         }

--- a/graphics/src/text/editor.rs
+++ b/graphics/src/text/editor.rs
@@ -57,16 +57,12 @@ impl Editor {
             .expect("Editor should always be initialized")
     }
 
-    fn with_internal_mut<T>(
-        &mut self,
-        f: impl FnOnce(&mut Internal) -> T,
-    ) -> T {
-        let editor =
-            self.0.take().expect("Editor should always be initialized");
+    fn with_internal_mut<T>(&mut self, f: impl FnOnce(&mut Internal) -> T) -> T {
+        let editor = self.0.take().expect("Editor should always be initialized");
 
         // TODO: Handle multiple strong references somehow
-        let mut internal = Arc::try_unwrap(editor)
-            .expect("Editor cannot have multiple strong references");
+        let mut internal =
+            Arc::try_unwrap(editor).expect("Editor cannot have multiple strong references");
 
         // Clear cursor cache
         let _ = internal
@@ -92,8 +88,7 @@ impl editor::Editor for Editor {
             line_height: 1.0,
         });
 
-        let mut font_system =
-            text::font_system().write().expect("Write font system");
+        let mut font_system = text::font_system().write().expect("Write font system");
 
         buffer.set_text(
             text,
@@ -113,8 +108,7 @@ impl editor::Editor for Editor {
     fn is_empty(&self) -> bool {
         let buffer = self.buffer();
 
-        buffer.lines.is_empty()
-            || (buffer.lines.len() == 1 && buffer.lines[0].text().is_empty())
+        buffer.lines.is_empty() || (buffer.lines.len() == 1 && buffer.lines[0].text().is_empty())
     }
 
     fn line(&self, index: usize) -> Option<editor::Line<'_>> {
@@ -154,9 +148,7 @@ impl editor::Editor for Editor {
 
                 let regions = buffer
                     .layout_runs()
-                    .filter(|run| {
-                        run.line_i >= start.line && run.line_i <= end.line
-                    })
+                    .filter(|run| run.line_i >= start.line && run.line_i <= end.line)
                     .flat_map(|run| {
                         let line_top = run.line_top;
                         run.highlight(start, end)
@@ -188,20 +180,15 @@ impl editor::Editor for Editor {
                         // Fallback: cursor not found in any run (e.g. empty buffer).
                         let line_height = buffer.metrics().line_height;
                         let scroll_y = buffer.scroll().vertical;
-                        let visual_lines_offset =
-                            visual_lines_offset(cursor.line, buffer);
-                        Point::new(
-                            0.0,
-                            visual_lines_offset as f32 * line_height - scroll_y,
-                        )
+                        let visual_lines_offset = visual_lines_offset(cursor.line, buffer);
+                        Point::new(0.0, visual_lines_offset as f32 * line_height - scroll_y)
                     });
 
                 Selection::Caret(point)
             }
         };
 
-        *internal.selection.write().expect("Write to cursor cache") =
-            Some(cursor.clone());
+        *internal.selection.write().expect("Write to cursor cache") = Some(cursor.clone());
 
         cursor
     }
@@ -235,8 +222,7 @@ impl editor::Editor for Editor {
     }
 
     fn perform(&mut self, action: Action) {
-        let mut font_system =
-            text::font_system().write().expect("Write font system");
+        let mut font_system = text::font_system().write().expect("Write font system");
 
         self.with_internal_mut(|internal| {
             let editor = &mut internal.editor;
@@ -256,9 +242,7 @@ impl editor::Editor for Editor {
                             | Motion::DocumentEnd => {
                                 editor.action(
                                     font_system.raw(),
-                                    cosmic_text::Action::Motion(to_motion(
-                                        motion,
-                                    )),
+                                    cosmic_text::Action::Motion(to_motion(motion)),
                                 );
                             }
                             // Other motions simply move the cursor to one end of the selection
@@ -280,9 +264,7 @@ impl editor::Editor for Editor {
                     let cursor = editor.cursor();
 
                     if editor.selection_bounds().is_none() {
-                        editor.set_selection(cosmic_text::Selection::Normal(
-                            cursor,
-                        ));
+                        editor.set_selection(cosmic_text::Selection::Normal(cursor));
                     }
 
                     editor.action(
@@ -319,19 +301,15 @@ impl editor::Editor for Editor {
                     {
                         let cursor = editor.cursor();
 
-                        editor.set_selection(cosmic_text::Selection::Normal(
-                            cosmic_text::Cursor {
-                                line: 0,
-                                index: 0,
-                                ..cursor
-                            },
-                        ));
+                        editor.set_selection(cosmic_text::Selection::Normal(cosmic_text::Cursor {
+                            line: 0,
+                            index: 0,
+                            ..cursor
+                        }));
 
                         editor.action(
                             font_system.raw(),
-                            cosmic_text::Action::Motion(
-                                cosmic_text::Motion::BufferEnd,
-                            ),
+                            cosmic_text::Action::Motion(cosmic_text::Motion::BufferEnd),
                         );
                     }
                 }
@@ -346,43 +324,25 @@ impl editor::Editor for Editor {
 
                     match edit {
                         Edit::Insert(c) => {
-                            editor.action(
-                                font_system.raw(),
-                                cosmic_text::Action::Insert(c),
-                            );
+                            editor.action(font_system.raw(), cosmic_text::Action::Insert(c));
                         }
                         Edit::Paste(text) => {
                             editor.insert_string(&text, None);
                         }
                         Edit::Indent => {
-                            editor.action(
-                                font_system.raw(),
-                                cosmic_text::Action::Indent,
-                            );
+                            editor.action(font_system.raw(), cosmic_text::Action::Indent);
                         }
                         Edit::Unindent => {
-                            editor.action(
-                                font_system.raw(),
-                                cosmic_text::Action::Unindent,
-                            );
+                            editor.action(font_system.raw(), cosmic_text::Action::Unindent);
                         }
                         Edit::Enter => {
-                            editor.action(
-                                font_system.raw(),
-                                cosmic_text::Action::Enter,
-                            );
+                            editor.action(font_system.raw(), cosmic_text::Action::Enter);
                         }
                         Edit::Backspace => {
-                            editor.action(
-                                font_system.raw(),
-                                cosmic_text::Action::Backspace,
-                            );
+                            editor.action(font_system.raw(), cosmic_text::Action::Backspace);
                         }
                         Edit::Delete => {
-                            editor.action(
-                                font_system.raw(),
-                                cosmic_text::Action::Delete,
-                            );
+                            editor.action(font_system.raw(), cosmic_text::Action::Delete);
                         }
                     }
 
@@ -392,9 +352,8 @@ impl editor::Editor for Editor {
                         .map(|(start, _)| start)
                         .unwrap_or(cursor);
 
-                    internal.topmost_line_changed = Some(
-                        selection_start.line.min(topmost_line_before_edit),
-                    );
+                    internal.topmost_line_changed =
+                        Some(selection_start.line.min(topmost_line_before_edit));
                 }
 
                 // Mouse events
@@ -428,10 +387,7 @@ impl editor::Editor for Editor {
                     editor.action(
                         font_system.raw(),
                         cosmic_text::Action::Scroll {
-                            pixels: lines as f32
-                                * buffer_from_editor(editor)
-                                    .metrics()
-                                    .line_height,
+                            pixels: lines as f32 * buffer_from_editor(editor).metrics().line_height,
                         },
                     );
                 }
@@ -451,13 +407,11 @@ impl editor::Editor for Editor {
             if let Some(selection) = cursor.selection {
                 internal
                     .editor
-                    .set_selection(cosmic_text::Selection::Normal(
-                        cosmic_text::Cursor {
-                            line: selection.line,
-                            index: selection.column,
-                            affinity: cosmic_text::Affinity::Before,
-                        },
-                    ));
+                    .set_selection(cosmic_text::Selection::Normal(cosmic_text::Cursor {
+                        line: selection.line,
+                        index: selection.column,
+                        affinity: cosmic_text::Affinity::Before,
+                    }));
             }
         });
     }
@@ -469,8 +423,7 @@ impl editor::Editor for Editor {
     fn min_bounds(&self) -> Size {
         let internal = self.internal();
 
-        let (bounds, _has_rtl) =
-            text::measure(buffer_from_editor(&internal.editor));
+        let (bounds, _has_rtl) = text::measure(buffer_from_editor(&internal.editor));
 
         bounds
     }
@@ -485,8 +438,7 @@ impl editor::Editor for Editor {
         new_highlighter: &mut impl Highlighter,
     ) {
         self.with_internal_mut(|internal| {
-            let mut font_system =
-                text::font_system().write().expect("Write font system");
+            let mut font_system = text::font_system().write().expect("Write font system");
 
             let buffer = buffer_mut_from_editor(&mut internal.editor);
 
@@ -505,9 +457,9 @@ impl editor::Editor for Editor {
                 log::trace!("Updating font of `Editor`...");
 
                 for line in buffer.lines.iter_mut() {
-                    let _ = line.set_attrs_list(cosmic_text::AttrsList::new(
-                        &text::to_attributes(new_font),
-                    ));
+                    let _ = line.set_attrs_list(cosmic_text::AttrsList::new(&text::to_attributes(
+                        new_font,
+                    )));
                 }
 
                 internal.font = new_font;
@@ -517,15 +469,10 @@ impl editor::Editor for Editor {
             let metrics = buffer.metrics();
             let new_line_height = new_line_height.to_absolute(new_size);
 
-            if new_size.0 != metrics.font_size
-                || new_line_height.0 != metrics.line_height
-            {
+            if new_size.0 != metrics.font_size || new_line_height.0 != metrics.line_height {
                 log::trace!("Updating `Metrics` of `Editor`...");
 
-                buffer.set_metrics(cosmic_text::Metrics::new(
-                    new_size.0,
-                    new_line_height.0,
-                ));
+                buffer.set_metrics(cosmic_text::Metrics::new(new_size.0, new_line_height.0));
             }
 
             let new_wrap = text::to_wrap(new_wrapping);
@@ -539,15 +486,12 @@ impl editor::Editor for Editor {
             if new_bounds != internal.bounds {
                 log::trace!("Updating size of `Editor`...");
 
-                buffer
-                    .set_size(Some(new_bounds.width), Some(new_bounds.height));
+                buffer.set_size(Some(new_bounds.width), Some(new_bounds.height));
 
                 internal.bounds = new_bounds;
             }
 
-            if let Some(topmost_line_changed) =
-                internal.topmost_line_changed.take()
-            {
+            if let Some(topmost_line_changed) = internal.topmost_line_changed.take() {
                 log::trace!(
                     "Notifying highlighter of line \
                     change: {topmost_line_changed}"
@@ -570,8 +514,7 @@ impl editor::Editor for Editor {
         let buffer = buffer_from_editor(&internal.editor);
 
         let scroll = buffer.scroll();
-        let mut window = (internal.bounds.height / buffer.metrics().line_height)
-            .ceil() as i32;
+        let mut window = (internal.bounds.height / buffer.metrics().line_height).ceil() as i32;
 
         let last_visible_line = buffer.lines[scroll.line..]
             .iter()
@@ -598,14 +541,12 @@ impl editor::Editor for Editor {
             return;
         }
 
-        let editor =
-            self.0.take().expect("Editor should always be initialized");
+        let editor = self.0.take().expect("Editor should always be initialized");
 
-        let mut internal = Arc::try_unwrap(editor)
-            .expect("Editor cannot have multiple strong references");
+        let mut internal =
+            Arc::try_unwrap(editor).expect("Editor cannot have multiple strong references");
 
-        let mut font_system =
-            text::font_system().write().expect("Write font system");
+        let mut font_system = text::font_system().write().expect("Write font system");
 
         let attributes = text::to_attributes(font);
 
@@ -739,9 +680,7 @@ fn to_motion(motion: Motion) -> cosmic_text::Motion {
     }
 }
 
-fn buffer_from_editor<'a, 'b>(
-    editor: &'a impl cosmic_text::Edit<'b>,
-) -> &'a cosmic_text::Buffer
+fn buffer_from_editor<'a, 'b>(editor: &'a impl cosmic_text::Edit<'b>) -> &'a cosmic_text::Buffer
 where
     'b: 'a,
 {

--- a/graphics/src/text/paragraph.rs
+++ b/graphics/src/text/paragraph.rs
@@ -3,9 +3,7 @@ use iced_core::text::Ellipsize;
 
 use crate::core;
 use crate::core::alignment;
-use crate::core::text::{
-    Affinity, Alignment, Hit, LineHeight, Shaping, Span, Text, Wrapping,
-};
+use crate::core::text::{Affinity, Alignment, Hit, LineHeight, Shaping, Span, Text, Wrapping};
 use crate::core::{Font, Pixels, Point, Rectangle, Size};
 use crate::text;
 
@@ -75,8 +73,7 @@ impl core::text::Paragraph for Paragraph {
     fn with_text(text: Text<&str>) -> Self {
         log::trace!("Allocating plain paragraph: {}", text.content);
 
-        let mut font_system =
-            text::font_system().write().expect("Write font system");
+        let mut font_system = text::font_system().write().expect("Write font system");
 
         let mut buffer = cosmic_text::Buffer::new(
             font_system.raw(),
@@ -99,8 +96,7 @@ impl core::text::Paragraph for Paragraph {
         );
 
         buffer.shape_until_scroll(font_system.raw(), false);
-        let min_bounds =
-            text::align(&mut buffer, font_system.raw(), text.align_x);
+        let min_bounds = text::align(&mut buffer, font_system.raw(), text.align_x);
 
         Self(Arc::new(Internal {
             buffer,
@@ -119,8 +115,7 @@ impl core::text::Paragraph for Paragraph {
     fn with_spans<Link>(text: Text<&[Span<'_, Link>]>) -> Self {
         log::trace!("Allocating rich paragraph: {} spans", text.content.len());
 
-        let mut font_system =
-            text::font_system().write().expect("Write font system");
+        let mut font_system = text::font_system().write().expect("Write font system");
 
         let mut buffer = cosmic_text::Buffer::new(
             font_system.raw(),
@@ -172,8 +167,7 @@ impl core::text::Paragraph for Paragraph {
         );
 
         buffer.shape_until_scroll(font_system.raw(), false);
-        let min_bounds =
-            text::align(&mut buffer, font_system.raw(), text.align_x);
+        let min_bounds = text::align(&mut buffer, font_system.raw(), text.align_x);
 
         Self(Arc::new(Internal {
             buffer,
@@ -192,8 +186,7 @@ impl core::text::Paragraph for Paragraph {
     fn resize(&mut self, new_bounds: Size) {
         let paragraph = Arc::make_mut(&mut self.0);
 
-        let mut font_system =
-            text::font_system().write().expect("Write font system");
+        let mut font_system = text::font_system().write().expect("Write font system");
 
         paragraph
             .buffer
@@ -202,11 +195,7 @@ impl core::text::Paragraph for Paragraph {
             .buffer
             .shape_until_scroll(font_system.raw(), false);
 
-        let min_bounds = text::align(
-            &mut paragraph.buffer,
-            font_system.raw(),
-            paragraph.align_x,
-        );
+        let min_bounds = text::align(&mut paragraph.buffer, font_system.raw(), paragraph.align_x);
 
         paragraph.bounds = new_bounds;
         paragraph.min_bounds = min_bounds;
@@ -338,10 +327,7 @@ impl core::text::Paragraph for Paragraph {
             let new_bounds = || {
                 Rectangle::new(
                     Point::new(glyph.x, y),
-                    Size::new(
-                        glyph.w,
-                        glyph.line_height_opt.unwrap_or(line_height),
-                    ),
+                    Size::new(glyph.w, glyph.line_height_opt.unwrap_or(line_height)),
                 )
             };
 
@@ -379,9 +365,7 @@ impl core::text::Paragraph for Paragraph {
             .iter()
             .find(|glyph| {
                 if Some(glyph.start) != last_start {
-                    last_grapheme_count = run.text[glyph.start..glyph.end]
-                        .graphemes(false)
-                        .count();
+                    last_grapheme_count = run.text[glyph.start..glyph.end].graphemes(false).count();
                     last_start = Some(glyph.start);
                     graphemes_seen += last_grapheme_count;
                 }
@@ -405,18 +389,10 @@ impl core::text::Paragraph for Paragraph {
         ))
     }
 
-    fn cursor_position(
-        &self,
-        line: usize,
-        byte_index: usize,
-        affinity: Affinity,
-    ) -> Option<Point> {
+    fn cursor_position(&self, line: usize, byte_index: usize, affinity: Affinity) -> Option<Point> {
         let internal = self.internal();
-        let cursor = cosmic_text::Cursor::new_with_affinity(
-            line,
-            byte_index,
-            to_cosmic_affinity(affinity),
-        );
+        let cursor =
+            cosmic_text::Cursor::new_with_affinity(line, byte_index, to_cosmic_affinity(affinity));
         internal
             .buffer
             .cursor_position(&cursor)
@@ -430,16 +406,10 @@ impl core::text::Paragraph for Paragraph {
         end: (usize, Affinity),
     ) -> Vec<Rectangle> {
         let internal = self.internal();
-        let start_cursor = cosmic_text::Cursor::new_with_affinity(
-            line,
-            start.0,
-            to_cosmic_affinity(start.1),
-        );
-        let end_cursor = cosmic_text::Cursor::new_with_affinity(
-            line,
-            end.0,
-            to_cosmic_affinity(end.1),
-        );
+        let start_cursor =
+            cosmic_text::Cursor::new_with_affinity(line, start.0, to_cosmic_affinity(start.1));
+        let end_cursor =
+            cosmic_text::Cursor::new_with_affinity(line, end.0, to_cosmic_affinity(end.1));
 
         internal
             .buffer

--- a/graphics/src/viewport.rs
+++ b/graphics/src/viewport.rs
@@ -20,10 +20,7 @@ impl Viewport {
             physical_size,
             logical_size: size,
             scale_factor,
-            projection: Transformation::orthographic(
-                physical_size.width,
-                physical_size.height,
-            ),
+            projection: Transformation::orthographic(physical_size.width, physical_size.height),
         }
     }
 

--- a/highlighter/src/lib.rs
+++ b/highlighter/src/lib.rs
@@ -12,8 +12,7 @@ use syntect::highlighting;
 use syntect::parsing;
 use two_face::re_exports::syntect;
 
-static SYNTAXES: LazyLock<parsing::SyntaxSet> =
-    LazyLock::new(two_face::syntax::extra_no_newlines);
+static SYNTAXES: LazyLock<parsing::SyntaxSet> = LazyLock::new(two_face::syntax::extra_no_newlines);
 
 static THEMES: LazyLock<highlighting::ThemeSet> =
     LazyLock::new(highlighting::ThemeSet::load_defaults);
@@ -33,17 +32,14 @@ impl highlighter::Highlighter for Highlighter {
     type Settings = Settings;
     type Highlight = Highlight;
 
-    type Iterator<'a> =
-        Box<dyn Iterator<Item = (Range<usize>, Self::Highlight)> + 'a>;
+    type Iterator<'a> = Box<dyn Iterator<Item = (Range<usize>, Self::Highlight)> + 'a>;
 
     fn new(settings: &Self::Settings) -> Self {
         let syntax = SYNTAXES
             .find_syntax_by_token(&settings.token)
             .unwrap_or_else(|| SYNTAXES.find_syntax_plain_text());
 
-        let highlighter = highlighting::Highlighter::new(
-            &THEMES.themes[settings.theme.key()],
-        );
+        let highlighter = highlighting::Highlighter::new(&THEMES.themes[settings.theme.key()]);
 
         let parser = parsing::ParseState::new(syntax);
         let stack = parsing::ScopeStack::new();
@@ -61,9 +57,7 @@ impl highlighter::Highlighter for Highlighter {
             .find_syntax_by_token(&new_settings.token)
             .unwrap_or_else(|| SYNTAXES.find_syntax_plain_text());
 
-        self.highlighter = highlighting::Highlighter::new(
-            &THEMES.themes[new_settings.theme.key()],
-        );
+        self.highlighter = highlighting::Highlighter::new(&THEMES.themes[new_settings.theme.key()]);
 
         // Restart the highlighter
         self.change_line(0);
@@ -80,29 +74,26 @@ impl highlighter::Highlighter for Highlighter {
             self.current_line = 0;
         }
 
-        let (parser, stack) =
-            self.caches.last().cloned().unwrap_or_else(|| {
-                (
-                    parsing::ParseState::new(self.syntax),
-                    parsing::ScopeStack::new(),
-                )
-            });
+        let (parser, stack) = self.caches.last().cloned().unwrap_or_else(|| {
+            (
+                parsing::ParseState::new(self.syntax),
+                parsing::ScopeStack::new(),
+            )
+        });
 
         self.caches.push((parser, stack));
     }
 
     fn highlight_line(&mut self, line: &str) -> Self::Iterator<'_> {
         if self.current_line / LINES_PER_SNAPSHOT >= self.caches.len() {
-            let (parser, stack) =
-                self.caches.last().expect("Caches must not be empty");
+            let (parser, stack) = self.caches.last().expect("Caches must not be empty");
 
             self.caches.push((parser.clone(), stack.clone()));
         }
 
         self.current_line += 1;
 
-        let (parser, stack) =
-            self.caches.last_mut().expect("Caches must not be empty");
+        let (parser, stack) = self.caches.last_mut().expect("Caches must not be empty");
 
         let ops = parser.parse_line(line, &SYNTAXES).unwrap_or_default();
 
@@ -159,9 +150,7 @@ impl Stream {
             .find_syntax_by_token(&settings.token)
             .unwrap_or_else(|| SYNTAXES.find_syntax_plain_text());
 
-        let highlighter = highlighting::Highlighter::new(
-            &THEMES.themes[settings.theme.key()],
-        );
+        let highlighter = highlighting::Highlighter::new(&THEMES.themes[settings.theme.key()]);
 
         let state = parsing::ParseState::new(syntax);
         let stack = parsing::ScopeStack::new();
@@ -223,9 +212,9 @@ impl Highlight {
     ///
     /// If `None`, the original text color should be unchanged.
     pub fn color(&self) -> Option<Color> {
-        self.0.foreground.map(|color| {
-            Color::from_rgba8(color.r, color.g, color.b, color.a as f32 / 255.0)
-        })
+        self.0
+            .foreground
+            .map(|color| Color::from_rgba8(color.r, color.g, color.b, color.a as f32 / 255.0))
     }
 
     /// Returns the font of this [`Highlight`].
@@ -294,10 +283,9 @@ impl Theme {
     /// Returns `true` if the [`Theme`] is dark, and false otherwise.
     pub fn is_dark(self) -> bool {
         match self {
-            Self::SolarizedDark
-            | Self::Base16Mocha
-            | Self::Base16Ocean
-            | Self::Base16Eighties => true,
+            Self::SolarizedDark | Self::Base16Mocha | Self::Base16Ocean | Self::Base16Eighties => {
+                true
+            }
             Self::InspiredGitHub => false,
         }
     }

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -49,11 +49,7 @@ pub trait Program: Sized {
 
     fn boot(&self) -> (Self::State, Task<Self::Message>);
 
-    fn update(
-        &self,
-        state: &mut Self::State,
-        message: Self::Message,
-    ) -> Task<Self::Message>;
+    fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message>;
 
     fn view<'a>(
         &self,
@@ -90,18 +86,11 @@ pub trait Program: Sized {
         format!("{title} - Iced")
     }
 
-    fn subscription(
-        &self,
-        _state: &Self::State,
-    ) -> Subscription<Self::Message> {
+    fn subscription(&self, _state: &Self::State) -> Subscription<Self::Message> {
         Subscription::none()
     }
 
-    fn theme(
-        &self,
-        _state: &Self::State,
-        _window: window::Id,
-    ) -> Option<Self::Theme> {
+    fn theme(&self, _state: &Self::State, _window: window::Id) -> Option<Self::Theme> {
         None
     }
 
@@ -159,11 +148,7 @@ pub fn with_title<P: Program>(
             self.program.boot()
         }
 
-        fn update(
-            &self,
-            state: &mut Self::State,
-            message: Self::Message,
-        ) -> Task<Self::Message> {
+        fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
             self.program.update(state, message)
         }
 
@@ -175,26 +160,15 @@ pub fn with_title<P: Program>(
             self.program.view(state, window)
         }
 
-        fn theme(
-            &self,
-            state: &Self::State,
-            window: window::Id,
-        ) -> Option<Self::Theme> {
+        fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
             self.program.theme(state, window)
         }
 
-        fn subscription(
-            &self,
-            state: &Self::State,
-        ) -> Subscription<Self::Message> {
+        fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
             self.program.subscription(state)
         }
 
-        fn style(
-            &self,
-            state: &Self::State,
-            theme: &Self::Theme,
-        ) -> theme::Style {
+        fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
             self.program.style(state, theme)
         }
 
@@ -226,10 +200,7 @@ pub fn with_subscription<P: Program>(
         type Renderer = P::Renderer;
         type Executor = P::Executor;
 
-        fn subscription(
-            &self,
-            state: &Self::State,
-        ) -> Subscription<Self::Message> {
+        fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
             (self.subscription)(state)
         }
 
@@ -249,11 +220,7 @@ pub fn with_subscription<P: Program>(
             self.program.boot()
         }
 
-        fn update(
-            &self,
-            state: &mut Self::State,
-            message: Self::Message,
-        ) -> Task<Self::Message> {
+        fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
             self.program.update(state, message)
         }
 
@@ -269,19 +236,11 @@ pub fn with_subscription<P: Program>(
             self.program.title(state, window)
         }
 
-        fn theme(
-            &self,
-            state: &Self::State,
-            window: window::Id,
-        ) -> Option<Self::Theme> {
+        fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
             self.program.theme(state, window)
         }
 
-        fn style(
-            &self,
-            state: &Self::State,
-            theme: &Self::Theme,
-        ) -> theme::Style {
+        fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
             self.program.style(state, theme)
         }
 
@@ -316,11 +275,7 @@ pub fn with_theme<P: Program>(
         type Renderer = P::Renderer;
         type Executor = P::Executor;
 
-        fn theme(
-            &self,
-            state: &Self::State,
-            window: window::Id,
-        ) -> Option<Self::Theme> {
+        fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
             (self.theme)(state, window)
         }
 
@@ -344,11 +299,7 @@ pub fn with_theme<P: Program>(
             self.program.title(state, window)
         }
 
-        fn update(
-            &self,
-            state: &mut Self::State,
-            message: Self::Message,
-        ) -> Task<Self::Message> {
+        fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
             self.program.update(state, message)
         }
 
@@ -360,18 +311,11 @@ pub fn with_theme<P: Program>(
             self.program.view(state, window)
         }
 
-        fn subscription(
-            &self,
-            state: &Self::State,
-        ) -> Subscription<Self::Message> {
+        fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
             self.program.subscription(state)
         }
 
-        fn style(
-            &self,
-            state: &Self::State,
-            theme: &Self::Theme,
-        ) -> theme::Style {
+        fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
             self.program.style(state, theme)
         }
 
@@ -403,11 +347,7 @@ pub fn with_style<P: Program>(
         type Renderer = P::Renderer;
         type Executor = P::Executor;
 
-        fn style(
-            &self,
-            state: &Self::State,
-            theme: &Self::Theme,
-        ) -> theme::Style {
+        fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
             (self.style)(state, theme)
         }
 
@@ -431,11 +371,7 @@ pub fn with_style<P: Program>(
             self.program.title(state, window)
         }
 
-        fn update(
-            &self,
-            state: &mut Self::State,
-            message: Self::Message,
-        ) -> Task<Self::Message> {
+        fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
             self.program.update(state, message)
         }
 
@@ -447,18 +383,11 @@ pub fn with_style<P: Program>(
             self.program.view(state, window)
         }
 
-        fn subscription(
-            &self,
-            state: &Self::State,
-        ) -> Subscription<Self::Message> {
+        fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
             self.program.subscription(state)
         }
 
-        fn theme(
-            &self,
-            state: &Self::State,
-            window: window::Id,
-        ) -> Option<Self::Theme> {
+        fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
             self.program.theme(state, window)
         }
 
@@ -510,11 +439,7 @@ pub fn with_scale_factor<P: Program>(
             self.program.boot()
         }
 
-        fn update(
-            &self,
-            state: &mut Self::State,
-            message: Self::Message,
-        ) -> Task<Self::Message> {
+        fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
             self.program.update(state, message)
         }
 
@@ -526,26 +451,15 @@ pub fn with_scale_factor<P: Program>(
             self.program.view(state, window)
         }
 
-        fn subscription(
-            &self,
-            state: &Self::State,
-        ) -> Subscription<Self::Message> {
+        fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
             self.program.subscription(state)
         }
 
-        fn theme(
-            &self,
-            state: &Self::State,
-            window: window::Id,
-        ) -> Option<Self::Theme> {
+        fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
             self.program.theme(state, window)
         }
 
-        fn style(
-            &self,
-            state: &Self::State,
-            theme: &Self::Theme,
-        ) -> theme::Style {
+        fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
             self.program.style(state, theme)
         }
 
@@ -601,11 +515,7 @@ pub fn with_executor<P: Program, E: Executor>(
             self.program.boot()
         }
 
-        fn update(
-            &self,
-            state: &mut Self::State,
-            message: Self::Message,
-        ) -> Task<Self::Message> {
+        fn update(&self, state: &mut Self::State, message: Self::Message) -> Task<Self::Message> {
             self.program.update(state, message)
         }
 
@@ -617,26 +527,15 @@ pub fn with_executor<P: Program, E: Executor>(
             self.program.view(state, window)
         }
 
-        fn subscription(
-            &self,
-            state: &Self::State,
-        ) -> Subscription<Self::Message> {
+        fn subscription(&self, state: &Self::State) -> Subscription<Self::Message> {
             self.program.subscription(state)
         }
 
-        fn theme(
-            &self,
-            state: &Self::State,
-            window: window::Id,
-        ) -> Option<Self::Theme> {
+        fn theme(&self, state: &Self::State, window: window::Id) -> Option<Self::Theme> {
             self.program.theme(state, window)
         }
 
-        fn style(
-            &self,
-            state: &Self::State,
-            theme: &Self::Theme,
-        ) -> theme::Style {
+        fn style(&self, state: &Self::State, theme: &Self::Theme) -> theme::Style {
             self.program.style(state, theme)
         }
 
@@ -652,10 +551,7 @@ pub fn with_executor<P: Program, E: Executor>(
 }
 
 /// The renderer of some [`Program`].
-pub trait Renderer:
-    text::Renderer<Font = Font> + compositor::Default + renderer::Headless
-{
-}
+pub trait Renderer: text::Renderer<Font = Font> + compositor::Default + renderer::Headless {}
 
 impl<T> Renderer for T where
     T: text::Renderer<Font = Font> + compositor::Default + renderer::Headless
@@ -687,10 +583,7 @@ impl<P: Program> Instance<P> {
     }
 
     /// Produces the current widget tree of the [`Instance`].
-    pub fn view(
-        &self,
-        window: window::Id,
-    ) -> Element<'_, P::Message, P::Theme, P::Renderer> {
+    pub fn view(&self, window: window::Id) -> Element<'_, P::Message, P::Theme, P::Renderer> {
         self.program.view(&self.state, window)
     }
 

--- a/renderer/src/fallback.rs
+++ b/renderer/src/fallback.rs
@@ -3,8 +3,7 @@ use crate::core::image;
 use crate::core::renderer;
 use crate::core::svg;
 use crate::core::{
-    self, Background, Color, Font, Image, Pixels, Point, Rectangle, Size, Svg,
-    Transformation,
+    self, Background, Color, Font, Image, Pixels, Point, Rectangle, Size, Svg, Transformation,
 };
 use crate::graphics::compositor;
 use crate::graphics::mesh;
@@ -39,11 +38,7 @@ where
     A: core::Renderer,
     B: core::Renderer,
 {
-    fn fill_quad(
-        &mut self,
-        quad: renderer::Quad,
-        background: impl Into<Background>,
-    ) {
+    fn fill_quad(&mut self, quad: renderer::Quad, background: impl Into<Background>) {
         delegate!(self, renderer, renderer.fill_quad(quad, background.into()));
     }
 
@@ -74,9 +69,7 @@ where
     fn allocate_image(
         &mut self,
         handle: &image::Handle,
-        callback: impl FnOnce(Result<image::Allocation, image::Error>)
-        + Send
-        + 'static,
+        callback: impl FnOnce(Result<image::Allocation, image::Error>) + Send + 'static,
     ) {
         delegate!(self, renderer, renderer.allocate_image(handle, callback));
     }
@@ -178,10 +171,7 @@ where
 {
     type Handle = A::Handle;
 
-    fn load_image(
-        &self,
-        handle: &Self::Handle,
-    ) -> Result<image::Allocation, image::Error> {
+    fn load_image(&self, handle: &Self::Handle) -> Result<image::Allocation, image::Error> {
         delegate!(self, renderer, renderer.load_image(handle))
     }
 
@@ -189,12 +179,7 @@ where
         delegate!(self, renderer, renderer.measure_image(handle))
     }
 
-    fn draw_image(
-        &mut self,
-        image: Image<A::Handle>,
-        bounds: Rectangle,
-        clip_bounds: Rectangle,
-    ) {
+    fn draw_image(&mut self, image: Image<A::Handle>, bounds: Rectangle, clip_bounds: Rectangle) {
         delegate!(
             self,
             renderer,
@@ -212,12 +197,7 @@ where
         delegate!(self, renderer, renderer.measure_svg(handle))
     }
 
-    fn draw_svg(
-        &mut self,
-        svg: Svg,
-        bounds: Rectangle,
-        clip_bounds: Rectangle,
-    ) {
+    fn draw_svg(&mut self, svg: Svg, bounds: Rectangle, clip_bounds: Rectangle) {
         delegate!(self, renderer, renderer.draw_svg(svg, bounds, clip_bounds));
     }
 }
@@ -337,12 +317,8 @@ where
 
     fn create_renderer(&self) -> Self::Renderer {
         match self {
-            Self::Primary(compositor) => {
-                Renderer::Primary(compositor.create_renderer())
-            }
-            Self::Secondary(compositor) => {
-                Renderer::Secondary(compositor.create_renderer())
-            }
+            Self::Primary(compositor) => Renderer::Primary(compositor.create_renderer()),
+            Self::Secondary(compositor) => Renderer::Secondary(compositor.create_renderer()),
         }
     }
 
@@ -353,21 +329,16 @@ where
         height: u32,
     ) -> Self::Surface {
         match self {
-            Self::Primary(compositor) => Surface::Primary(
-                compositor.create_surface(window, width, height),
-            ),
-            Self::Secondary(compositor) => Surface::Secondary(
-                compositor.create_surface(window, width, height),
-            ),
+            Self::Primary(compositor) => {
+                Surface::Primary(compositor.create_surface(window, width, height))
+            }
+            Self::Secondary(compositor) => {
+                Surface::Secondary(compositor.create_surface(window, width, height))
+            }
         }
     }
 
-    fn configure_surface(
-        &mut self,
-        surface: &mut Self::Surface,
-        width: u32,
-        height: u32,
-    ) {
+    fn configure_surface(&mut self, surface: &mut Self::Surface, width: u32, height: u32) {
         match (self, surface) {
             (Self::Primary(compositor), Surface::Primary(surface)) => {
                 compositor.configure_surface(surface, width, height);
@@ -396,17 +367,15 @@ where
         on_pre_present: impl FnOnce(),
     ) -> Result<(), compositor::SurfaceError> {
         match (self, renderer, surface) {
-            (
-                Self::Primary(compositor),
-                Renderer::Primary(renderer),
-                Surface::Primary(surface),
-            ) => compositor.present(
-                renderer,
-                surface,
-                viewport,
-                background_color,
-                on_pre_present,
-            ),
+            (Self::Primary(compositor), Renderer::Primary(renderer), Surface::Primary(surface)) => {
+                compositor.present(
+                    renderer,
+                    surface,
+                    viewport,
+                    background_color,
+                    on_pre_present,
+                )
+            }
             (
                 Self::Secondary(compositor),
                 Renderer::Secondary(renderer),
@@ -446,19 +415,13 @@ where
     A: iced_wgpu::primitive::Renderer,
     B: core::Renderer,
 {
-    fn draw_primitive(
-        &mut self,
-        bounds: Rectangle,
-        primitive: impl iced_wgpu::Primitive,
-    ) {
+    fn draw_primitive(&mut self, bounds: Rectangle, primitive: impl iced_wgpu::Primitive) {
         match self {
             Self::Primary(renderer) => {
                 renderer.draw_primitive(bounds, primitive);
             }
             Self::Secondary(_) => {
-                log::warn!(
-                    "Custom shader primitive is not supported with this renderer."
-                );
+                log::warn!("Custom shader primitive is not supported with this renderer.");
             }
         }
     }
@@ -481,12 +444,8 @@ mod geometry {
 
         fn new_frame(&self, bounds: Rectangle) -> Self::Frame {
             match self {
-                Self::Primary(renderer) => {
-                    Frame::Primary(renderer.new_frame(bounds))
-                }
-                Self::Secondary(renderer) => {
-                    Frame::Secondary(renderer.new_frame(bounds))
-                }
+                Self::Primary(renderer) => Frame::Primary(renderer.new_frame(bounds)),
+                Self::Secondary(renderer) => Frame::Secondary(renderer.new_frame(bounds)),
             }
         }
 
@@ -523,23 +482,15 @@ mod geometry {
             }
         }
 
-        fn cache(
-            self,
-            group: cache::Group,
-            previous: Option<Self::Cache>,
-        ) -> Self::Cache {
+        fn cache(self, group: cache::Group, previous: Option<Self::Cache>) -> Self::Cache {
             match (self, previous) {
-                (
-                    Self::Primary(geometry),
-                    Some(Geometry::Primary(previous)),
-                ) => Geometry::Primary(geometry.cache(group, Some(previous))),
-                (Self::Primary(geometry), None) => {
-                    Geometry::Primary(geometry.cache(group, None))
+                (Self::Primary(geometry), Some(Geometry::Primary(previous))) => {
+                    Geometry::Primary(geometry.cache(group, Some(previous)))
                 }
-                (
-                    Self::Secondary(geometry),
-                    Some(Geometry::Secondary(previous)),
-                ) => Geometry::Secondary(geometry.cache(group, Some(previous))),
+                (Self::Primary(geometry), None) => Geometry::Primary(geometry.cache(group, None)),
+                (Self::Secondary(geometry), Some(Geometry::Secondary(previous))) => {
+                    Geometry::Secondary(geometry.cache(group, Some(previous)))
+                }
                 (Self::Secondary(geometry), None) => {
                     Geometry::Secondary(geometry.cache(group, None))
                 }
@@ -581,12 +532,7 @@ mod geometry {
             delegate!(self, frame, frame.fill(path, fill));
         }
 
-        fn fill_rectangle(
-            &mut self,
-            top_left: Point,
-            size: Size,
-            fill: impl Into<Fill>,
-        ) {
+        fn fill_rectangle(&mut self, top_left: Point, size: Size, fill: impl Into<Fill>) {
             delegate!(self, frame, frame.fill_rectangle(top_left, size, fill));
         }
 
@@ -600,18 +546,10 @@ mod geometry {
             size: Size,
             stroke: impl Into<Stroke<'a>>,
         ) {
-            delegate!(
-                self,
-                frame,
-                frame.stroke_rectangle(top_left, size, stroke)
-            );
+            delegate!(self, frame, frame.stroke_rectangle(top_left, size, stroke));
         }
 
-        fn stroke_text<'a>(
-            &mut self,
-            text: impl Into<Text>,
-            stroke: impl Into<Stroke<'a>>,
-        ) {
+        fn stroke_text<'a>(&mut self, text: impl Into<Text>, stroke: impl Into<Stroke<'a>>) {
             delegate!(self, frame, frame.stroke_text(text, stroke));
         }
 
@@ -672,12 +610,8 @@ mod geometry {
 
         fn into_geometry(self) -> Self::Geometry {
             match self {
-                Frame::Primary(frame) => {
-                    Geometry::Primary(frame.into_geometry())
-                }
-                Frame::Secondary(frame) => {
-                    Geometry::Secondary(frame.into_geometry())
-                }
+                Frame::Primary(frame) => Geometry::Primary(frame.into_geometry()),
+                Frame::Secondary(frame) => Geometry::Secondary(frame.into_geometry()),
             }
         }
     }
@@ -693,9 +627,7 @@ where
         default_text_size: Pixels,
         backend: Option<&str>,
     ) -> Option<Self> {
-        if let Some(renderer) =
-            A::new(default_font, default_text_size, backend).await
-        {
+        if let Some(renderer) = A::new(default_font, default_text_size, backend).await {
             return Some(Self::Primary(renderer));
         }
 

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -24,10 +24,7 @@ pub type Compositor = renderer::Compositor;
 
 #[cfg(all(feature = "wgpu-bare", feature = "tiny-skia"))]
 mod renderer {
-    pub type Renderer = crate::fallback::Renderer<
-        iced_wgpu::Renderer,
-        iced_tiny_skia::Renderer,
-    >;
+    pub type Renderer = crate::fallback::Renderer<iced_wgpu::Renderer, iced_tiny_skia::Renderer>;
 
     pub type Compositor = crate::fallback::Compositor<
         iced_wgpu::window::Compositor,

--- a/runtime/src/clipboard.rs
+++ b/runtime/src/clipboard.rs
@@ -98,11 +98,7 @@ pub fn write_primary<Message>(contents: String) -> Task<Message> {
 /// Read the current contents of the clipboard.
 pub fn read_data<T: AllowedMimeTypes>() -> Task<Option<T>> {
     task::oneshot(|tx| {
-        crate::Action::Clipboard(Action::ReadData(
-            T::allowed().into(),
-            tx,
-            Kind::Standard,
-        ))
+        crate::Action::Clipboard(Action::ReadData(T::allowed().into(), tx, Kind::Standard))
     })
     .map(|d| d.and_then(|d| T::try_from(d).ok()))
 }

--- a/runtime/src/dnd.rs
+++ b/runtime/src/dnd.rs
@@ -6,7 +6,7 @@ use dnd::{DndDestinationRectangle, DndSurface};
 use iced_core::clipboard::DndSource;
 use window_clipboard::mime::{AllowedMimeTypes, AsMimeTypes};
 
-use crate::{oneshot, task, Action, Task};
+use crate::{Action, Task, oneshot, task};
 
 /// An action to be performed on the system.
 pub enum DndAction {
@@ -41,9 +41,7 @@ impl std::fmt::Debug for DndAction {
                 .field("rectangles", rectangles)
                 .finish(),
             Self::EndDnd => f.write_str("EndDnd"),
-            Self::PeekDnd(mime, _) => {
-                f.debug_struct("PeekDnd").field("mime", mime).finish()
-            }
+            Self::PeekDnd(mime, _) => f.debug_struct("PeekDnd").field("mime", mime).finish(),
             Self::SetAction(a) => f.debug_tuple("SetAction").field(a).finish(),
         }
     }

--- a/runtime/src/image.rs
+++ b/runtime/src/image.rs
@@ -18,7 +18,5 @@ pub enum Action {
 /// that using a [`Handle`] will draw the corresponding image immediately
 /// in the next frame.
 pub fn allocate(handle: impl Into<Handle>) -> Task<Result<Allocation, Error>> {
-    task::oneshot(|sender| {
-        crate::Action::Image(Action::Allocate(handle.into(), sender))
-    })
+    task::oneshot(|sender| crate::Action::Image(Action::Allocate(handle.into(), sender)))
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -87,9 +87,7 @@ impl<T> Action<T> {
     fn output<O>(self) -> Result<T, Action<O>> {
         match self {
             Action::Output(output) => Ok(output),
-            Action::LoadFont { bytes, channel } => {
-                Err(Action::LoadFont { bytes, channel })
-            }
+            Action::LoadFont { bytes, channel } => Err(Action::LoadFont { bytes, channel }),
             Action::Widget(operation) => Err(Action::Widget(operation)),
             Action::Clipboard(action) => Err(Action::Clipboard(action)),
             Action::Window(action) => Err(Action::Window(action)),

--- a/runtime/src/platform_specific/wayland/activation.rs
+++ b/runtime/src/platform_specific/wayland/activation.rs
@@ -36,7 +36,7 @@ impl fmt::Debug for Action {
                 f,
                 "Action::ActivationAction::Activate {{ window: {:?}, token: {:?} }}",
                 window, token,
-            )
+            ),
         }
     }
 }

--- a/runtime/src/platform_specific/wayland/layer_surface.rs
+++ b/runtime/src/platform_specific/wayland/layer_surface.rs
@@ -6,8 +6,8 @@ use cctk::sctk::{
 };
 use iced_core::layout::Limits;
 
-use iced_core::window::Id;
 use iced_core::Rectangle;
+use iced_core::window::Id;
 
 /// output for layer surface
 #[derive(Debug, Clone)]
@@ -162,35 +162,44 @@ impl fmt::Debug for Action {
             ),
             Action::Size { id, width, height } => write!(
                 f,
-                "Action::LayerSurfaceAction::Size {{ id: {:#?}, width: {:?}, height: {:?} }}", id, width, height
+                "Action::LayerSurfaceAction::Size {{ id: {:#?}, width: {:?}, height: {:?} }}",
+                id, width, height
             ),
-            Action::Destroy(id) => write!(
-                f,
-                "Action::LayerSurfaceAction::Destroy {{ id: {:#?} }}", id
-            ),
+            Action::Destroy(id) => {
+                write!(f, "Action::LayerSurfaceAction::Destroy {{ id: {:#?} }}", id)
+            }
             Action::Anchor { id, anchor } => write!(
                 f,
-                "Action::LayerSurfaceAction::Anchor {{ id: {:#?}, anchor: {:?} }}", id, anchor
+                "Action::LayerSurfaceAction::Anchor {{ id: {:#?}, anchor: {:?} }}",
+                id, anchor
             ),
             Action::ExclusiveZone { id, exclusive_zone } => write!(
                 f,
-                "Action::LayerSurfaceAction::ExclusiveZone {{ id: {:#?}, exclusive_zone: {exclusive_zone} }}", id
+                "Action::LayerSurfaceAction::ExclusiveZone {{ id: {:#?}, exclusive_zone: {exclusive_zone} }}",
+                id
             ),
             Action::Margin { id, margin } => write!(
                 f,
-                "Action::LayerSurfaceAction::Margin {{ id: {:#?}, margin: {:?} }}", id, margin
+                "Action::LayerSurfaceAction::Margin {{ id: {:#?}, margin: {:?} }}",
+                id, margin
             ),
-            Action::KeyboardInteractivity { id, keyboard_interactivity } => write!(
+            Action::KeyboardInteractivity {
+                id,
+                keyboard_interactivity,
+            } => write!(
                 f,
-                "Action::LayerSurfaceAction::KeyboardInteractivity {{ id: {:#?}, keyboard_interactivity: {:?} }}", id, keyboard_interactivity
+                "Action::LayerSurfaceAction::KeyboardInteractivity {{ id: {:#?}, keyboard_interactivity: {:?} }}",
+                id, keyboard_interactivity
             ),
             Action::InputZone { id, zone } => write!(
                 f,
-                "Action::LayerSurfaceAction::InputZone {{ id: {:#?}, zone: {:?} }}", id, zone
+                "Action::LayerSurfaceAction::InputZone {{ id: {:#?}, zone: {:?} }}",
+                id, zone
             ),
             Action::Layer { id, layer } => write!(
                 f,
-                "Action::LayerSurfaceAction::Layer {{ id: {:#?}, layer: {:?} }}", id, layer
+                "Action::LayerSurfaceAction::Layer {{ id: {:#?}, layer: {:?} }}",
+                id, layer
             ),
         }
     }

--- a/runtime/src/platform_specific/wayland/mod.rs
+++ b/runtime/src/platform_specific/wayland/mod.rs
@@ -50,25 +50,13 @@ pub struct CornerRadius {
 impl Debug for Action {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Action::LayerSurface(arg0) => {
-                f.debug_tuple("LayerSurface").field(arg0).finish()
-            }
+            Action::LayerSurface(arg0) => f.debug_tuple("LayerSurface").field(arg0).finish(),
             Action::Popup(arg0) => f.debug_tuple("Popup").field(arg0).finish(),
-            Action::Activation(arg0) => {
-                f.debug_tuple("Activation").field(arg0).finish()
-            }
-            Action::SessionLock(arg0) => {
-                f.debug_tuple("SessionLock").field(arg0).finish()
-            }
-            Action::OverlapNotify(id, _) => {
-                f.debug_tuple("OverlapNotify").field(id).finish()
-            }
-            Action::Subsurface(action) => {
-                f.debug_tuple("Subsurface").field(action).finish()
-            }
-            Action::InhibitShortcuts(v) => {
-                f.debug_tuple("InhibitShortcuts").field(v).finish()
-            }
+            Action::Activation(arg0) => f.debug_tuple("Activation").field(arg0).finish(),
+            Action::SessionLock(arg0) => f.debug_tuple("SessionLock").field(arg0).finish(),
+            Action::OverlapNotify(id, _) => f.debug_tuple("OverlapNotify").field(id).finish(),
+            Action::Subsurface(action) => f.debug_tuple("Subsurface").field(action).finish(),
+            Action::InhibitShortcuts(v) => f.debug_tuple("InhibitShortcuts").field(v).finish(),
             Action::RoundedCorners(id, v) => {
                 f.debug_tuple("RoundedCorners").field(id).field(v).finish()
             }

--- a/runtime/src/platform_specific/wayland/popup.rs
+++ b/runtime/src/platform_specific/wayland/popup.rs
@@ -3,9 +3,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-use cctk::sctk::reexports::protocols::xdg::shell::client::xdg_positioner::{
-    Anchor, Gravity,
-};
+use cctk::sctk::reexports::protocols::xdg::shell::client::xdg_positioner::{Anchor, Gravity};
 use iced_core::layout::Limits;
 use iced_core::window::Id;
 use iced_core::{Element, Rectangle};
@@ -129,16 +127,10 @@ pub enum Action {
 impl fmt::Debug for Action {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Action::Popup { popup, .. } => write!(
-                f,
-                "Action::PopupAction::Popup {{ popup: {:?} }}",
-                popup
-            ),
-            Action::Destroy { id } => write!(
-                f,
-                "Action::PopupAction::Destroy {{ id: {:?} }}",
-                id
-            ),
+            Action::Popup { popup, .. } => {
+                write!(f, "Action::PopupAction::Popup {{ popup: {:?} }}", popup)
+            }
+            Action::Destroy { id } => write!(f, "Action::PopupAction::Destroy {{ id: {:?} }}", id),
             Action::Size { id, width, height } => write!(
                 f,
                 "Action::PopupAction::Size {{ id: {:?}, width: {:?}, height: {:?} }}",

--- a/runtime/src/platform_specific/wayland/subsurface.rs
+++ b/runtime/src/platform_specific/wayland/subsurface.rs
@@ -3,9 +3,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-use cctk::sctk::reexports::protocols::xdg::shell::client::xdg_positioner::{
-    Anchor, Gravity,
-};
+use cctk::sctk::reexports::protocols::xdg::shell::client::xdg_positioner::{Anchor, Gravity};
 use iced_core::layout::Limits;
 use iced_core::window::Id;
 use iced_core::{Element, Point, Rectangle, Size};
@@ -74,11 +72,9 @@ impl fmt::Debug for Action {
                 "Action::SubsurfaceAction::Subsurface {{ subsurface: {:?} }}",
                 subsurface
             ),
-            Action::Destroy { id } => write!(
-                f,
-                "Action::SubsurfaceAction::Destroy {{ id: {:?} }}",
-                id
-            ),
+            Action::Destroy { id } => {
+                write!(f, "Action::SubsurfaceAction::Destroy {{ id: {:?} }}", id)
+            }
             Action::Reposition { id, x, y } => write!(
                 f,
                 "Action::SubsurfaceAction::Reposition {{ id: {:?}, x: {:?}, y: {:?} }}",

--- a/runtime/src/system.rs
+++ b/runtime/src/system.rs
@@ -49,9 +49,7 @@ pub struct Information {
 
 /// Returns available system information.
 pub fn information() -> Task<Information> {
-    task::oneshot(|channel| {
-        crate::Action::System(Action::GetInformation(channel))
-    })
+    task::oneshot(|channel| crate::Action::System(Action::GetInformation(channel)))
 }
 
 /// Returns the current system theme.

--- a/runtime/src/task.rs
+++ b/runtime/src/task.rs
@@ -109,10 +109,7 @@ impl<T> Task<T> {
     }
 
     /// Maps the output of a [`Task`] with the given closure.
-    pub fn map<O>(
-        self,
-        mut f: impl FnMut(T) -> O + MaybeSend + 'static,
-    ) -> Task<O>
+    pub fn map<O>(self, mut f: impl FnMut(T) -> O + MaybeSend + 'static) -> Task<O>
     where
         T: MaybeSend + 'static,
         O: MaybeSend + 'static,
@@ -125,10 +122,7 @@ impl<T> Task<T> {
     ///
     /// This is the monadic interface of [`Task`]—analogous to [`Future`] and
     /// [`Stream`].
-    pub fn then<O>(
-        self,
-        mut f: impl FnMut(T) -> Task<O> + MaybeSend + 'static,
-    ) -> Task<O>
+    pub fn then<O>(self, mut f: impl FnMut(T) -> Task<O> + MaybeSend + 'static) -> Task<O>
     where
         T: MaybeSend + 'static,
         O: MaybeSend + 'static,
@@ -136,20 +130,14 @@ impl<T> Task<T> {
         Task {
             stream: match self.stream {
                 None => None,
-                Some(stream) => {
-                    Some(boxed_stream(stream.flat_map(move |action| {
-                        match action.output() {
-                            Ok(output) => {
-                                f(output).stream.unwrap_or_else(|| {
-                                    boxed_stream(stream::empty())
-                                })
-                            }
-                            Err(action) => boxed_stream(stream::once(
-                                async move { action },
-                            )),
-                        }
-                    })))
-                }
+                Some(stream) => Some(boxed_stream(stream.flat_map(move |action| {
+                    match action.output() {
+                        Ok(output) => f(output)
+                            .stream
+                            .unwrap_or_else(|| boxed_stream(stream::empty())),
+                        Err(action) => boxed_stream(stream::once(async move { action })),
+                    }
+                }))),
             },
             units: self.units,
         }
@@ -190,10 +178,7 @@ impl<T> Task<T> {
                             let mut outputs = outputs?;
 
                             let Some(action) = stream.next().await else {
-                                return Some((
-                                    Some(Action::Output(outputs)),
-                                    (stream, None),
-                                ));
+                                return Some((Some(Action::Output(outputs)), (stream, None)));
                             };
 
                             match action.output() {
@@ -202,10 +187,7 @@ impl<T> Task<T> {
 
                                     Some((None, (stream, Some(outputs))))
                                 }
-                                Err(action) => Some((
-                                    Some(action),
-                                    (stream, Some(outputs)),
-                                )),
+                                Err(action) => Some((Some(action), (stream, Some(outputs)))),
                             }
                         },
                     )
@@ -345,10 +327,7 @@ impl Handle {
 impl Drop for Handle {
     fn drop(&mut self) {
         if let InternalHandle::AbortOnDrop(handle) = &mut self.internal {
-            let handle = std::mem::replace(
-                handle,
-                Arc::new(stream::AbortHandle::new_pair().0),
-            );
+            let handle = std::mem::replace(handle, Arc::new(stream::AbortHandle::new_pair().0));
 
             if let Some(handle) = Arc::into_inner(handle) {
                 handle.abort();
@@ -361,10 +340,7 @@ impl<T> Task<Option<T>> {
     /// Executes a new [`Task`] after this one, only when it produces `Some` value.
     ///
     /// The value is provided to the closure to create the subsequent [`Task`].
-    pub fn and_then<A>(
-        self,
-        f: impl Fn(T) -> Task<A> + MaybeSend + 'static,
-    ) -> Task<A>
+    pub fn and_then<A>(self, f: impl Fn(T) -> Task<A> + MaybeSend + 'static) -> Task<A>
     where
         T: MaybeSend + 'static,
         A: MaybeSend + 'static,
@@ -386,17 +362,12 @@ impl<T, E> Task<Result<T, E>> {
         E: MaybeSend + 'static,
         A: MaybeSend + 'static,
     {
-        self.then(move |result| {
-            result.map_or_else(|error| Task::done(Err(error)), &f)
-        })
+        self.then(move |result| result.map_or_else(|error| Task::done(Err(error)), &f))
     }
 
     /// Maps the error type of this [`Task`] to a different one using the given
     /// function.
-    pub fn map_err<E2>(
-        self,
-        f: impl Fn(E) -> E2 + MaybeSend + 'static,
-    ) -> Task<Result<T, E2>>
+    pub fn map_err<E2>(self, f: impl Fn(E) -> E2 + MaybeSend + 'static) -> Task<Result<T, E2>>
     where
         T: MaybeSend + 'static,
         E: MaybeSend + 'static,
@@ -425,10 +396,9 @@ where
     T: Send + 'static,
 {
     channel(move |sender| {
-        let operation =
-            widget::operation::map(Box::new(operation), move |value| {
-                let _ = sender.clone().try_send(value);
-            });
+        let operation = widget::operation::map(Box::new(operation), move |value| {
+            let _ = sender.clone().try_send(value);
+        });
 
         Action::Widget(Box::new(operation))
     })
@@ -445,11 +415,13 @@ where
     let action = f(sender);
 
     Task {
-        stream: Some(boxed_stream(stream::once(async move { action }).chain(
-            receiver.into_stream().filter_map(|result| async move {
-                Some(Action::Output(result.ok()?))
-            }),
-        ))),
+        stream: Some(boxed_stream(
+            stream::once(async move { action }).chain(
+                receiver
+                    .into_stream()
+                    .filter_map(|result| async move { Some(Action::Output(result.ok()?)) }),
+            ),
+        )),
         units: 1,
     }
 }
@@ -542,10 +514,7 @@ async fn yield_now() {
     impl Future for YieldNow {
         type Output = ();
 
-        fn poll(
-            mut self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
-        ) -> task::Poll<()> {
+        fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<()> {
             if self.yielded {
                 return task::Poll::Ready(());
             }

--- a/runtime/src/user_interface.rs
+++ b/runtime/src/user_interface.rs
@@ -10,9 +10,7 @@ use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::widget;
 use crate::core::window;
-use crate::core::{
-    Clipboard, Element, InputMethod, Layout, Rectangle, Shell, Size, Vector,
-};
+use crate::core::{Clipboard, Element, InputMethod, Layout, Rectangle, Shell, Size, Vector};
 
 /// A set of interactive graphical elements with a specific [`Layout`].
 ///
@@ -220,103 +218,101 @@ where
             )
             .map(overlay::Nested::new);
 
-        let (base_cursor, overlay_statuses, overlay_interaction) =
-            if maybe_overlay.is_some() {
-                let bounds = self.bounds;
+        let (base_cursor, overlay_statuses, overlay_interaction) = if maybe_overlay.is_some() {
+            let bounds = self.bounds;
 
-                let mut overlay = maybe_overlay.as_mut().unwrap();
-                let mut layout = overlay.layout(renderer, bounds);
-                let mut event_statuses = Vec::new();
+            let mut overlay = maybe_overlay.as_mut().unwrap();
+            let mut layout = overlay.layout(renderer, bounds);
+            let mut event_statuses = Vec::new();
 
-                for event in events {
-                    let mut shell = Shell::new(messages);
+            for event in events {
+                let mut shell = Shell::new(messages);
 
-                    overlay.update(
-                        event,
-                        Layout::new(&layout),
-                        cursor,
+                overlay.update(
+                    event,
+                    Layout::new(&layout),
+                    cursor,
+                    renderer,
+                    clipboard,
+                    &mut shell,
+                );
+
+                event_statuses.push(shell.event_status());
+                redraw_request = redraw_request.min(shell.redraw_request());
+                input_method.merge(shell.input_method());
+
+                if shell.is_layout_invalid() {
+                    drop(maybe_overlay);
+
+                    self.base = self.root.as_widget_mut().layout(
+                        &mut self.state,
                         renderer,
-                        clipboard,
-                        &mut shell,
+                        &layout::Limits::new(Size::ZERO, self.bounds),
                     );
 
-                    event_statuses.push(shell.event_status());
-                    redraw_request = redraw_request.min(shell.redraw_request());
-                    input_method.merge(shell.input_method());
-
-                    if shell.is_layout_invalid() {
-                        drop(maybe_overlay);
-
-                        self.base = self.root.as_widget_mut().layout(
+                    maybe_overlay = self
+                        .root
+                        .as_widget_mut()
+                        .overlay(
                             &mut self.state,
+                            Layout::new(&self.base),
                             renderer,
-                            &layout::Limits::new(Size::ZERO, self.bounds),
-                        );
+                            &viewport,
+                            Vector::ZERO,
+                        )
+                        .map(overlay::Nested::new);
 
-                        maybe_overlay = self
-                            .root
-                            .as_widget_mut()
-                            .overlay(
-                                &mut self.state,
-                                Layout::new(&self.base),
-                                renderer,
-                                &viewport,
-                                Vector::ZERO,
-                            )
-                            .map(overlay::Nested::new);
-
-                        if maybe_overlay.is_none() {
-                            break;
-                        }
-
-                        overlay = maybe_overlay.as_mut().unwrap();
-
-                        shell.revalidate_layout(|| {
-                            layout = overlay.layout(renderer, bounds);
-                            has_layout_changed = true;
-                        });
+                    if maybe_overlay.is_none() {
+                        break;
                     }
 
-                    if shell.are_widgets_invalid() {
-                        outdated = true;
-                    }
+                    overlay = maybe_overlay.as_mut().unwrap();
+
+                    shell.revalidate_layout(|| {
+                        layout = overlay.layout(renderer, bounds);
+                        has_layout_changed = true;
+                    });
                 }
 
-                let (base_cursor, interaction) =
-                    if let Some(overlay) = maybe_overlay.as_mut() {
-                        let interaction = cursor
-                            .position()
-                            .map(|cursor_position| {
-                                overlay.mouse_interaction(
-                                    Layout::new(&layout),
-                                    mouse::Cursor::Available(cursor_position),
-                                    renderer,
-                                )
-                            })
-                            .unwrap_or_default();
+                if shell.are_widgets_invalid() {
+                    outdated = true;
+                }
+            }
 
-                        if interaction == mouse::Interaction::None {
-                            (cursor, mouse::Interaction::None)
-                        } else {
-                            (mouse::Cursor::Unavailable, interaction)
-                        }
-                    } else {
-                        (cursor, mouse::Interaction::None)
-                    };
+            let (base_cursor, interaction) = if let Some(overlay) = maybe_overlay.as_mut() {
+                let interaction = cursor
+                    .position()
+                    .map(|cursor_position| {
+                        overlay.mouse_interaction(
+                            Layout::new(&layout),
+                            mouse::Cursor::Available(cursor_position),
+                            renderer,
+                        )
+                    })
+                    .unwrap_or_default();
 
-                self.overlay = Some(Overlay {
-                    layout,
-                    interaction,
-                });
-
-                (base_cursor, event_statuses, interaction)
+                if interaction == mouse::Interaction::None {
+                    (cursor, mouse::Interaction::None)
+                } else {
+                    (mouse::Cursor::Unavailable, interaction)
+                }
             } else {
-                (
-                    cursor,
-                    vec![event::Status::Ignored; events.len()],
-                    mouse::Interaction::None,
-                )
+                (cursor, mouse::Interaction::None)
             };
+
+            self.overlay = Some(Overlay {
+                layout,
+                interaction,
+            });
+
+            (base_cursor, event_statuses, interaction)
+        } else {
+            (
+                cursor,
+                vec![event::Status::Ignored; events.len()],
+                mouse::Interaction::None,
+            )
+        };
 
         drop(maybe_overlay);
 
@@ -370,11 +366,8 @@ where
                         .map(overlay::Nested::new)
                     {
                         let layout = overlay.layout(renderer, self.bounds);
-                        let interaction = overlay.mouse_interaction(
-                            Layout::new(&layout),
-                            cursor,
-                            renderer,
-                        );
+                        let interaction =
+                            overlay.mouse_interaction(Layout::new(&layout), cursor, renderer);
 
                         self.overlay = Some(Overlay {
                             layout,
@@ -391,18 +384,17 @@ where
             })
             .collect();
 
-        let mouse_interaction =
-            if overlay_interaction == mouse::Interaction::None {
-                self.root.as_widget().mouse_interaction(
-                    &self.state,
-                    Layout::new(&self.base),
-                    base_cursor,
-                    &viewport,
-                    renderer,
-                )
-            } else {
-                overlay_interaction
-            };
+        let mouse_interaction = if overlay_interaction == mouse::Interaction::None {
+            self.root.as_widget().mouse_interaction(
+                &self.state,
+                Layout::new(&self.base),
+                base_cursor,
+                &viewport,
+                renderer,
+            )
+        } else {
+            overlay_interaction
+        };
 
         (
             if outdated {
@@ -549,11 +541,7 @@ where
     }
 
     /// Applies a [`widget::Operation`] to the [`UserInterface`].
-    pub fn operate(
-        &mut self,
-        renderer: &Renderer,
-        operation: &mut dyn widget::Operation,
-    ) {
+    pub fn operate(&mut self, renderer: &Renderer, operation: &mut dyn widget::Operation) {
         let viewport = Rectangle::with_size(self.bounds);
 
         self.root.as_widget_mut().operate(
@@ -604,15 +592,10 @@ where
 
     /// get a11y nodes
     #[cfg(feature = "a11y")]
-    pub fn a11y_nodes(
-        &self,
-        cursor: mouse::Cursor,
-    ) -> iced_accessibility::A11yTree {
-        self.root.as_widget().a11y_nodes(
-            Layout::new(&self.base),
-            &self.state,
-            cursor,
-        )
+    pub fn a11y_nodes(&self, cursor: mouse::Cursor) -> iced_accessibility::A11yTree {
+        self.root
+            .as_widget()
+            .a11y_nodes(Layout::new(&self.base), &self.state, cursor)
     }
 
     /// Find widget with given id

--- a/runtime/src/widget/operation.rs
+++ b/runtime/src/widget/operation.rs
@@ -4,15 +4,10 @@ use crate::core::widget::operation;
 use crate::task;
 use crate::{Action, Task};
 
-pub use crate::core::widget::operation::scrollable::{
-    AbsoluteOffset, RelativeOffset,
-};
+pub use crate::core::widget::operation::scrollable::{AbsoluteOffset, RelativeOffset};
 
 /// Snaps the scrollable with the given [`Id`] to the provided [`RelativeOffset`].
-pub fn snap_to<T>(
-    id: impl Into<Id>,
-    offset: impl Into<RelativeOffset<Option<f32>>>,
-) -> Task<T> {
+pub fn snap_to<T>(id: impl Into<Id>, offset: impl Into<RelativeOffset<Option<f32>>>) -> Task<T> {
     task::effect(Action::widget(operation::scrollable::snap_to(
         id.into(),
         offset.into(),
@@ -28,10 +23,7 @@ pub fn snap_to_end<T>(id: impl Into<Id>) -> Task<T> {
 }
 
 /// Scrolls the scrollable with the given [`Id`] to the provided [`AbsoluteOffset`].
-pub fn scroll_to<T>(
-    id: impl Into<Id>,
-    offset: impl Into<AbsoluteOffset<Option<f32>>>,
-) -> Task<T> {
+pub fn scroll_to<T>(id: impl Into<Id>, offset: impl Into<AbsoluteOffset<Option<f32>>>) -> Task<T> {
     task::effect(Action::widget(operation::scrollable::scroll_to(
         id.into(),
         offset.into(),

--- a/runtime/src/widget/selector.rs
+++ b/runtime/src/widget/selector.rs
@@ -1,7 +1,5 @@
 //! Find and query widgets in your applications.
-pub use iced_selector::{
-    Bounded, Candidate, Selector, Target, Text, id, is_focused,
-};
+pub use iced_selector::{Bounded, Candidate, Selector, Target, Text, id, is_focused};
 
 use crate::Task;
 use crate::task;

--- a/runtime/src/window.rs
+++ b/runtime/src/window.rs
@@ -1,8 +1,7 @@
 //! Build window-based GUI applications.
 use crate::core::time::Instant;
 use crate::core::window::{
-    Direction, Event, Icon, Id, Level, Mode, Screenshot, Settings,
-    UserAttention,
+    Direction, Event, Icon, Id, Level, Mode, Screenshot, Settings, UserAttention,
 };
 use crate::core::{Point, Size};
 use crate::futures::Subscription;
@@ -216,9 +215,7 @@ impl<T> Window for T where T: HasWindowHandle + HasDisplayHandle {}
 /// animations without missing any frames.
 pub fn frames() -> Subscription<(Id, Instant)> {
     event::listen_raw(|event, _status, window| match event {
-        crate::core::Event::Window(Event::RedrawRequested(at)) => {
-            Some((window, at))
-        }
+        crate::core::Event::Window(Event::RedrawRequested(at)) => Some((window, at)),
         _ => None,
     })
 }
@@ -234,11 +231,9 @@ pub fn frames() -> Subscription<(Id, Instant)> {
 pub fn wayland_frames() -> Subscription<Instant> {
     event::listen_raw(|event, _status, _window| match event {
         iced_core::Event::Window(Event::RedrawRequested(at))
-        | iced_core::Event::PlatformSpecific(
-            iced_core::event::PlatformSpecific::Wayland(
-                iced_core::event::wayland::Event::Frame(at, _, _),
-            ),
-        ) => Some(at),
+        | iced_core::Event::PlatformSpecific(iced_core::event::PlatformSpecific::Wayland(
+            iced_core::event::wayland::Event::Frame(at, _, _),
+        )) => Some(at),
         _ => None,
     })
 }
@@ -305,9 +300,7 @@ pub fn open(settings: Settings) -> (Id, Task<Id>) {
 
     (
         id,
-        task::oneshot(|channel| {
-            crate::Action::Window(Action::Open(id, settings, channel))
-        }),
+        task::oneshot(|channel| crate::Action::Window(Action::Open(id, settings, channel))),
     )
 }
 
@@ -367,16 +360,12 @@ pub fn set_resize_increments<T>(id: Id, increments: Option<Size>) -> Task<T> {
 
 /// Gets the window size in logical dimensions.
 pub fn size(id: Id) -> Task<Size> {
-    task::oneshot(move |channel| {
-        crate::Action::Window(Action::GetSize(id, channel))
-    })
+    task::oneshot(move |channel| crate::Action::Window(Action::GetSize(id, channel)))
 }
 
 /// Gets the maximized state of the window with the given [`Id`].
 pub fn is_maximized(id: Id) -> Task<bool> {
-    task::oneshot(move |channel| {
-        crate::Action::Window(Action::GetMaximized(id, channel))
-    })
+    task::oneshot(move |channel| crate::Action::Window(Action::GetMaximized(id, channel)))
 }
 
 /// Maximizes the window.
@@ -386,9 +375,7 @@ pub fn maximize<T>(id: Id, maximized: bool) -> Task<T> {
 
 /// Gets the minimized state of the window with the given [`Id`].
 pub fn is_minimized(id: Id) -> Task<Option<bool>> {
-    task::oneshot(move |channel| {
-        crate::Action::Window(Action::GetMinimized(id, channel))
-    })
+    task::oneshot(move |channel| crate::Action::Window(Action::GetMinimized(id, channel)))
 }
 
 /// Minimizes the window.
@@ -398,16 +385,12 @@ pub fn minimize<T>(id: Id, minimized: bool) -> Task<T> {
 
 /// Gets the position in logical coordinates of the window with the given [`Id`].
 pub fn position(id: Id) -> Task<Option<Point>> {
-    task::oneshot(move |channel| {
-        crate::Action::Window(Action::GetPosition(id, channel))
-    })
+    task::oneshot(move |channel| crate::Action::Window(Action::GetPosition(id, channel)))
 }
 
 /// Gets the scale factor of the window with the given [`Id`].
 pub fn scale_factor(id: Id) -> Task<f32> {
-    task::oneshot(move |channel| {
-        crate::Action::Window(Action::GetScaleFactor(id, channel))
-    })
+    task::oneshot(move |channel| crate::Action::Window(Action::GetScaleFactor(id, channel)))
 }
 
 /// Moves the window to the given logical coordinates.
@@ -417,9 +400,7 @@ pub fn move_to<T>(id: Id, position: Point) -> Task<T> {
 
 /// Gets the current [`Mode`] of the window.
 pub fn mode(id: Id) -> Task<Mode> {
-    task::oneshot(move |channel| {
-        crate::Action::Window(Action::GetMode(id, channel))
-    })
+    task::oneshot(move |channel| crate::Action::Window(Action::GetMode(id, channel)))
 }
 
 /// Changes the [`Mode`] of the window.
@@ -443,10 +424,7 @@ pub fn toggle_decorations<T>(id: Id) -> Task<T> {
 ///
 /// Providing `None` will unset the request for user attention. Unsetting the request for
 /// user attention might not be done automatically by the WM when the window receives input.
-pub fn request_user_attention<T>(
-    id: Id,
-    user_attention: Option<UserAttention>,
-) -> Task<T> {
+pub fn request_user_attention<T>(id: Id, user_attention: Option<UserAttention>) -> Task<T> {
     task::effect(crate::Action::Window(Action::RequestUserAttention(
         id,
         user_attention,
@@ -478,9 +456,7 @@ pub fn show_system_menu<T>(id: Id) -> Task<T> {
 /// Gets an identifier unique to the window, provided by the underlying windowing system. This is
 /// not to be confused with [`Id`].
 pub fn raw_id<Message>(id: Id) -> Task<u64> {
-    task::oneshot(|channel| {
-        crate::Action::Window(Action::GetRawId(id, channel))
-    })
+    task::oneshot(|channel| crate::Action::Window(Action::GetRawId(id, channel)))
 }
 
 /// Changes the [`Icon`] of the window.
@@ -491,10 +467,7 @@ pub fn set_icon<T>(id: Id, icon: Icon) -> Task<T> {
 /// Runs the given callback with a reference to the [`Window`] with the given [`Id`].
 ///
 /// Note that if the window closes before this call is processed the callback will not be run.
-pub fn run<T>(
-    id: Id,
-    f: impl FnOnce(&dyn Window) -> T + Send + 'static,
-) -> Task<T>
+pub fn run<T>(id: Id, f: impl FnOnce(&dyn Window) -> T + Send + 'static) -> Task<T>
 where
     T: Send + 'static,
 {
@@ -511,10 +484,7 @@ where
 /// Runs the given callback with the native window handle for the window with the given id.
 ///
 /// Note that if the window closes before this call is processed the callback will not be run.
-pub fn run_with_handle<T>(
-    id: Id,
-    f: impl FnOnce(WindowHandle<'_>) -> T + Send + 'static,
-) -> Task<T>
+pub fn run_with_handle<T>(id: Id, f: impl FnOnce(WindowHandle<'_>) -> T + Send + 'static) -> Task<T>
 where
     T: Send + 'static,
 {
@@ -530,9 +500,7 @@ where
 
 /// Captures a [`Screenshot`] from the window.
 pub fn screenshot(id: Id) -> Task<Screenshot> {
-    task::oneshot(move |channel| {
-        crate::Action::Window(Action::Screenshot(id, channel))
-    })
+    task::oneshot(move |channel| crate::Action::Window(Action::Screenshot(id, channel)))
 }
 
 /// Enables mouse passthrough for the given window.
@@ -553,9 +521,7 @@ pub fn disable_mouse_passthrough<Message>(id: Id) -> Task<Message> {
 
 /// Gets the logical dimensions of the monitor containing the window with the given [`Id`].
 pub fn monitor_size(id: Id) -> Task<Option<Size>> {
-    task::oneshot(move |channel| {
-        crate::Action::Window(Action::GetMonitorSize(id, channel))
-    })
+    task::oneshot(move |channel| crate::Action::Window(Action::GetMonitorSize(id, channel)))
 }
 
 /// Sets whether the system can automatically organize windows into tabs.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-max_width=80
-edition="2024"

--- a/selector/src/find.rs
+++ b/selector/src/find.rs
@@ -1,7 +1,5 @@
 use crate::Selector;
-use crate::core::widget::operation::{
-    Focusable, Outcome, Scrollable, TextInput,
-};
+use crate::core::widget::operation::{Focusable, Outcome, Scrollable, TextInput};
 use crate::core::widget::{Id, Operation};
 use crate::core::{Rectangle, Vector};
 use crate::target::Candidate;
@@ -136,10 +134,7 @@ where
     S: Strategy + Send,
     S::Output: Send,
 {
-    fn traverse(
-        &mut self,
-        operate: &mut dyn FnMut(&mut dyn Operation<S::Output>),
-    ) {
+    fn traverse(&mut self, operate: &mut dyn FnMut(&mut dyn Operation<S::Output>)) {
         if self.strategy.is_done() {
             return;
         }
@@ -161,18 +156,11 @@ where
         self.strategy.feed(Candidate::Container {
             id,
             bounds,
-            visible_bounds: self
-                .viewport
-                .intersection(&(bounds + self.translation)),
+            visible_bounds: self.viewport.intersection(&(bounds + self.translation)),
         });
     }
 
-    fn focusable(
-        &mut self,
-        id: Option<&Id>,
-        bounds: Rectangle,
-        state: &mut dyn Focusable,
-    ) {
+    fn focusable(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Focusable) {
         if self.strategy.is_done() {
             return;
         }
@@ -180,9 +168,7 @@ where
         self.strategy.feed(Candidate::Focusable {
             id,
             bounds,
-            visible_bounds: self
-                .viewport
-                .intersection(&(bounds + self.translation)),
+            visible_bounds: self.viewport.intersection(&(bounds + self.translation)),
             state,
         });
     }
@@ -199,8 +185,7 @@ where
             return;
         }
 
-        let visible_bounds =
-            self.viewport.intersection(&(bounds + self.translation));
+        let visible_bounds = self.viewport.intersection(&(bounds + self.translation));
 
         self.strategy.feed(Candidate::Scrollable {
             id,
@@ -215,12 +200,7 @@ where
         self.viewport = visible_bounds.unwrap_or_default();
     }
 
-    fn text_input(
-        &mut self,
-        id: Option<&Id>,
-        bounds: Rectangle,
-        state: &mut dyn TextInput,
-    ) {
+    fn text_input(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn TextInput) {
         if self.strategy.is_done() {
             return;
         }
@@ -228,9 +208,7 @@ where
         self.strategy.feed(Candidate::TextInput {
             id,
             bounds,
-            visible_bounds: self
-                .viewport
-                .intersection(&(bounds + self.translation)),
+            visible_bounds: self.viewport.intersection(&(bounds + self.translation)),
             state,
         });
     }
@@ -243,19 +221,12 @@ where
         self.strategy.feed(Candidate::Text {
             id,
             bounds,
-            visible_bounds: self
-                .viewport
-                .intersection(&(bounds + self.translation)),
+            visible_bounds: self.viewport.intersection(&(bounds + self.translation)),
             content: text,
         });
     }
 
-    fn custom(
-        &mut self,
-        id: Option<&Id>,
-        bounds: Rectangle,
-        state: &mut dyn Any,
-    ) {
+    fn custom(&mut self, id: Option<&Id>, bounds: Rectangle, state: &mut dyn Any) {
         if self.strategy.is_done() {
             return;
         }
@@ -263,9 +234,7 @@ where
         self.strategy.feed(Candidate::Custom {
             id,
             bounds,
-            visible_bounds: self
-                .viewport
-                .intersection(&(bounds + self.translation)),
+            visible_bounds: self.viewport.intersection(&(bounds + self.translation)),
             state,
         });
     }

--- a/selector/src/target.rs
+++ b/selector/src/target.rs
@@ -274,8 +274,9 @@ impl Text {
     /// Returns the visible bounds of the [`Text`], in screen coordinates.
     pub fn visible_bounds(&self) -> Option<Rectangle> {
         match self {
-            Text::Raw { visible_bounds, .. }
-            | Text::Input { visible_bounds, .. } => *visible_bounds,
+            Text::Raw { visible_bounds, .. } | Text::Input { visible_bounds, .. } => {
+                *visible_bounds
+            }
         }
     }
 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -37,8 +37,7 @@ use crate::theme;
 use crate::shell;
 use crate::window;
 use crate::{
-    Element, Executor, Font, Never, Preset, Result, Settings, Size,
-    Subscription, Theme, message,
+    Element, Executor, Font, Never, Preset, Result, Settings, Size, Subscription, Theme, message,
     program::{self, Program},
     task::Task,
 };
@@ -355,13 +354,9 @@ impl<P: Program> Application<P> {
     pub fn title(
         self,
         title: impl TitleFn<P::State>,
-    ) -> Application<
-        impl Program<State = P::State, Message = P::Message, Theme = P::Theme>,
-    > {
+    ) -> Application<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Application {
-            raw: program::with_title(self.raw, move |state, _window| {
-                title.title(state)
-            }),
+            raw: program::with_title(self.raw, move |state, _window| title.title(state)),
             settings: self.settings,
             window: self.window,
             presets: self.presets,
@@ -372,9 +367,7 @@ impl<P: Program> Application<P> {
     pub fn subscription(
         self,
         f: impl Fn(&P::State) -> Subscription<P::Message>,
-    ) -> Application<
-        impl Program<State = P::State, Message = P::Message, Theme = P::Theme>,
-    > {
+    ) -> Application<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Application {
             raw: program::with_subscription(self.raw, f),
             settings: self.settings,
@@ -387,13 +380,9 @@ impl<P: Program> Application<P> {
     pub fn theme(
         self,
         f: impl ThemeFn<P::State, P::Theme>,
-    ) -> Application<
-        impl Program<State = P::State, Message = P::Message, Theme = P::Theme>,
-    > {
+    ) -> Application<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Application {
-            raw: program::with_theme(self.raw, move |state, _window| {
-                f.theme(state)
-            }),
+            raw: program::with_theme(self.raw, move |state, _window| f.theme(state)),
             settings: self.settings,
             window: self.window,
             presets: self.presets,
@@ -404,9 +393,7 @@ impl<P: Program> Application<P> {
     pub fn style(
         self,
         f: impl Fn(&P::State, &P::Theme) -> theme::Style,
-    ) -> Application<
-        impl Program<State = P::State, Message = P::Message, Theme = P::Theme>,
-    > {
+    ) -> Application<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Application {
             raw: program::with_style(self.raw, f),
             settings: self.settings,
@@ -419,13 +406,9 @@ impl<P: Program> Application<P> {
     pub fn scale_factor(
         self,
         f: impl Fn(&P::State) -> f32,
-    ) -> Application<
-        impl Program<State = P::State, Message = P::Message, Theme = P::Theme>,
-    > {
+    ) -> Application<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Application {
-            raw: program::with_scale_factor(self.raw, move |state, _window| {
-                f(state) as f64
-            }),
+            raw: program::with_scale_factor(self.raw, move |state, _window| f(state) as f64),
             settings: self.settings,
             window: self.window,
             presets: self.presets,
@@ -435,9 +418,7 @@ impl<P: Program> Application<P> {
     /// Sets the executor of the [`Application`].
     pub fn executor<E>(
         self,
-    ) -> Application<
-        impl Program<State = P::State, Message = P::Message, Theme = P::Theme>,
-    >
+    ) -> Application<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>>
     where
         E: Executor,
     {
@@ -454,10 +435,7 @@ impl<P: Program> Application<P> {
     /// Presets can be used to override the default booting strategy
     /// of your application during testing to create reproducible
     /// environments.
-    pub fn presets(
-        self,
-        presets: impl IntoIterator<Item = Preset<P::State, P::Message>>,
-    ) -> Self {
+    pub fn presets(self, presets: impl IntoIterator<Item = Preset<P::State, P::Message>>) -> Self {
         Self {
             presets: presets.into_iter().collect(),
             ..self
@@ -484,9 +462,7 @@ impl<P: Program> Program for Application<P> {
         Some(self.window.clone())
     }
 
-    fn boot(
-        &self,
-    ) -> (<Self as Program>::State, Task<<Self as Program>::Message>) {
+    fn boot(&self) -> (<Self as Program>::State, Task<<Self as Program>::Message>) {
         self.raw.boot()
     }
 
@@ -511,11 +487,7 @@ impl<P: Program> Program for Application<P> {
         debug::hot(|| self.raw.view(state, window))
     }
 
-    fn title(
-        &self,
-        state: &<Self as Program>::State,
-        window: window::Id,
-    ) -> String {
+    fn title(&self, state: &<Self as Program>::State, window: window::Id) -> String {
         debug::hot(|| self.raw.title(state, window))
     }
 
@@ -542,17 +514,11 @@ impl<P: Program> Program for Application<P> {
         debug::hot(|| self.raw.style(state, theme))
     }
 
-    fn scale_factor(
-        &self,
-        state: &<Self as Program>::State,
-        window: window::Id,
-    ) -> f64 {
+    fn scale_factor(&self, state: &<Self as Program>::State, window: window::Id) -> f64 {
         debug::hot(|| self.raw.scale_factor(state, window))
     }
 
-    fn presets(
-        &self,
-    ) -> &[Preset<<Self as Program>::State, <Self as Program>::Message>] {
+    fn presets(&self) -> &[Preset<<Self as Program>::State, <Self as Program>::Message>] {
         &self.presets
     }
 }
@@ -658,8 +624,8 @@ pub trait ViewFn<'a, State, Message, Theme, Renderer> {
     fn view(&self, state: &'a State) -> Element<'a, Message, Theme, Renderer>;
 }
 
-impl<'a, T, State, Message, Theme, Renderer, Widget>
-    ViewFn<'a, State, Message, Theme, Renderer> for T
+impl<'a, T, State, Message, Theme, Renderer, Widget> ViewFn<'a, State, Message, Theme, Renderer>
+    for T
 where
     T: Fn(&'a State) -> Widget,
     State: 'static,

--- a/src/application/timed.rs
+++ b/src/application/timed.rs
@@ -25,9 +25,7 @@ pub fn timed<State, Message, Theme, Renderer>(
     update: impl UpdateFn<State, Message>,
     subscription: impl Fn(&State) -> Subscription<Message>,
     view: impl for<'a> ViewFn<'a, State, Message, Theme, Renderer>,
-) -> Application<
-    impl Program<State = State, Message = (Message, Instant), Theme = Theme>,
->
+) -> Application<impl Program<State = State, Message = (Message, Instant), Theme = Theme>>
 where
     State: 'static,
     Message: Send + 'static,
@@ -36,16 +34,7 @@ where
 {
     use std::marker::PhantomData;
 
-    struct Instance<
-        State,
-        Message,
-        Theme,
-        Renderer,
-        Boot,
-        Update,
-        Subscription,
-        View,
-    > {
+    struct Instance<State, Message, Theme, Renderer, Boot, Update, Subscription, View> {
         boot: Boot,
         update: Update,
         subscription: Subscription,
@@ -56,18 +45,8 @@ where
         _renderer: PhantomData<Renderer>,
     }
 
-    impl<State, Message, Theme, Renderer, Boot, Update, Subscription, View>
-        Program
-        for Instance<
-            State,
-            Message,
-            Theme,
-            Renderer,
-            Boot,
-            Update,
-            Subscription,
-            View,
-        >
+    impl<State, Message, Theme, Renderer, Boot, Update, Subscription, View> Program
+        for Instance<State, Message, Theme, Renderer, Boot, Update, Subscription, View>
     where
         Message: Send + 'static,
         Theme: theme::Base + 'static,
@@ -137,10 +116,7 @@ where
             &self,
             state: &<Self as Program>::State,
         ) -> self::Subscription<<Self as Program>::Message> {
-            debug::hot(|| {
-                (self.subscription)(state)
-                    .map(|message| (message, Instant::now()))
-            })
+            debug::hot(|| (self.subscription)(state).map(|message| (message, Instant::now())))
         }
     }
 
@@ -167,12 +143,8 @@ where
 /// but it also takes an [`Instant`].
 pub trait UpdateFn<State, Message> {
     /// Processes the message and updates the state of the [`Application`].
-    fn update(
-        &self,
-        state: &mut State,
-        message: Message,
-        now: Instant,
-    ) -> impl Into<Task<Message>>;
+    fn update(&self, state: &mut State, message: Message, now: Instant)
+    -> impl Into<Task<Message>>;
 }
 
 impl<State, Message> UpdateFn<State, Message> for () {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -6,10 +6,7 @@ pub use crate::program::{self, Program};
 use crate::shell;
 use crate::theme;
 use crate::window;
-use crate::{
-    Element, Executor, Font, Preset, Result, Settings, Subscription, Theme,
-    task::Task,
-};
+use crate::{Element, Executor, Font, Preset, Result, Settings, Subscription, Theme, task::Task};
 
 use iced_debug as debug;
 
@@ -81,10 +78,7 @@ where
             None
         }
 
-        fn boot(
-            &self,
-        ) -> (<Self as Program>::State, Task<<Self as Program>::Message>)
-        {
+        fn boot(&self) -> (<Self as Program>::State, Task<<Self as Program>::Message>) {
             self.boot.boot()
         }
 
@@ -203,13 +197,9 @@ impl<P: Program> Daemon<P> {
     pub fn title(
         self,
         title: impl TitleFn<P::State>,
-    ) -> Daemon<
-        impl Program<State = P::State, Message = P::Message, Theme = P::Theme>,
-    > {
+    ) -> Daemon<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Daemon {
-            raw: program::with_title(self.raw, move |state, window| {
-                title.title(state, window)
-            }),
+            raw: program::with_title(self.raw, move |state, window| title.title(state, window)),
             settings: self.settings,
             presets: self.presets,
         }
@@ -219,9 +209,7 @@ impl<P: Program> Daemon<P> {
     pub fn subscription(
         self,
         f: impl Fn(&P::State) -> Subscription<P::Message>,
-    ) -> Daemon<
-        impl Program<State = P::State, Message = P::Message, Theme = P::Theme>,
-    > {
+    ) -> Daemon<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Daemon {
             raw: program::with_subscription(self.raw, f),
             settings: self.settings,
@@ -233,13 +221,9 @@ impl<P: Program> Daemon<P> {
     pub fn theme(
         self,
         f: impl ThemeFn<P::State, P::Theme>,
-    ) -> Daemon<
-        impl Program<State = P::State, Message = P::Message, Theme = P::Theme>,
-    > {
+    ) -> Daemon<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Daemon {
-            raw: program::with_theme(self.raw, move |state, window| {
-                f.theme(state, window)
-            }),
+            raw: program::with_theme(self.raw, move |state, window| f.theme(state, window)),
             settings: self.settings,
             presets: self.presets,
         }
@@ -249,9 +233,7 @@ impl<P: Program> Daemon<P> {
     pub fn style(
         self,
         f: impl Fn(&P::State, &P::Theme) -> theme::Style,
-    ) -> Daemon<
-        impl Program<State = P::State, Message = P::Message, Theme = P::Theme>,
-    > {
+    ) -> Daemon<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Daemon {
             raw: program::with_style(self.raw, f),
             settings: self.settings,
@@ -263,9 +245,7 @@ impl<P: Program> Daemon<P> {
     pub fn scale_factor(
         self,
         f: impl Fn(&P::State, window::Id) -> f64,
-    ) -> Daemon<
-        impl Program<State = P::State, Message = P::Message, Theme = P::Theme>,
-    > {
+    ) -> Daemon<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>> {
         Daemon {
             raw: program::with_scale_factor(self.raw, f),
             settings: self.settings,
@@ -276,9 +256,7 @@ impl<P: Program> Daemon<P> {
     /// Sets the executor of the [`Daemon`].
     pub fn executor<E>(
         self,
-    ) -> Daemon<
-        impl Program<State = P::State, Message = P::Message, Theme = P::Theme>,
-    >
+    ) -> Daemon<impl Program<State = P::State, Message = P::Message, Theme = P::Theme>>
     where
         E: Executor,
     {
@@ -294,10 +272,7 @@ impl<P: Program> Daemon<P> {
     /// Presets can be used to override the default booting strategy
     /// of your application during testing to create reproducible
     /// environments.
-    pub fn presets(
-        self,
-        presets: impl IntoIterator<Item = Preset<P::State, P::Message>>,
-    ) -> Self {
+    pub fn presets(self, presets: impl IntoIterator<Item = Preset<P::State, P::Message>>) -> Self {
         Self {
             presets: presets.into_iter().collect(),
             ..self
@@ -324,9 +299,7 @@ impl<P: Program> Program for Daemon<P> {
         None
     }
 
-    fn boot(
-        &self,
-    ) -> (<Self as Program>::State, Task<<Self as Program>::Message>) {
+    fn boot(&self) -> (<Self as Program>::State, Task<<Self as Program>::Message>) {
         self.raw.boot()
     }
 
@@ -351,11 +324,7 @@ impl<P: Program> Program for Daemon<P> {
         debug::hot(|| self.raw.view(state, window))
     }
 
-    fn title(
-        &self,
-        state: &<Self as Program>::State,
-        window: window::Id,
-    ) -> String {
+    fn title(&self, state: &<Self as Program>::State, window: window::Id) -> String {
         debug::hot(|| self.raw.title(state, window))
     }
 
@@ -382,11 +351,7 @@ impl<P: Program> Program for Daemon<P> {
         debug::hot(|| self.raw.style(state, theme))
     }
 
-    fn scale_factor(
-        &self,
-        state: &<Self as Program>::State,
-        window: window::Id,
-    ) -> f64 {
+    fn scale_factor(&self, state: &<Self as Program>::State, window: window::Id) -> f64 {
         debug::hot(|| self.raw.scale_factor(state, window))
     }
 
@@ -427,25 +392,17 @@ where
 /// returns any `Into<Element<'_, Message>>`.
 pub trait ViewFn<'a, State, Message, Theme, Renderer> {
     /// Produces the widget of the [`Daemon`].
-    fn view(
-        &self,
-        state: &'a State,
-        window: window::Id,
-    ) -> Element<'a, Message, Theme, Renderer>;
+    fn view(&self, state: &'a State, window: window::Id) -> Element<'a, Message, Theme, Renderer>;
 }
 
-impl<'a, T, State, Message, Theme, Renderer, Widget>
-    ViewFn<'a, State, Message, Theme, Renderer> for T
+impl<'a, T, State, Message, Theme, Renderer, Widget> ViewFn<'a, State, Message, Theme, Renderer>
+    for T
 where
     T: Fn(&'a State, window::Id) -> Widget,
     State: 'static,
     Widget: Into<Element<'a, Message, Theme, Renderer>>,
 {
-    fn view(
-        &self,
-        state: &'a State,
-        window: window::Id,
-    ) -> Element<'a, Message, Theme, Renderer> {
+    fn view(&self, state: &'a State, window: window::Id) -> Element<'a, Message, Theme, Renderer> {
         self(state, window).into()
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,16 +27,12 @@ pub enum Error {
 impl From<shell::Error> for Error {
     fn from(error: shell::Error) -> Error {
         match error {
-            shell::Error::ExecutorCreationFailed(error) => {
-                Error::ExecutorCreationFailed(error)
-            }
+            shell::Error::ExecutorCreationFailed(error) => Error::ExecutorCreationFailed(error),
             #[cfg(feature = "winit")]
             shell::Error::WindowCreationFailed(error) => {
                 Error::WindowCreationFailed(Box::new(error))
             }
-            shell::Error::GraphicsCreationFailed(error) => {
-                Error::GraphicsCreationFailed(error)
-            }
+            shell::Error::GraphicsCreationFailed(error) => Error::GraphicsCreationFailed(error),
             shell::Error::EventLoop(error) => Error::EventLoop(Box::new(error)),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -533,9 +533,7 @@ pub mod window;
 
 #[cfg(feature = "winit")]
 pub mod platform_specific {
-    pub use iced_winit::{
-        platform_specific as shell, runtime::platform_specific as runtime,
-    };
+    pub use iced_winit::{platform_specific as shell, runtime::platform_specific as runtime};
 }
 
 #[cfg(feature = "winit")]
@@ -554,10 +552,9 @@ pub use crate::core::gradient;
 pub use crate::core::padding;
 pub use crate::core::theme;
 pub use crate::core::{
-    Alignment, Animation, Background, Border, Color, ContentFit, Degrees,
-    Function, Gradient, Length, Never, Padding, Pixels, Point, Radians,
-    Rectangle, Rotation, Settings, Shadow, Size, Theme, Transformation, Vector,
-    id, layout::Limits, never,
+    Alignment, Animation, Background, Border, Color, ContentFit, Degrees, Function, Gradient,
+    Length, Never, Padding, Pixels, Point, Radians, Rectangle, Rotation, Settings, Shadow, Size,
+    Theme, Transformation, Vector, id, layout::Limits, never,
 };
 pub use crate::program::{Preset, message};
 pub use crate::runtime::exit;
@@ -584,8 +581,8 @@ pub mod task {
 pub mod clipboard {
     //! Access the clipboard.
     pub use crate::runtime::clipboard::{
-        read, read_data, read_primary, read_primary_data, write, write_data,
-        write_primary, write_primary_data,
+        read, read_data, read_primary, read_primary_data, write, write_data, write_primary,
+        write_primary_data,
     };
     pub use dnd;
     pub use mime;
@@ -621,9 +618,7 @@ pub mod keyboard {
 
 pub mod mouse {
     //! Listen and react to mouse events.
-    pub use crate::core::mouse::{
-        Button, Cursor, Event, Interaction, ScrollDelta,
-    };
+    pub use crate::core::mouse::{Button, Cursor, Event, Interaction, ScrollDelta};
 }
 
 pub mod system {
@@ -642,12 +637,8 @@ pub mod overlay {
     /// This is an alias of an [`overlay::Element`] with a default `Renderer`.
     ///
     /// [`overlay::Element`]: crate::core::overlay::Element
-    pub type Element<
-        'a,
-        Message,
-        Theme = crate::Renderer,
-        Renderer = crate::Renderer,
-    > = crate::core::overlay::Element<'a, Message, Theme, Renderer>;
+    pub type Element<'a, Message, Theme = crate::Renderer, Renderer = crate::Renderer> =
+        crate::core::overlay::Element<'a, Message, Theme, Renderer>;
 
     pub use iced_widget::overlay::*;
 }
@@ -689,12 +680,8 @@ pub use window::Window;
 /// A generic widget.
 ///
 /// This is an alias of an `iced_native` element with a default `Renderer`.
-pub type Element<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> = crate::core::Element<'a, Message, Theme, Renderer>;
+pub type Element<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> =
+    crate::core::Element<'a, Message, Theme, Renderer>;
 
 /// The result of running an iced program.
 pub type Result = std::result::Result<(), Error>;
@@ -733,8 +720,7 @@ pub type Result = std::result::Result<(), Error>;
 /// ```
 pub fn run<State, Message, Theme, Renderer>(
     update: impl application::UpdateFn<State, Message> + 'static,
-    view: impl for<'a> application::ViewFn<'a, State, Message, Theme, Renderer>
-    + 'static,
+    view: impl for<'a> application::ViewFn<'a, State, Message, Theme, Renderer> + 'static,
 ) -> Result
 where
     State: Default + 'static,

--- a/src/time.rs
+++ b/src/time.rs
@@ -4,11 +4,7 @@ pub use crate::core::time::*;
 #[allow(unused_imports)]
 #[cfg_attr(
     docsrs,
-    doc(cfg(any(
-        feature = "tokio",
-        feature = "smol",
-        target_arch = "wasm32"
-    )))
+    doc(cfg(any(feature = "tokio", feature = "smol", target_arch = "wasm32")))
 )]
 pub use iced_futures::backend::default::time::*;
 

--- a/test/src/emulator.rs
+++ b/test/src/emulator.rs
@@ -68,12 +68,7 @@ impl<P: Program + 'static> Emulator<P> {
     /// The [`Emulator`] will send [`Event`] notifications through the provided [`mpsc::Sender`].
     ///
     /// When the [`Emulator`] has finished booting, an [`Event::Ready`] will be produced.
-    pub fn new(
-        sender: mpsc::Sender<Event<P>>,
-        program: &P,
-        mode: Mode,
-        size: Size,
-    ) -> Emulator<P> {
+    pub fn new(sender: mpsc::Sender<Event<P>>, program: &P, mode: Mode, size: Size) -> Emulator<P> {
         Self::with_preset(sender, program, mode, size, None)
     }
 
@@ -219,8 +214,7 @@ impl<P: Program + 'static> Emulator<P> {
 
                             let _ = sender.send(self.window);
                         }
-                        window::Action::GetOldest(sender)
-                        | window::Action::GetLatest(sender) => {
+                        window::Action::GetOldest(sender) | window::Action::GetLatest(sender) => {
                             let _ = sender.send(Some(self.window));
                         }
                         window::Action::GetSize(id, sender) => {
@@ -250,8 +244,7 @@ impl<P: Program + 'static> Emulator<P> {
                         }
                         window::Action::GetMode(id, sender) => {
                             if id == self.window {
-                                let _ =
-                                    sender.send(core::window::Mode::Windowed);
+                                let _ = sender.send(core::window::Mode::Windowed);
                             }
                         }
                         _ => {
@@ -321,10 +314,7 @@ impl<P: Program + 'static> Emulator<P> {
                 };
 
                 for event in &events {
-                    if let core::Event::Mouse(mouse::Event::CursorMoved {
-                        position,
-                    }) = event
-                    {
+                    if let core::Event::Mouse(mouse::Event::CursorMoved { position }) = event {
                         self.cursor = mouse::Cursor::Available(*position);
                     }
                 }
@@ -340,9 +330,11 @@ impl<P: Program + 'static> Emulator<P> {
                 self.cache = Some(user_interface.into_cache());
 
                 let task = self.runtime.enter(|| {
-                    Task::batch(messages.into_iter().map(|message| {
-                        program.update(&mut self.state, message)
-                    }))
+                    Task::batch(
+                        messages
+                            .into_iter()
+                            .map(|message| program.update(&mut self.state, message)),
+                    )
                 });
 
                 self.resubscribe(program);
@@ -421,18 +413,13 @@ impl<P: Program + 'static> Emulator<P> {
         self.runtime
             .track(subscription::into_recipes(self.runtime.enter(|| {
                 program.subscription(&self.state).map(|message| {
-                    Event::Action(Action(Action_::Runtime(
-                        runtime::Action::Output(message),
-                    )))
+                    Event::Action(Action(Action_::Runtime(runtime::Action::Output(message))))
                 })
             })));
     }
 
     /// Returns the current view of the [`Emulator`].
-    pub fn view(
-        &self,
-        program: &P,
-    ) -> Element<'_, P::Message, P::Theme, P::Renderer> {
+    pub fn view(&self, program: &P) -> Element<'_, P::Message, P::Theme, P::Renderer> {
         program.view(&self.state, self.window)
     }
 
@@ -484,11 +471,9 @@ impl<P: Program + 'static> Emulator<P> {
             (self.size.height * scale_factor).round() as u32,
         );
 
-        let rgba = self.renderer.screenshot(
-            physical_size,
-            scale_factor,
-            style.background_color,
-        );
+        let rgba = self
+            .renderer
+            .screenshot(physical_size, scale_factor, style.background_color);
 
         window::Screenshot {
             rgba: Bytes::from(rgba),

--- a/test/src/error.rs
+++ b/test/src/error.rs
@@ -46,9 +46,7 @@ pub enum Error {
         instruction: Instruction,
     },
     /// The [`Preset`](crate::program::Preset) of a program could not be found.
-    #[error(
-        "the preset \"{name}\" does not exist (available presets: {available:?})"
-    )]
+    #[error("the preset \"{name}\" does not exist (available presets: {available:?})")]
     PresetNotFound {
         /// The name of the [`Preset`](crate::program::Preset).
         name: String,

--- a/test/src/ice.rs
+++ b/test/src/ice.rs
@@ -78,8 +78,7 @@ impl Ice {
             match field.trim() {
                 "viewport" => {
                     viewport = Some(
-                        if let Some((width, height)) =
-                            value.trim().split_once('x')
+                        if let Some((width, height)) = value.trim().split_once('x')
                             && let Ok(width) = width.parse()
                             && let Ok(height) = height.parse()
                         {
@@ -130,11 +129,9 @@ impl Ice {
             .skip(1)
             .enumerate()
             .map(|(i, line)| {
-                Instruction::parse(line).map_err(|error| {
-                    ParseError::InvalidInstruction {
-                        line: metadata.lines().count() + 1 + i,
-                        error,
-                    }
+                Instruction::parse(line).map_err(|error| ParseError::InvalidInstruction {
+                    line: metadata.lines().count() + 1 + i,
+                    error,
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -153,7 +150,7 @@ impl std::fmt::Display for Ice {
         writeln!(
             f,
             "viewport: {width}x{height}",
-            width = self.viewport.width as u32, // TODO
+            width = self.viewport.width as u32,   // TODO
             height = self.viewport.height as u32, // TODO
         )?;
 

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -181,13 +181,7 @@ pub fn run(
     for (file, ice, preset) in tests {
         let (sender, mut receiver) = mpsc::channel(1);
 
-        let mut emulator = Emulator::with_preset(
-            sender,
-            &program,
-            ice.mode,
-            ice.viewport,
-            preset,
-        );
+        let mut emulator = Emulator::with_preset(sender, &program, ice.mode, ice.viewport, preset);
 
         let mut instructions = ice.instructions.into_iter();
 
@@ -232,12 +226,7 @@ pub fn screenshot<P: program::Program + 'static>(
 
     let (sender, mut receiver) = mpsc::channel(100);
 
-    let mut emulator = Emulator::new(
-        sender,
-        program,
-        emulator::Mode::Immediate,
-        viewport.into(),
-    );
+    let mut emulator = Emulator::new(sender, program, emulator::Mode::Immediate, viewport.into());
 
     let start = Instant::now();
 
@@ -248,9 +237,7 @@ pub fn screenshot<P: program::Program + 'static>(
                     emulator.perform(program, action);
                 }
                 emulator::Event::Failed(_) => {
-                    unreachable!(
-                        "no instructions should be executed during a screenshot"
-                    );
+                    unreachable!("no instructions should be executed during a screenshot");
                 }
                 emulator::Event::Ready => {}
             }

--- a/test/src/simulator.rs
+++ b/test/src/simulator.rs
@@ -23,12 +23,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 /// A user interface that can be interacted with and inspected programmatically.
-pub struct Simulator<
-    'a,
-    Message,
-    Theme = core::Theme,
-    Renderer = renderer::Renderer,
-> {
+pub struct Simulator<'a, Message, Theme = core::Theme, Renderer = renderer::Renderer> {
     raw: UserInterface<'a, Message, Theme, Renderer>,
     renderer: Renderer,
     size: Size,
@@ -42,9 +37,7 @@ where
     Renderer: core::Renderer + core::renderer::Headless,
 {
     /// Creates a new [`Simulator`] with default [`Settings`] and a default size (1024x768).
-    pub fn new(
-        element: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn new(element: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self::with_settings(Settings::default(), element)
     }
 
@@ -117,11 +110,9 @@ where
         );
 
         match operation.finish() {
-            widget::operation::Outcome::Some(output) => {
-                output.ok_or(Error::SelectorNotFound {
-                    selector: description,
-                })
-            }
+            widget::operation::Outcome::Some(output) => output.ok_or(Error::SelectorNotFound {
+                selector: description,
+            }),
             _ => Err(Error::SelectorNotFound {
                 selector: description,
             }),
@@ -178,10 +169,7 @@ where
     }
 
     /// Simulates the given raw sequence of events in the [`Simulator`].
-    pub fn simulate(
-        &mut self,
-        events: impl IntoIterator<Item = Event>,
-    ) -> Vec<event::Status> {
+    pub fn simulate(&mut self, events: impl IntoIterator<Item = Event>) -> Vec<event::Status> {
         let events: Vec<Event> = events.into_iter().collect();
 
         let (_state, statuses) = self.raw.update(
@@ -225,26 +213,18 @@ where
             (self.size.height * scale_factor).round() as u32,
         );
 
-        let rgba = self.renderer.screenshot(
-            physical_size,
-            scale_factor,
-            base.background_color,
-        );
+        let rgba = self
+            .renderer
+            .screenshot(physical_size, scale_factor, base.background_color);
 
         Ok(Snapshot {
-            screenshot: window::Screenshot::new(
-                rgba,
-                physical_size,
-                scale_factor,
-            ),
+            screenshot: window::Screenshot::new(rgba, physical_size, scale_factor),
             renderer: self.renderer.name(),
         })
     }
 
     /// Turns the [`Simulator`] into the sequence of messages produced by any interactions.
-    pub fn into_messages(
-        self,
-    ) -> impl Iterator<Item = Message> + use<Message, Theme, Renderer> {
+    pub fn into_messages(self) -> impl Iterator<Item = Message> + use<Message, Theme, Renderer> {
         self.messages.into_iter()
     }
 }
@@ -367,10 +347,7 @@ pub fn click() -> impl Iterator<Item = Event> {
 }
 
 /// Returns the sequence of events of a key press.
-pub fn press_key(
-    key: impl Into<keyboard::Key>,
-    text: Option<SmolStr>,
-) -> Event {
+pub fn press_key(key: impl Into<keyboard::Key>, text: Option<SmolStr>) -> Event {
     let key = key.into();
 
     Event::Keyboard(keyboard::Event::KeyPressed {

--- a/tester/src/recorder.rs
+++ b/tester/src/recorder.rs
@@ -7,8 +7,8 @@ use crate::core::widget;
 use crate::core::widget::operation;
 use crate::core::widget::tree;
 use crate::core::{
-    self, Clipboard, Color, Element, Event, Layout, Length, Point, Rectangle,
-    Shell, Size, Vector, Widget,
+    self, Clipboard, Color, Element, Event, Layout, Length, Point, Rectangle, Shell, Size, Vector,
+    Widget,
 };
 use crate::test::Selector;
 use crate::test::instruction::{Interaction, Mouse, Target};
@@ -27,9 +27,7 @@ pub struct Recorder<'a, Message, Theme, Renderer> {
 }
 
 impl<'a, Message, Theme, Renderer> Recorder<'a, Message, Theme, Renderer> {
-    pub fn new(
-        content: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn new(content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             content: content.into(),
             on_record: None,
@@ -37,10 +35,7 @@ impl<'a, Message, Theme, Renderer> Recorder<'a, Message, Theme, Renderer> {
         }
     }
 
-    pub fn on_record(
-        mut self,
-        on_record: impl Fn(Interaction) -> Message + 'a,
-    ) -> Self {
+    pub fn on_record(mut self, on_record: impl Fn(Interaction) -> Message + 'a) -> Self {
         self.on_record = Some(Box::new(on_record));
         self
     }
@@ -140,11 +135,9 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        self.content.as_widget_mut().layout(
-            &mut tree.children[0],
-            renderer,
-            limits,
-        )
+        self.content
+            .as_widget_mut()
+            .layout(&mut tree.children[0], renderer, limits)
     }
 
     fn draw(
@@ -208,12 +201,9 @@ where
         renderer: &Renderer,
         operation: &mut dyn widget::Operation,
     ) {
-        self.content.as_widget_mut().operate(
-            &mut tree.children[0],
-            layout,
-            renderer,
-            operation,
-        );
+        self.content
+            .as_widget_mut()
+            .operate(&mut tree.children[0], layout, renderer, operation);
     }
 
     fn overlay<'a>(
@@ -400,14 +390,13 @@ fn record<Message>(
         return;
     }
 
-    let interaction =
-        if let Event::Mouse(mouse::Event::CursorMoved { position }) = event {
-            Interaction::from_event(&Event::Mouse(mouse::Event::CursorMoved {
-                position: *position - (bounds.position() - Point::ORIGIN),
-            }))
-        } else {
-            Interaction::from_event(event)
-        };
+    let interaction = if let Event::Mouse(mouse::Event::CursorMoved { position }) = event {
+        Interaction::from_event(&Event::Mouse(mouse::Event::CursorMoved {
+            position: *position - (bounds.position() - Point::ORIGIN),
+        }))
+    } else {
+        Interaction::from_event(event)
+    };
 
     let Some(mut interaction) = interaction else {
         return;
@@ -463,24 +452,23 @@ fn find_text(
         return None;
     };
 
-    let (content, visible_bounds) =
-        targets.into_iter().rev().find_map(|target| {
-            if let selector::Target::Text {
-                content,
-                visible_bounds,
-                ..
-            }
-            | selector::Target::TextInput {
-                content,
-                visible_bounds,
-                ..
-            } = target
-            {
-                Some((content, visible_bounds))
-            } else {
-                None
-            }
-        })?;
+    let (content, visible_bounds) = targets.into_iter().rev().find_map(|target| {
+        if let selector::Target::Text {
+            content,
+            visible_bounds,
+            ..
+        }
+        | selector::Target::TextInput {
+            content,
+            visible_bounds,
+            ..
+        } = target
+        {
+            Some((content, visible_bounds))
+        } else {
+            None
+        }
+    })?;
 
     let mut by_text = content.clone().find_all();
     operate(&mut operation::black_box(&mut by_text));

--- a/tiny_skia/src/engine.rs
+++ b/tiny_skia/src/engine.rs
@@ -2,9 +2,7 @@ use crate::Primitive;
 use tiny_skia::Transform;
 
 use crate::core::renderer::Quad;
-use crate::core::{
-    Background, Color, Gradient, Rectangle, Size, Transformation, Vector,
-};
+use crate::core::{Background, Color, Gradient, Rectangle, Size, Transformation, Vector};
 use crate::graphics::{Image, Text};
 use crate::text;
 
@@ -44,8 +42,8 @@ impl Engine {
             return;
         }
 
-        let clip_mask = (!physical_bounds.is_within_strict(&clip_bounds))
-            .then_some(clip_mask as &_);
+        let clip_mask =
+            (!physical_bounds.is_within_strict(&clip_bounds)).then_some(clip_mask as &_);
 
         let transform = into_transform(transformation);
 
@@ -101,48 +99,37 @@ impl Engine {
             let colors = (y..y + height)
                 .flat_map(|y| (x..x + width).map(move |x| (x as f32, y as f32)))
                 .filter_map(|(x, y)| {
-                    tiny_skia::Size::from_wh(half_width, half_height).map(
-                        |size| {
-                            let shadow_distance = rounded_box_sdf(
-                                Vector::new(
-                                    x - physical_bounds.position().x
-                                        - (shadow.offset.x
-                                            * transformation.scale_factor())
-                                        - half_width,
-                                    y - physical_bounds.position().y
-                                        - (shadow.offset.y
-                                            * transformation.scale_factor())
-                                        - half_height,
-                                ),
-                                size,
-                                &radii,
-                            )
-                            .max(0.0);
-                            let shadow_alpha = 1.0
-                                - smoothstep(
-                                    -shadow.blur_radius
-                                        * transformation.scale_factor(),
-                                    shadow.blur_radius
-                                        * transformation.scale_factor(),
-                                    shadow_distance,
-                                );
+                    tiny_skia::Size::from_wh(half_width, half_height).map(|size| {
+                        let shadow_distance = rounded_box_sdf(
+                            Vector::new(
+                                x - physical_bounds.position().x
+                                    - (shadow.offset.x * transformation.scale_factor())
+                                    - half_width,
+                                y - physical_bounds.position().y
+                                    - (shadow.offset.y * transformation.scale_factor())
+                                    - half_height,
+                            ),
+                            size,
+                            &radii,
+                        )
+                        .max(0.0);
+                        let shadow_alpha = 1.0
+                            - smoothstep(
+                                -shadow.blur_radius * transformation.scale_factor(),
+                                shadow.blur_radius * transformation.scale_factor(),
+                                shadow_distance,
+                            );
 
-                            let mut color = into_color(shadow.color);
-                            color.apply_opacity(shadow_alpha);
+                        let mut color = into_color(shadow.color);
+                        color.apply_opacity(shadow_alpha);
 
-                            color.to_color_u8().premultiply()
-                        },
-                    )
+                        color.to_color_u8().premultiply()
+                    })
                 })
                 .collect();
 
             if let Some(pixmap) = tiny_skia::IntSize::from_wh(width, height)
-                .and_then(|size| {
-                    tiny_skia::Pixmap::from_vec(
-                        bytemuck::cast_vec(colors),
-                        size,
-                    )
-                })
+                .and_then(|size| tiny_skia::Pixmap::from_vec(bytemuck::cast_vec(colors), size))
             {
                 pixels.draw_pixmap(
                     x as i32,
@@ -159,12 +146,9 @@ impl Engine {
             &path,
             &tiny_skia::Paint {
                 shader: match background {
-                    Background::Color(color) => {
-                        tiny_skia::Shader::SolidColor(into_color(*color))
-                    }
+                    Background::Color(color) => tiny_skia::Shader::SolidColor(into_color(*color)),
                     Background::Gradient(Gradient::Linear(linear)) => {
-                        let (start, end) =
-                            linear.angle.to_distance(&quad.bounds);
+                        let (start, end) = linear.angle.to_distance(&quad.bounds);
 
                         let stops: Vec<tiny_skia::GradientStop> = linear
                             .stops
@@ -191,10 +175,7 @@ impl Engine {
                             },
                             tiny_skia::Point { x: end.x, y: end.y },
                             if stops.is_empty() {
-                                vec![tiny_skia::GradientStop::new(
-                                    0.0,
-                                    tiny_skia::Color::BLACK,
-                                )]
+                                vec![tiny_skia::GradientStop::new(0.0, tiny_skia::Color::BLACK)]
                             } else {
                                 stops
                             },
@@ -241,15 +222,12 @@ impl Engine {
 
             // Stroking a path works well in this case
             if is_simple_border {
-                let border_path =
-                    rounded_rectangle(border_bounds, border_radius);
+                let border_path = rounded_rectangle(border_bounds, border_radius);
 
                 pixels.stroke_path(
                     &border_path,
                     &tiny_skia::Paint {
-                        shader: tiny_skia::Shader::SolidColor(into_color(
-                            quad.border.color,
-                        )),
+                        shader: tiny_skia::Shader::SolidColor(into_color(quad.border.color)),
                         anti_alias: true,
                         ..tiny_skia::Paint::default()
                     },
@@ -263,17 +241,13 @@ impl Engine {
             } else {
                 // Draw corners that have too small border radii as having no border radius,
                 // but mask them with the rounded rectangle with the correct border radius.
-                let mut temp_pixmap = tiny_skia::Pixmap::new(
-                    path_bounds.width as u32,
-                    path_bounds.height as u32,
-                )
-                .unwrap();
+                let mut temp_pixmap =
+                    tiny_skia::Pixmap::new(path_bounds.width as u32, path_bounds.height as u32)
+                        .unwrap();
 
-                let mut quad_mask = tiny_skia::Mask::new(
-                    path_bounds.width as u32,
-                    path_bounds.height as u32,
-                )
-                .unwrap();
+                let mut quad_mask =
+                    tiny_skia::Mask::new(path_bounds.width as u32, path_bounds.height as u32)
+                        .unwrap();
 
                 let zero_bounds = Rectangle {
                     x: 0.0,
@@ -283,12 +257,7 @@ impl Engine {
                 };
                 let path = rounded_rectangle(zero_bounds, fill_border_radius);
 
-                quad_mask.fill_path(
-                    &path,
-                    tiny_skia::FillRule::EvenOdd,
-                    true,
-                    transform,
-                );
+                quad_mask.fill_path(&path, tiny_skia::FillRule::EvenOdd, true, transform);
                 let path_bounds = Rectangle {
                     x: (border_width / 2.0),
                     y: (border_width / 2.0),
@@ -296,15 +265,12 @@ impl Engine {
                     height: path_bounds.height - border_width,
                 };
 
-                let border_radius_path =
-                    rounded_rectangle(path_bounds, border_radius);
+                let border_radius_path = rounded_rectangle(path_bounds, border_radius);
 
                 temp_pixmap.stroke_path(
                     &border_radius_path,
                     &tiny_skia::Paint {
-                        shader: tiny_skia::Shader::SolidColor(into_color(
-                            quad.border.color,
-                        )),
+                        shader: tiny_skia::Shader::SolidColor(into_color(quad.border.color)),
                         anti_alias: true,
                         ..tiny_skia::Paint::default()
                     },
@@ -345,28 +311,26 @@ impl Engine {
                 transformation: local_transformation,
             } => {
                 let transformation = transformation * *local_transformation;
-                let Some(clip_bounds) = clip_bounds
-                    .intersection(&(*local_clip_bounds * transformation))
+                let Some(clip_bounds) =
+                    clip_bounds.intersection(&(*local_clip_bounds * transformation))
                 else {
                     return;
                 };
 
                 let physical_bounds =
-                    Rectangle::new(*position, paragraph.min_bounds)
-                        * transformation;
+                    Rectangle::new(*position, paragraph.min_bounds) * transformation;
 
                 if !clip_bounds.intersects(&physical_bounds) {
                     return;
                 }
 
-                let clip_mask =
-                    match physical_bounds.is_within_strict(&clip_bounds) {
-                        true => None,
-                        false => {
-                            adjust_clip_mask(clip_mask, clip_bounds);
-                            Some(clip_mask as &_)
-                        }
-                    };
+                let clip_mask = match physical_bounds.is_within_strict(&clip_bounds) {
+                    true => None,
+                    false => {
+                        adjust_clip_mask(clip_mask, clip_bounds);
+                        Some(clip_mask as &_)
+                    }
+                };
 
                 self.text_pipeline.draw_paragraph(
                     paragraph,
@@ -385,27 +349,25 @@ impl Engine {
                 transformation: local_transformation,
             } => {
                 let transformation = transformation * *local_transformation;
-                let Some(clip_bounds) = clip_bounds
-                    .intersection(&(*local_clip_bounds * transformation))
+                let Some(clip_bounds) =
+                    clip_bounds.intersection(&(*local_clip_bounds * transformation))
                 else {
                     return;
                 };
 
-                let physical_bounds =
-                    Rectangle::new(*position, editor.bounds) * transformation;
+                let physical_bounds = Rectangle::new(*position, editor.bounds) * transformation;
 
                 if !clip_bounds.intersects(&physical_bounds) {
                     return;
                 }
 
-                let clip_mask =
-                    match physical_bounds.is_within_strict(&clip_bounds) {
-                        true => None,
-                        false => {
-                            adjust_clip_mask(clip_mask, clip_bounds);
-                            Some(clip_mask as &_)
-                        }
-                    };
+                let clip_mask = match physical_bounds.is_within_strict(&clip_bounds) {
+                    true => None,
+                    false => {
+                        adjust_clip_mask(clip_mask, clip_bounds);
+                        Some(clip_mask as &_)
+                    }
+                };
 
                 self.text_pipeline.draw_editor(
                     editor,
@@ -434,14 +396,13 @@ impl Engine {
                     return;
                 }
 
-                let clip_mask =
-                    match physical_bounds.is_within_strict(&clip_bounds) {
-                        true => None,
-                        false => {
-                            adjust_clip_mask(clip_mask, clip_bounds);
-                            Some(clip_mask as &_)
-                        }
-                    };
+                let clip_mask = match physical_bounds.is_within_strict(&clip_bounds) {
+                    true => None,
+                    false => {
+                        adjust_clip_mask(clip_mask, clip_bounds);
+                        Some(clip_mask as &_)
+                    }
+                };
 
                 self.text_pipeline.draw_cached(
                     content,
@@ -481,8 +442,8 @@ impl Engine {
                     return;
                 }
 
-                let clip_mask = (!physical_bounds.is_within(&clip_bounds))
-                    .then_some(clip_mask as &_);
+                let clip_mask =
+                    (!physical_bounds.is_within(&clip_bounds)).then_some(clip_mask as &_);
 
                 self.text_pipeline.draw_raw(
                     &buffer,
@@ -521,8 +482,8 @@ impl Engine {
                     return;
                 }
 
-                let clip_mask = (!physical_bounds.is_within(&clip_bounds))
-                    .then_some(clip_mask as &_);
+                let clip_mask =
+                    (!physical_bounds.is_within(&clip_bounds)).then_some(clip_mask as &_);
 
                 pixels.fill_path(
                     path,
@@ -552,8 +513,8 @@ impl Engine {
                     return;
                 }
 
-                let clip_mask = (!physical_bounds.is_within(&clip_bounds))
-                    .then_some(clip_mask as &_);
+                let clip_mask =
+                    (!physical_bounds.is_within(&clip_bounds)).then_some(clip_mask as &_);
 
                 pixels.stroke_path(
                     path,
@@ -583,17 +544,14 @@ impl Engine {
                     return;
                 }
 
-                let clip_mask = (!physical_bounds.is_within(&_clip_bounds))
-                    .then_some(_clip_mask as &_);
+                let clip_mask =
+                    (!physical_bounds.is_within(&_clip_bounds)).then_some(_clip_mask as &_);
 
                 let center = physical_bounds.center();
                 let radians = f32::from(image.rotation);
 
-                let transform = Transform::default().post_rotate_at(
-                    radians.to_degrees(),
-                    center.x,
-                    center.y,
-                );
+                let transform =
+                    Transform::default().post_rotate_at(radians.to_degrees(), center.x, center.y);
 
                 self.raster_pipeline.draw(
                     &image.handle,
@@ -614,8 +572,8 @@ impl Engine {
                     return;
                 }
 
-                let clip_mask = (!physical_bounds.is_within(&_clip_bounds))
-                    .then_some(_clip_mask as &_);
+                let clip_mask =
+                    (!physical_bounds.is_within(&_clip_bounds)).then_some(_clip_mask as &_);
 
                 let center = physical_bounds.center();
                 let radians = f32::from(svg.rotation);
@@ -638,15 +596,11 @@ impl Engine {
             }
             #[cfg(not(feature = "image"))]
             Image::Raster { .. } => {
-                log::warn!(
-                    "Unsupported primitive in `iced_tiny_skia`: {image:?}",
-                );
+                log::warn!("Unsupported primitive in `iced_tiny_skia`: {image:?}",);
             }
             #[cfg(not(feature = "svg"))]
             Image::Vector { .. } => {
-                log::warn!(
-                    "Unsupported primitive in `iced_tiny_skia`: {image:?}",
-                );
+                log::warn!("Unsupported primitive in `iced_tiny_skia`: {image:?}",);
             }
         }
     }
@@ -680,25 +634,13 @@ fn into_transform(transformation: Transformation) -> tiny_skia::Transform {
     }
 }
 
-fn rounded_rectangle(
-    bounds: Rectangle,
-    border_radius: [f32; 4],
-) -> tiny_skia::Path {
+fn rounded_rectangle(bounds: Rectangle, border_radius: [f32; 4]) -> tiny_skia::Path {
     let [top_left, top_right, bottom_right, bottom_left] = border_radius;
 
-    if top_left == 0.0
-        && top_right == 0.0
-        && bottom_right == 0.0
-        && bottom_left == 0.0
-    {
+    if top_left == 0.0 && top_right == 0.0 && bottom_right == 0.0 && bottom_left == 0.0 {
         return tiny_skia::PathBuilder::from_rect(
-            tiny_skia::Rect::from_xywh(
-                bounds.x,
-                bounds.y,
-                bounds.width,
-                bounds.height,
-            )
-            .expect("Build quad rectangle"),
+            tiny_skia::Rect::from_xywh(bounds.x, bounds.y, bounds.width, bounds.height)
+                .expect("Build quad rectangle"),
         );
     }
 
@@ -830,11 +772,7 @@ fn smoothstep(a: f32, b: f32, x: f32) -> f32 {
     x * x * (3.0 - 2.0 * x)
 }
 
-fn rounded_box_sdf(
-    to_center: Vector,
-    size: tiny_skia::Size,
-    radii: &[f32],
-) -> f32 {
+fn rounded_box_sdf(to_center: Vector, size: tiny_skia::Size, radii: &[f32]) -> f32 {
     let radius = match (to_center.x > 0.0, to_center.y > 0.0) {
         (true, true) => radii[2],
         (true, false) => radii[1],
@@ -854,13 +792,7 @@ pub fn adjust_clip_mask(clip_mask: &mut tiny_skia::Mask, bounds: Rectangle) {
     let path = {
         let mut builder = tiny_skia::PathBuilder::new();
         builder.push_rect(
-            tiny_skia::Rect::from_xywh(
-                bounds.x,
-                bounds.y,
-                bounds.width,
-                bounds.height,
-            )
-            .unwrap(),
+            tiny_skia::Rect::from_xywh(bounds.x, bounds.y, bounds.width, bounds.height).unwrap(),
         );
 
         builder.finish().unwrap()

--- a/tiny_skia/src/geometry.rs
+++ b/tiny_skia/src/geometry.rs
@@ -96,9 +96,7 @@ impl geometry::frame::Backend for Frame {
     }
 
     fn fill(&mut self, path: &Path, fill: impl Into<Fill>) {
-        let Some(path) =
-            convert_path(path).and_then(|path| path.transform(self.transform))
-        else {
+        let Some(path) = convert_path(path).and_then(|path| path.transform(self.transform)) else {
             return;
         };
 
@@ -114,12 +112,7 @@ impl geometry::frame::Backend for Frame {
         });
     }
 
-    fn fill_rectangle(
-        &mut self,
-        top_left: Point,
-        size: Size,
-        fill: impl Into<Fill>,
-    ) {
+    fn fill_rectangle(&mut self, top_left: Point, size: Size, fill: impl Into<Fill>) {
         let Some(path) = convert_path(&Path::rectangle(top_left, size))
             .and_then(|path| path.transform(self.transform))
         else {
@@ -142,9 +135,7 @@ impl geometry::frame::Backend for Frame {
     }
 
     fn stroke<'a>(&mut self, path: &Path, stroke: impl Into<Stroke<'a>>) {
-        let Some(path) =
-            convert_path(path).and_then(|path| path.transform(self.transform))
-        else {
+        let Some(path) = convert_path(path).and_then(|path| path.transform(self.transform)) else {
             return;
         };
 
@@ -161,12 +152,7 @@ impl geometry::frame::Backend for Frame {
         });
     }
 
-    fn stroke_rectangle<'a>(
-        &mut self,
-        top_left: Point,
-        size: Size,
-        stroke: impl Into<Stroke<'a>>,
-    ) {
+    fn stroke_rectangle<'a>(&mut self, top_left: Point, size: Size, stroke: impl Into<Stroke<'a>>) {
         self.stroke(&Path::rectangle(top_left, size), stroke);
     }
 
@@ -175,17 +161,10 @@ impl geometry::frame::Backend for Frame {
 
         let (scale_x, scale_y) = self.transform.get_scale();
 
-        if !self.transform.has_skew()
-            && scale_x == scale_y
-            && scale_x > 0.0
-            && scale_y > 0.0
-        {
+        if !self.transform.has_skew() && scale_x == scale_y && scale_x > 0.0 && scale_y > 0.0 {
             let (bounds, size, line_height) = if self.transform.is_identity() {
                 (
-                    Rectangle::new(
-                        text.position,
-                        Size::new(text.max_width, f32::INFINITY),
-                    ),
+                    Rectangle::new(text.position, Size::new(text.max_width, f32::INFINITY)),
                     text.size,
                     text.line_height,
                 )
@@ -200,12 +179,8 @@ impl geometry::frame::Backend for Frame {
                 let size = text.size.0 * scale_y;
 
                 let line_height = match text.line_height {
-                    LineHeight::Absolute(size) => {
-                        LineHeight::Absolute(Pixels(size.0 * scale_y))
-                    }
-                    LineHeight::Relative(factor) => {
-                        LineHeight::Relative(factor)
-                    }
+                    LineHeight::Absolute(size) => LineHeight::Absolute(Pixels(size.0 * scale_y)),
+                    LineHeight::Relative(factor) => LineHeight::Relative(factor),
                 };
 
                 (
@@ -238,11 +213,7 @@ impl geometry::frame::Backend for Frame {
         }
     }
 
-    fn stroke_text<'a>(
-        &mut self,
-        text: impl Into<geometry::Text>,
-        stroke: impl Into<Stroke<'a>>,
-    ) {
+    fn stroke_text<'a>(&mut self, text: impl Into<geometry::Text>, stroke: impl Into<Stroke<'a>>) {
         let text = text.into();
         let stroke = stroke.into();
 
@@ -268,14 +239,13 @@ impl geometry::frame::Backend for Frame {
     }
 
     fn translate(&mut self, translation: Vector) {
-        self.transform =
-            self.transform.pre_translate(translation.x, translation.y);
+        self.transform = self.transform.pre_translate(translation.x, translation.y);
     }
 
     fn rotate(&mut self, angle: impl Into<Radians>) {
-        self.transform = self.transform.pre_concat(
-            tiny_skia::Transform::from_rotate(angle.into().0.to_degrees()),
-        );
+        self.transform = self.transform.pre_concat(tiny_skia::Transform::from_rotate(
+            angle.into().0.to_degrees(),
+        ));
     }
 
     fn scale(&mut self, scale: impl Into<f32>) {
@@ -302,8 +272,7 @@ impl geometry::frame::Backend for Frame {
     fn draw_image(&mut self, bounds: Rectangle, image: impl Into<core::Image>) {
         let mut image = image.into();
 
-        let (bounds, external_rotation) =
-            transform_rectangle(bounds, self.transform);
+        let (bounds, external_rotation) = transform_rectangle(bounds, self.transform);
 
         image.rotation += external_rotation;
 
@@ -317,8 +286,7 @@ impl geometry::frame::Backend for Frame {
     fn draw_svg(&mut self, bounds: Rectangle, svg: impl Into<Svg>) {
         let mut svg = svg.into();
 
-        let (bounds, external_rotation) =
-            transform_rectangle(bounds, self.transform);
+        let (bounds, external_rotation) = transform_rectangle(bounds, self.transform);
 
         svg.rotation += external_rotation;
 
@@ -401,8 +369,7 @@ fn convert_path(path: &Path) -> Option<tiny_skia::Path> {
                     builder.move_to(from.x, from.y);
                 }
 
-                builder
-                    .cubic_to(ctrl1.x, ctrl1.y, ctrl2.x, ctrl2.y, to.x, to.y);
+                builder.cubic_to(ctrl1.x, ctrl1.y, ctrl2.x, ctrl2.y, to.x, to.y);
 
                 last_point = to;
             }
@@ -461,10 +428,7 @@ pub fn into_paint(style: Style) -> tiny_skia::Paint<'static> {
                             y: linear.end.y,
                         },
                         if stops.is_empty() {
-                            vec![tiny_skia::GradientStop::new(
-                                0.0,
-                                tiny_skia::Color::BLACK,
-                            )]
+                            vec![tiny_skia::GradientStop::new(0.0, tiny_skia::Color::BLACK)]
                         } else {
                             stops
                         },

--- a/tiny_skia/src/layer.rs
+++ b/tiny_skia/src/layer.rs
@@ -1,8 +1,6 @@
 use crate::Primitive;
 use crate::core::renderer::Quad;
-use crate::core::{
-    self, Background, Color, Point, Rectangle, Svg, Transformation,
-};
+use crate::core::{self, Background, Color, Point, Rectangle, Svg, Transformation};
 use crate::graphics::damage;
 use crate::graphics::layer;
 use crate::graphics::text::{Editor, Paragraph, Raw, Text};
@@ -83,8 +81,7 @@ impl Layer {
             bounds: Rectangle::new(position, text.bounds) * transformation,
             color,
             size: text.size * transformation.scale_factor(),
-            line_height: text.line_height.to_absolute(text.size)
-                * transformation.scale_factor(),
+            line_height: text.line_height.to_absolute(text.size) * transformation.scale_factor(),
             font: text.font,
             align_x: text.align_x,
             align_y: text.align_y,
@@ -95,11 +92,7 @@ impl Layer {
         self.text.push(Item::Live(text));
     }
 
-    pub fn draw_text_raw(
-        &mut self,
-        raw: graphics::text::Raw,
-        transformation: Transformation,
-    ) {
+    pub fn draw_text_raw(&mut self, raw: graphics::text::Raw, transformation: Transformation) {
         let raw = Text::Raw {
             raw,
             transformation,
@@ -165,8 +158,7 @@ impl Layer {
     ) {
         let image = Image::Raster {
             image: core::Image {
-                border_radius: image.border_radius
-                    * transformation.scale_factor(),
+                border_radius: image.border_radius * transformation.scale_factor(),
                 ..image
             },
             bounds: bounds * transformation,
@@ -268,15 +260,13 @@ impl Layer {
             &current.primitives,
             |item| match item {
                 Item::Live(primitive) => vec![primitive.visible_bounds()],
-                Item::Group(primitives, group_bounds, transformation) => {
-                    primitives
-                        .as_slice()
-                        .iter()
-                        .map(Primitive::visible_bounds)
-                        .map(|bounds| bounds * *transformation)
-                        .filter_map(|bounds| bounds.intersection(group_bounds))
-                        .collect()
-                }
+                Item::Group(primitives, group_bounds, transformation) => primitives
+                    .as_slice()
+                    .iter()
+                    .map(Primitive::visible_bounds)
+                    .map(|bounds| bounds * *transformation)
+                    .filter_map(|bounds| bounds.intersection(group_bounds))
+                    .collect(),
                 Item::Cached(_primitives, bounds, _transformation) => {
                     vec![*bounds]
                 }
@@ -406,16 +396,16 @@ impl<T> Item<T> {
     pub fn transformation(&self) -> Transformation {
         match self {
             Item::Live(_) => Transformation::IDENTITY,
-            Item::Group(_, _, transformation)
-            | Item::Cached(_, _, transformation) => *transformation,
+            Item::Group(_, _, transformation) | Item::Cached(_, _, transformation) => {
+                *transformation
+            }
         }
     }
 
     pub fn clip_bounds(&self) -> Rectangle {
         match self {
             Item::Live(_) => Rectangle::INFINITE,
-            Item::Group(_, clip_bounds, _)
-            | Item::Cached(_, clip_bounds, _) => *clip_bounds,
+            Item::Group(_, clip_bounds, _) | Item::Cached(_, clip_bounds, _) => *clip_bounds,
         }
     }
 

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -29,9 +29,7 @@ pub use settings::Settings;
 pub use geometry::Geometry;
 
 use crate::core::renderer;
-use crate::core::{
-    Background, Color, Font, Pixels, Point, Rectangle, Size, Transformation,
-};
+use crate::core::{Background, Color, Font, Pixels, Point, Rectangle, Size, Transformation};
 use crate::engine::Engine;
 use crate::graphics::Viewport;
 use crate::graphics::compositor;
@@ -92,9 +90,7 @@ impl Renderer {
             pixels.fill_path(
                 &path,
                 &tiny_skia::Paint {
-                    shader: tiny_skia::Shader::SolidColor(engine::into_color(
-                        background_color,
-                    )),
+                    shader: tiny_skia::Shader::SolidColor(engine::into_color(background_color)),
                     anti_alias: false,
                     blend_mode: tiny_skia::BlendMode::Source,
                     ..Default::default()
@@ -105,8 +101,7 @@ impl Renderer {
             );
 
             for layer in self.layers.iter() {
-                let Some(layer_bounds) =
-                    damage_bounds.intersection(&(layer.bounds * scale_factor))
+                let Some(layer_bounds) = damage_bounds.intersection(&(layer.bounds * scale_factor))
                 else {
                     continue;
                 };
@@ -132,9 +127,8 @@ impl Renderer {
                     let render_span = debug::render(debug::Primitive::Triangle);
 
                     for group in &layer.primitives {
-                        let Some(group_bounds) = (group.clip_bounds()
-                            * scale_factor)
-                            .intersection(&layer_bounds)
+                        let Some(group_bounds) =
+                            (group.clip_bounds() * scale_factor).intersection(&layer_bounds)
                         else {
                             continue;
                         };
@@ -144,8 +138,7 @@ impl Renderer {
                         for primitive in group.as_slice() {
                             self.engine.draw_primitive(
                                 primitive,
-                                Transformation::scale(scale_factor)
-                                    * group.transformation(),
+                                Transformation::scale(scale_factor) * group.transformation(),
                                 pixels,
                                 clip_mask,
                                 group_bounds,
@@ -181,8 +174,7 @@ impl Renderer {
                         for text in group.as_slice() {
                             self.engine.draw_text(
                                 text,
-                                Transformation::scale(scale_factor)
-                                    * group.transformation(),
+                                Transformation::scale(scale_factor) * group.transformation(),
                                 pixels,
                                 clip_mask,
                                 layer_bounds,
@@ -216,11 +208,7 @@ impl core::Renderer for Renderer {
         self.layers.pop_transformation();
     }
 
-    fn fill_quad(
-        &mut self,
-        quad: renderer::Quad,
-        background: impl Into<Background>,
-    ) {
+    fn fill_quad(&mut self, quad: renderer::Quad, background: impl Into<Background>) {
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_quad(quad, background.into(), transformation);
     }
@@ -232,9 +220,7 @@ impl core::Renderer for Renderer {
     fn allocate_image(
         &mut self,
         _handle: &core::image::Handle,
-        callback: impl FnOnce(Result<core::image::Allocation, core::image::Error>)
-        + Send
-        + 'static,
+        callback: impl FnOnce(Result<core::image::Allocation, core::image::Error>) + Send + 'static,
     ) {
         #[cfg(feature = "image")]
         #[allow(unsafe_code)]
@@ -277,13 +263,7 @@ impl core::text::Renderer for Renderer {
         clip_bounds: Rectangle,
     ) {
         let (layer, transformation) = self.layers.current_mut();
-        layer.draw_paragraph(
-            text,
-            position,
-            color,
-            clip_bounds,
-            transformation,
-        );
+        layer.draw_paragraph(text, position, color, clip_bounds, transformation);
     }
 
     fn fill_editor(
@@ -340,11 +320,7 @@ impl graphics::geometry::Renderer for Renderer {
                 text,
                 clip_bounds,
             } => {
-                layer.draw_primitive_group(
-                    primitives,
-                    clip_bounds,
-                    transformation,
-                );
+                layer.draw_primitive_group(primitives, clip_bounds, transformation);
 
                 for image in images {
                     layer.draw_image(image, transformation);
@@ -353,21 +329,13 @@ impl graphics::geometry::Renderer for Renderer {
                 layer.draw_text_group(text, clip_bounds, transformation);
             }
             Geometry::Cache(cache) => {
-                layer.draw_primitive_cache(
-                    cache.primitives,
-                    cache.clip_bounds,
-                    transformation,
-                );
+                layer.draw_primitive_cache(cache.primitives, cache.clip_bounds, transformation);
 
                 for image in cache.images.iter() {
                     layer.draw_image(image.clone(), transformation);
                 }
 
-                layer.draw_text_cache(
-                    cache.text,
-                    cache.clip_bounds,
-                    transformation,
-                );
+                layer.draw_text_cache(cache.text, cache.clip_bounds, transformation);
             }
         }
     }
@@ -394,19 +362,11 @@ impl core::image::Renderer for Renderer {
         self.engine.raster_pipeline.load(handle)
     }
 
-    fn measure_image(
-        &self,
-        handle: &Self::Handle,
-    ) -> Option<crate::core::Size<u32>> {
+    fn measure_image(&self, handle: &Self::Handle) -> Option<crate::core::Size<u32>> {
         self.engine.raster_pipeline.dimensions(handle)
     }
 
-    fn draw_image(
-        &mut self,
-        image: core::Image,
-        bounds: Rectangle,
-        clip_bounds: Rectangle,
-    ) {
+    fn draw_image(&mut self, image: core::Image, bounds: Rectangle, clip_bounds: Rectangle) {
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_raster(image, bounds, clip_bounds, transformation);
     }
@@ -414,19 +374,11 @@ impl core::image::Renderer for Renderer {
 
 #[cfg(feature = "svg")]
 impl core::svg::Renderer for Renderer {
-    fn measure_svg(
-        &self,
-        handle: &core::svg::Handle,
-    ) -> crate::core::Size<u32> {
+    fn measure_svg(&self, handle: &core::svg::Handle) -> crate::core::Size<u32> {
         self.engine.vector_pipeline.viewport_dimensions(handle)
     }
 
-    fn draw_svg(
-        &mut self,
-        svg: core::Svg,
-        bounds: Rectangle,
-        clip_bounds: Rectangle,
-    ) {
+    fn draw_svg(&mut self, svg: core::Svg, bounds: Rectangle, clip_bounds: Rectangle) {
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_svg(svg, bounds, clip_bounds, transformation);
     }
@@ -442,9 +394,7 @@ impl renderer::Headless for Renderer {
         default_text_size: Pixels,
         backend: Option<&str>,
     ) -> Option<Self> {
-        if backend.is_some_and(|backend| {
-            !["tiny-skia", "tiny_skia"].contains(&backend)
-        }) {
+        if backend.is_some_and(|backend| !["tiny-skia", "tiny_skia"].contains(&backend)) {
             return None;
         }
 

--- a/tiny_skia/src/raster.rs
+++ b/tiny_skia/src/raster.rs
@@ -18,17 +18,12 @@ impl Pipeline {
         }
     }
 
-    pub fn load(
-        &self,
-        handle: &raster::Handle,
-    ) -> Result<raster::Allocation, raster::Error> {
+    pub fn load(&self, handle: &raster::Handle) -> Result<raster::Allocation, raster::Error> {
         let mut cache = self.cache.borrow_mut();
         let image = cache.allocate(handle)?;
 
         #[allow(unsafe_code)]
-        Ok(unsafe {
-            raster::allocate(handle, Size::new(image.width(), image.height()))
-        })
+        Ok(unsafe { raster::allocate(handle, Size::new(image.width(), image.height())) })
     }
 
     pub fn dimensions(&self, handle: &raster::Handle) -> Option<Size<u32>> {
@@ -133,15 +128,12 @@ impl Cache {
                 return Err(raster::Error::Empty);
             }
 
-            let mut buffer =
-                vec![0u32; image.width() as usize * image.height() as usize];
+            let mut buffer = vec![0u32; image.width() as usize * image.height() as usize];
 
             for (i, pixel) in image.pixels().enumerate() {
                 let [r, g, b, a] = pixel.0;
 
-                buffer[i] = bytemuck::cast(
-                    tiny_skia::ColorU8::from_rgba(b, g, r, a).premultiply(),
-                );
+                buffer[i] = bytemuck::cast(tiny_skia::ColorU8::from_rgba(b, g, r, a).premultiply());
             }
 
             let _ = entry.insert(Some(Entry {
@@ -223,8 +215,7 @@ fn border_radius(
         ((width as usize * y as usize) + x as usize) * 4
     }
 
-    let clear_pixel = |img: &mut tiny_skia::PixmapMut<'_>,
-                       (x, y): (u32, u32)| {
+    let clear_pixel = |img: &mut tiny_skia::PixmapMut<'_>, (x, y): (u32, u32)| {
         let pixel = pixel_id(img.width(), (x, y));
         img.data_mut()[pixel..pixel + 4].copy_from_slice(&[0; 4]);
     };

--- a/tiny_skia/src/vector.rs
+++ b/tiny_skia/src/vector.rs
@@ -106,14 +106,10 @@ impl Cache {
 
         if let hash_map::Entry::Vacant(entry) = self.trees.entry(id) {
             let svg = match handle.data() {
-                Data::Path(path) => {
-                    fs::read_to_string(path).ok().and_then(|contents| {
-                        usvg::Tree::from_str(&contents, &options).ok()
-                    })
-                }
-                Data::Bytes(bytes) => {
-                    usvg::Tree::from_data(bytes, &options).ok()
-                }
+                Data::Path(path) => fs::read_to_string(path)
+                    .ok()
+                    .and_then(|contents| usvg::Tree::from_str(&contents, &options).ok()),
+                Data::Bytes(bytes) => usvg::Tree::from_data(bytes, &options).ok(),
             };
 
             let _ = entry.insert(svg);
@@ -174,39 +170,25 @@ impl Cache {
 
             // SVG rendering can panic on malformed or complex vectors.
             // We catch panics to prevent crashes and continue gracefully.
-            let render_result =
-                panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                    resvg::render(tree, transform, &mut image.as_mut());
-                }));
+            let render_result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                resvg::render(tree, transform, &mut image.as_mut());
+            }));
 
             if render_result.is_err() {
-                log::warn!(
-                    "SVG rendering panicked for handle ID: {}",
-                    handle.id()
-                );
+                log::warn!("SVG rendering panicked for handle ID: {}", handle.id());
                 return None;
             }
 
             if let Some([r, g, b, _]) = key.color {
                 // Apply color filter
-                for pixel in
-                    bytemuck::cast_slice_mut::<u8, u32>(image.data_mut())
-                {
+                for pixel in bytemuck::cast_slice_mut::<u8, u32>(image.data_mut()) {
                     *pixel = bytemuck::cast(
-                        tiny_skia::ColorU8::from_rgba(
-                            b,
-                            g,
-                            r,
-                            (*pixel >> 24) as u8,
-                        )
-                        .premultiply(),
+                        tiny_skia::ColorU8::from_rgba(b, g, r, (*pixel >> 24) as u8).premultiply(),
                     );
                 }
             } else {
                 // Swap R and B channels for `softbuffer` presentation
-                for pixel in
-                    bytemuck::cast_slice_mut::<u8, u32>(image.data_mut())
-                {
+                for pixel in bytemuck::cast_slice_mut::<u8, u32>(image.data_mut()) {
                     *pixel = *pixel & 0xFF00_FF00
                         | ((0x0000_00FF & *pixel) << 16)
                         | ((0x00FF_0000 & *pixel) >> 16);

--- a/tiny_skia/src/window/compositor.rs
+++ b/tiny_skia/src/window/compositor.rs
@@ -14,10 +14,7 @@ pub struct Compositor {
 }
 
 pub struct Surface {
-    window: softbuffer::Surface<
-        Box<dyn compositor::Display>,
-        Box<dyn compositor::Window>,
-    >,
+    window: softbuffer::Surface<Box<dyn compositor::Display>, Box<dyn compositor::Window>>,
     clip_mask: tiny_skia::Mask,
     layer_stack: VecDeque<Vec<Layer>>,
     background_color: Color,
@@ -36,9 +33,7 @@ impl crate::graphics::Compositor for Compositor {
         backend: Option<&str>,
     ) -> Result<Self, Error> {
         match backend {
-            None | Some("tiny-skia") | Some("tiny_skia") => {
-                Ok(new(settings.into(), display))
-            }
+            None | Some("tiny-skia") | Some("tiny_skia") => Ok(new(settings.into(), display)),
             Some(backend) => Err(Error::GraphicsAdapterNotFound {
                 backend: "tiny-skia",
                 reason: error::Reason::DidNotMatch {
@@ -49,10 +44,7 @@ impl crate::graphics::Compositor for Compositor {
     }
 
     fn create_renderer(&self) -> Self::Renderer {
-        Renderer::new(
-            self.settings.default_font,
-            self.settings.default_text_size,
-        )
+        Renderer::new(self.settings.default_font, self.settings.default_text_size)
     }
 
     fn create_surface<W: compositor::Window + Clone>(
@@ -61,11 +53,8 @@ impl crate::graphics::Compositor for Compositor {
         width: u32,
         height: u32,
     ) -> Self::Surface {
-        let window = softbuffer::Surface::new(
-            &self.context,
-            Box::new(window.clone()) as _,
-        )
-        .expect("Create softbuffer surface for window");
+        let window = softbuffer::Surface::new(&self.context, Box::new(window.clone()) as _)
+            .expect("Create softbuffer surface for window");
 
         let mut surface = Surface {
             window,
@@ -82,12 +71,7 @@ impl crate::graphics::Compositor for Compositor {
         surface
     }
 
-    fn configure_surface(
-        &mut self,
-        surface: &mut Self::Surface,
-        width: u32,
-        height: u32,
-    ) {
+    fn configure_surface(&mut self, surface: &mut Self::Surface, width: u32, height: u32) {
         surface
             .window
             .resize(
@@ -96,8 +80,7 @@ impl crate::graphics::Compositor for Compositor {
             )
             .expect("Resize surface");
 
-        surface.clip_mask =
-            tiny_skia::Mask::new(width, height).expect("Create clip mask");
+        surface.clip_mask = tiny_skia::Mask::new(width, height).expect("Create clip mask");
         surface.layer_stack.clear();
     }
 
@@ -135,13 +118,10 @@ impl crate::graphics::Compositor for Compositor {
     }
 }
 
-pub fn new(
-    settings: Settings,
-    display: impl compositor::Display,
-) -> Compositor {
+pub fn new(settings: Settings, display: impl compositor::Display) -> Compositor {
     #[allow(unsafe_code)]
-    let context = softbuffer::Context::new(Box::new(display) as _)
-        .expect("Create softbuffer context");
+    let context =
+        softbuffer::Context::new(Box::new(display) as _).expect("Create softbuffer context");
 
     Compositor { context, settings }
 }
@@ -194,10 +174,7 @@ pub fn present(
         surface.layer_stack.push_front(renderer.layers().to_vec());
         surface.background_color = background_color;
 
-        let damage = damage::group(
-            damage,
-            Rectangle::with_size(viewport.logical_size()),
-        );
+        let damage = damage::group(damage, Rectangle::with_size(viewport.logical_size()));
 
         let mut pixels = tiny_skia::PixmapMut::from_bytes(
             bytemuck::cast_slice_mut(&mut buffer),
@@ -226,11 +203,9 @@ pub fn screenshot(
 ) -> Vec<u8> {
     let size = viewport.physical_size();
 
-    let mut offscreen_buffer: Vec<u32> =
-        vec![0; size.width as usize * size.height as usize];
+    let mut offscreen_buffer: Vec<u32> = vec![0; size.width as usize * size.height as usize];
 
-    let mut clip_mask = tiny_skia::Mask::new(size.width, size.height)
-        .expect("Create clip mask");
+    let mut clip_mask = tiny_skia::Mask::new(size.width, size.height).expect("Create clip mask");
 
     renderer.draw(
         &mut tiny_skia::PixmapMut::from_bytes(

--- a/wgpu/src/buffer.rs
+++ b/wgpu/src/buffer.rs
@@ -4,8 +4,8 @@ use std::ops::RangeBounds;
 
 pub const MAX_WRITE_SIZE: usize = 100 * 1024;
 
-const MAX_WRITE_SIZE_U64: NonZeroU64 = NonZeroU64::new(MAX_WRITE_SIZE as u64)
-    .expect("MAX_WRITE_SIZE must be non-zero");
+const MAX_WRITE_SIZE_U64: NonZeroU64 =
+    NonZeroU64::new(MAX_WRITE_SIZE as u64).expect("MAX_WRITE_SIZE must be non-zero");
 
 #[derive(Debug)]
 pub struct Buffer<T> {
@@ -79,9 +79,7 @@ impl<T: bytemuck::Pod> Buffer<T> {
                 (offset + bytes_written) as u64,
                 MAX_WRITE_SIZE_U64,
             )
-            .copy_from_slice(
-                &bytes[bytes_written..bytes_written + MAX_WRITE_SIZE],
-            );
+            .copy_from_slice(&bytes[bytes_written..bytes_written + MAX_WRITE_SIZE]);
 
             bytes_written += MAX_WRITE_SIZE;
         }
@@ -104,10 +102,7 @@ impl<T: bytemuck::Pod> Buffer<T> {
         bytes.len()
     }
 
-    pub fn slice(
-        &self,
-        bounds: impl RangeBounds<wgpu::BufferAddress>,
-    ) -> wgpu::BufferSlice<'_> {
+    pub fn slice(&self, bounds: impl RangeBounds<wgpu::BufferAddress>) -> wgpu::BufferSlice<'_> {
         self.raw.slice(bounds)
     }
 
@@ -122,8 +117,6 @@ impl<T: bytemuck::Pod> Buffer<T> {
 fn next_copy_size<T>(amount: usize) -> u64 {
     let align_mask = wgpu::COPY_BUFFER_ALIGNMENT - 1;
 
-    (((std::mem::size_of::<T>() * amount).next_power_of_two() as u64
-        + align_mask)
-        & !align_mask)
+    (((std::mem::size_of::<T>() * amount).next_power_of_two() as u64 + align_mask) & !align_mask)
         .max(wgpu::COPY_BUFFER_ALIGNMENT)
 }

--- a/wgpu/src/color.rs
+++ b/wgpu/src/color.rs
@@ -37,121 +37,108 @@ pub fn convert(
         usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
     });
 
-    let constant_layout =
-        device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("iced_wgpu.offscreen.blit.sampler_layout"),
-            entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler(
-                        wgpu::SamplerBindingType::NonFiltering,
-                    ),
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::VERTEX,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-            ],
-        });
-
-    let constant_bind_group =
-        device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("iced_wgpu.offscreen.sampler.bind_group"),
-            layout: &constant_layout,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::Sampler(&sampler),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: ratio.as_entire_binding(),
-                },
-            ],
-        });
-
-    let texture_layout =
-        device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            label: Some("iced_wgpu.offscreen.blit.texture_layout"),
-            entries: &[wgpu::BindGroupLayoutEntry {
+    let constant_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("iced_wgpu.offscreen.blit.sampler_layout"),
+        entries: &[
+            wgpu::BindGroupLayoutEntry {
                 binding: 0,
                 visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Texture {
-                    sample_type: wgpu::TextureSampleType::Float {
-                        filterable: false,
-                    },
-                    view_dimension: wgpu::TextureViewDimension::D2,
-                    multisampled: false,
+                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
                 },
                 count: None,
-            }],
-        });
+            },
+        ],
+    });
 
-    let pipeline_layout =
-        device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: Some("iced_wgpu.offscreen.blit.pipeline_layout"),
-            bind_group_layouts: &[&constant_layout, &texture_layout],
-            immediate_size: 0,
-        });
+    let constant_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("iced_wgpu.offscreen.sampler.bind_group"),
+        layout: &constant_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Sampler(&sampler),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: ratio.as_entire_binding(),
+            },
+        ],
+    });
+
+    let texture_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("iced_wgpu.offscreen.blit.texture_layout"),
+        entries: &[wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: wgpu::ShaderStages::FRAGMENT,
+            ty: wgpu::BindingType::Texture {
+                sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                view_dimension: wgpu::TextureViewDimension::D2,
+                multisampled: false,
+            },
+            count: None,
+        }],
+    });
+
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("iced_wgpu.offscreen.blit.pipeline_layout"),
+        bind_group_layouts: &[&constant_layout, &texture_layout],
+        immediate_size: 0,
+    });
 
     let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some("iced_wgpu.offscreen.blit.shader"),
-        source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!(
-            "shader/blit.wgsl"
-        ))),
+        source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("shader/blit.wgsl"))),
     });
 
-    let pipeline =
-        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("iced_wgpu.offscreen.blit.pipeline"),
-            layout: Some(&pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &shader,
-                entry_point: Some("vs_main"),
-                buffers: &[],
-                compilation_options: wgpu::PipelineCompilationOptions::default(
-                ),
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &shader,
-                entry_point: Some("fs_main"),
-                targets: &[Some(wgpu::ColorTargetState {
-                    format,
-                    blend: Some(wgpu::BlendState {
-                        color: wgpu::BlendComponent {
-                            src_factor: wgpu::BlendFactor::SrcAlpha,
-                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                            operation: wgpu::BlendOperation::Add,
-                        },
-                        alpha: wgpu::BlendComponent {
-                            src_factor: wgpu::BlendFactor::One,
-                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                            operation: wgpu::BlendOperation::Add,
-                        },
-                    }),
-                    write_mask: wgpu::ColorWrites::ALL,
-                })],
-                compilation_options: wgpu::PipelineCompilationOptions::default(
-                ),
-            }),
-            primitive: wgpu::PrimitiveState {
-                topology: wgpu::PrimitiveTopology::TriangleList,
-                front_face: wgpu::FrontFace::Cw,
-                ..wgpu::PrimitiveState::default()
-            },
-            depth_stencil: None,
-            multisample: wgpu::MultisampleState::default(),
-            multiview_mask: None,
-            cache: None,
-        });
+    let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("iced_wgpu.offscreen.blit.pipeline"),
+        layout: Some(&pipeline_layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: Some("vs_main"),
+            buffers: &[],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: Some("fs_main"),
+            targets: &[Some(wgpu::ColorTargetState {
+                format,
+                blend: Some(wgpu::BlendState {
+                    color: wgpu::BlendComponent {
+                        src_factor: wgpu::BlendFactor::SrcAlpha,
+                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                        operation: wgpu::BlendOperation::Add,
+                    },
+                    alpha: wgpu::BlendComponent {
+                        src_factor: wgpu::BlendFactor::One,
+                        dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                        operation: wgpu::BlendOperation::Add,
+                    },
+                }),
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        }),
+        primitive: wgpu::PrimitiveState {
+            topology: wgpu::PrimitiveTopology::TriangleList,
+            front_face: wgpu::FrontFace::Cw,
+            ..wgpu::PrimitiveState::default()
+        },
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        multiview_mask: None,
+        cache: None,
+    });
 
     let texture = device.create_texture(&wgpu::TextureDescriptor {
         label: Some("iced_wgpu.offscreen.conversion.source_texture"),
@@ -160,25 +147,22 @@ pub fn convert(
         sample_count: 1,
         dimension: wgpu::TextureDimension::D2,
         format,
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT
-            | wgpu::TextureUsages::COPY_SRC,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
         view_formats: &[],
     });
 
     let view = &texture.create_view(&wgpu::TextureViewDescriptor::default());
 
-    let texture_bind_group =
-        device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("iced_wgpu.offscreen.blit.texture_bind_group"),
-            layout: &texture_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: wgpu::BindingResource::TextureView(
-                    &source
-                        .create_view(&wgpu::TextureViewDescriptor::default()),
-                ),
-            }],
-        });
+    let texture_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("iced_wgpu.offscreen.blit.texture_bind_group"),
+        layout: &texture_layout,
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: wgpu::BindingResource::TextureView(
+                &source.create_view(&wgpu::TextureViewDescriptor::default()),
+            ),
+        }],
+    });
 
     let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
         label: Some("iced_wgpu.offscreen.blit.render_pass"),

--- a/wgpu/src/engine.rs
+++ b/wgpu/src/engine.rs
@@ -35,11 +35,7 @@ impl Engine {
 
             quad_pipeline: quad::Pipeline::new(&device, format),
             text_pipeline: text::Pipeline::new(&device, &queue, format),
-            triangle_pipeline: triangle::Pipeline::new(
-                &device,
-                format,
-                antialiasing,
-            ),
+            triangle_pipeline: triangle::Pipeline::new(&device, format, antialiasing),
 
             #[cfg(any(feature = "image", feature = "svg"))]
             image_pipeline: {
@@ -48,9 +44,7 @@ impl Engine {
                 crate::image::Pipeline::new(&device, format, backend)
             },
 
-            primitive_storage: Arc::new(RwLock::new(
-                primitive::Storage::default(),
-            )),
+            primitive_storage: Arc::new(RwLock::new(primitive::Storage::default())),
 
             device,
             queue,
@@ -60,11 +54,8 @@ impl Engine {
 
     #[cfg(any(feature = "image", feature = "svg"))]
     pub fn create_image_cache(&self) -> crate::image::Cache {
-        self.image_pipeline.create_cache(
-            &self.device,
-            &self.queue,
-            &self._shell,
-        )
+        self.image_pipeline
+            .create_cache(&self.device, &self.queue, &self._shell)
     }
 
     pub fn trim(&mut self) {

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -82,15 +82,14 @@ impl Atlas {
             ..Default::default()
         });
 
-        let texture_bind_group =
-            device.create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("iced_wgpu::image texture atlas bind group"),
-                layout: &texture_layout,
-                entries: &[wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::TextureView(&texture_view),
-                }],
-            });
+        let texture_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("iced_wgpu::image texture atlas bind group"),
+            layout: &texture_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&texture_view),
+            }],
+        });
 
         Atlas {
             size,
@@ -131,9 +130,7 @@ impl Atlas {
 
         match &entry {
             Entry::Contiguous(allocation) => {
-                self.upload_allocation(
-                    pixels, width, 0, allocation, encoder, belt,
-                );
+                self.upload_allocation(pixels, width, 0, allocation, encoder, belt);
             }
             Entry::Fragmented { fragments, .. } => {
                 for fragment in fragments {
@@ -326,8 +323,7 @@ impl Atlas {
         let bytes_per_row = (4 * (width + padding.width * 2))
             .next_multiple_of(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT)
             as usize;
-        let total_bytes =
-            bytes_per_row * (height + padding.height * 2) as usize;
+        let total_bytes = bytes_per_row * (height + padding.height * 2) as usize;
 
         let buffer_slice = belt.allocate(
             wgpu::BufferSize::new(total_bytes as u64).unwrap(),
@@ -349,21 +345,14 @@ impl Atlas {
         // Using `h` instead of `h-1` over-estimates by one full image_width
         // row, causing false positives for bottom-right fragments whose
         // x-offset is non-zero and whose bottom edge reaches the image edge.
-        if h > 0
-            && pixels.len()
-                < offset + (h - 1) * PIXEL * image_width as usize + stride
-        {
+        if h > 0 && pixels.len() < offset + (h - 1) * PIXEL * image_width as usize + stride {
             return;
         }
 
         // bounds check for pad_w low / high to fragment
         if pad_w > 0
             && (offset + stride < PIXEL
-                || offset
-                    + image_width as usize
-                        * PIXEL
-                        * (h.checked_sub(1).unwrap_or(0))
-                    + PIXEL
+                || offset + image_width as usize * PIXEL * (h.checked_sub(1).unwrap_or(0)) + PIXEL
                     > pixels.len())
         {
             return;
@@ -382,11 +371,9 @@ impl Atlas {
                 fragment[dst + PIXEL * i..dst + PIXEL * (i + 1)]
                     .copy_from_slice(&pixels[src..src + PIXEL]);
 
-                fragment[dst + stride + PIXEL * (pad_w + i)
-                    ..dst + stride + PIXEL * (pad_w + i + 1)]
-                    .copy_from_slice(
-                        &pixels[src + stride - PIXEL..src + stride],
-                    );
+                fragment
+                    [dst + stride + PIXEL * (pad_w + i)..dst + stride + PIXEL * (pad_w + i + 1)]
+                    .copy_from_slice(&pixels[src + stride - PIXEL..src + stride]);
             }
         }
 
@@ -402,8 +389,7 @@ impl Atlas {
                 .copy_from_slice(&pixels[src_top..src_top + PIXEL * w]);
 
             // Bottom
-            fragment
-                [dst_bottom + PIXEL * pad_w..dst_bottom + PIXEL * (pad_w + w)]
+            fragment[dst_bottom + PIXEL * pad_w..dst_bottom + PIXEL * (pad_w + w)]
                 .copy_from_slice(&pixels[src_bottom..src_bottom + PIXEL * w]);
 
             // Corners
@@ -413,11 +399,8 @@ impl Atlas {
                     .copy_from_slice(&pixels[offset..offset + PIXEL]);
 
                 // Top right
-                fragment[dst_top + PIXEL * (w + pad_w + i)
-                    ..dst_top + PIXEL * (w + pad_w + i + 1)]
-                    .copy_from_slice(
-                        &pixels[offset + PIXEL * (w - 1)..offset + PIXEL * w],
-                    );
+                fragment[dst_top + PIXEL * (w + pad_w + i)..dst_top + PIXEL * (w + pad_w + i + 1)]
+                    .copy_from_slice(&pixels[offset + PIXEL * (w - 1)..offset + PIXEL * w]);
 
                 // Bottom left
                 fragment[dst_bottom + PIXEL * i..dst_bottom + PIXEL * (i + 1)]
@@ -426,10 +409,7 @@ impl Atlas {
                 // Bottom right
                 fragment[dst_bottom + PIXEL * (w + pad_w + i)
                     ..dst_bottom + PIXEL * (w + pad_w + i + 1)]
-                    .copy_from_slice(
-                        &pixels[src_bottom + PIXEL * (w - 1)
-                            ..src_bottom + PIXEL * w],
-                    );
+                    .copy_from_slice(&pixels[src_bottom + PIXEL * (w - 1)..src_bottom + PIXEL * w]);
             }
         }
 
@@ -507,9 +487,7 @@ impl Atlas {
 
         let amount_to_copy = self.layers.len() - amount;
 
-        for (i, layer) in
-            self.layers.iter_mut().take(amount_to_copy).enumerate()
-        {
+        for (i, layer) in self.layers.iter_mut().take(amount_to_copy).enumerate() {
             if layer.is_empty() {
                 continue;
             }
@@ -544,22 +522,18 @@ impl Atlas {
         }
 
         self.texture = new_texture;
-        self.texture_view =
-            self.texture.create_view(&wgpu::TextureViewDescriptor {
-                dimension: Some(wgpu::TextureViewDimension::D2Array),
-                ..Default::default()
-            });
+        self.texture_view = self.texture.create_view(&wgpu::TextureViewDescriptor {
+            dimension: Some(wgpu::TextureViewDimension::D2Array),
+            ..Default::default()
+        });
 
-        self.texture_bind_group =
-            Arc::new(device.create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("iced_wgpu::image texture atlas bind group"),
-                layout: &self.texture_layout,
-                entries: &[wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::TextureView(
-                        &self.texture_view,
-                    ),
-                }],
-            }));
+        self.texture_bind_group = Arc::new(device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("iced_wgpu::image texture atlas bind group"),
+            layout: &self.texture_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&self.texture_view),
+            }],
+        }));
     }
 }

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -29,8 +29,7 @@ impl Cache {
         _shell: &Shell,
     ) -> Self {
         #[cfg(all(feature = "image", not(target_arch = "wasm32")))]
-        let worker =
-            Worker::new(device, _queue, backend, layout.clone(), _shell);
+        let worker = Worker::new(device, _queue, backend, layout.clone(), _shell);
 
         Self {
             atlas: Atlas::new(device, backend, layout),
@@ -38,10 +37,7 @@ impl Cache {
             raster: Raster {
                 cache: crate::image::raster::Cache::default(),
                 pending: HashMap::new(),
-                belt: wgpu::util::StagingBelt::new(
-                    device.clone(),
-                    2 * 1024 * 1024,
-                ),
+                belt: wgpu::util::StagingBelt::new(device.clone(), 2 * 1024 * 1024),
             },
             #[cfg(feature = "svg")]
             vector: crate::image::vector::Cache::default(),
@@ -54,9 +50,7 @@ impl Cache {
     pub fn allocate_image(
         &mut self,
         handle: &core::image::Handle,
-        callback: impl FnOnce(Result<core::image::Allocation, core::image::Error>)
-        + Send
-        + 'static,
+        callback: impl FnOnce(Result<core::image::Allocation, core::image::Error>) + Send + 'static,
     ) {
         use crate::image::raster::Memory;
 
@@ -108,11 +102,9 @@ impl Cache {
 
         match self.raster.cache.get_mut(handle).unwrap() {
             Memory::Host(image) => {
-                let mut encoder = device.create_command_encoder(
-                    &wgpu::CommandEncoderDescriptor {
-                        label: Some("raster image upload"),
-                    },
-                );
+                let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("raster image upload"),
+                });
 
                 let entry = self.atlas.upload(
                     device,
@@ -138,10 +130,7 @@ impl Cache {
 
                 #[allow(unsafe_code)]
                 let allocation = unsafe {
-                    core::image::allocate(
-                        handle,
-                        Size::new(image.width(), image.height()),
-                    )
+                    core::image::allocate(handle, Size::new(image.width(), image.height()))
                 };
 
                 self.raster.cache.insert(
@@ -166,8 +155,7 @@ impl Cache {
                 }
 
                 #[allow(unsafe_code)]
-                let new =
-                    unsafe { core::image::allocate(handle, entry.size()) };
+                let new = unsafe { core::image::allocate(handle, entry.size()) };
 
                 *allocation = Some(new.downgrade());
 
@@ -178,10 +166,7 @@ impl Cache {
     }
 
     #[cfg(feature = "image")]
-    pub fn measure_image(
-        &mut self,
-        handle: &core::image::Handle,
-    ) -> Option<Size<u32>> {
+    pub fn measure_image(&mut self, handle: &core::image::Handle) -> Option<Size<u32>> {
         self.receive();
 
         let image = load_image(
@@ -239,14 +224,9 @@ impl Cache {
 
         // TODO: Concurrent Wasm support
         if image.len() < MAX_SYNC_SIZE || cfg!(target_arch = "wasm32") {
-            let entry = self.atlas.upload(
-                device,
-                encoder,
-                belt,
-                image.width(),
-                image.height(),
-                &image,
-            )?;
+            let entry =
+                self.atlas
+                    .upload(device, encoder, belt, image.width(), image.height(), &image)?;
 
             *memory = Memory::Device {
                 entry,
@@ -325,9 +305,7 @@ impl Cache {
 
                     let allocation = if let Some(callbacks) = callbacks {
                         #[allow(unsafe_code)]
-                        let allocation = unsafe {
-                            core::image::allocate(&handle, entry.size())
-                        };
+                        let allocation = unsafe { core::image::allocate(&handle, entry.size()) };
 
                         let reference = allocation.downgrade();
 
@@ -380,8 +358,7 @@ struct Raster {
 }
 
 #[cfg(feature = "image")]
-type Callback =
-    Box<dyn FnOnce(Result<core::image::Allocation, core::image::Error>) + Send>;
+type Callback = Box<dyn FnOnce(Result<core::image::Allocation, core::image::Error>) + Send>;
 
 #[cfg(feature = "image")]
 fn load_image<'a>(
@@ -454,10 +431,7 @@ mod worker {
                 backend,
                 texture_layout,
                 shell: shell.clone(),
-                belt: wgpu::util::StagingBelt::new(
-                    device.clone(),
-                    4 * 1024 * 1024,
-                ),
+                belt: wgpu::util::StagingBelt::new(device.clone(), 4 * 1024 * 1024),
                 jobs: jobs_receiver,
                 output: work_sender,
                 quit: quit_receiver,
@@ -550,35 +524,25 @@ mod worker {
                 };
 
                 match job {
-                    Job::Load(handle) => {
-                        match crate::graphics::image::load(&handle) {
-                            Ok(image) => self.upload(
-                                handle,
-                                image.width(),
-                                image.height(),
-                                image.into_raw(),
-                                Shell::invalidate_layout,
-                            ),
-                            Err(error) => {
-                                let _ = self
-                                    .output
-                                    .send(Work::Error { handle, error });
-                            }
+                    Job::Load(handle) => match crate::graphics::image::load(&handle) {
+                        Ok(image) => self.upload(
+                            handle,
+                            image.width(),
+                            image.height(),
+                            image.into_raw(),
+                            Shell::invalidate_layout,
+                        ),
+                        Err(error) => {
+                            let _ = self.output.send(Work::Error { handle, error });
                         }
-                    }
+                    },
                     Job::Upload {
                         handle,
                         rgba,
                         width,
                         height,
                     } => {
-                        self.upload(
-                            handle,
-                            width,
-                            height,
-                            rgba,
-                            Shell::request_redraw,
-                        );
+                        self.upload(handle, width, height, rgba, Shell::request_redraw);
                     }
                     Job::Drop(bind_group) => {
                         drop(bind_group);
@@ -596,11 +560,11 @@ mod worker {
             rgba: Bytes,
             callback: fn(&Shell),
         ) {
-            let mut encoder = self.device.create_command_encoder(
-                &wgpu::CommandEncoderDescriptor {
+            let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
                     label: Some("raster image upload"),
-                },
-            );
+                });
 
             let mut atlas = Atlas::with_size(
                 &self.device,

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -34,11 +34,7 @@ pub struct Pipeline {
 }
 
 impl Pipeline {
-    pub fn new(
-        device: &wgpu::Device,
-        format: wgpu::TextureFormat,
-        backend: wgpu::Backend,
-    ) -> Self {
+    pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat, backend: wgpu::Backend) -> Self {
         let nearest_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             address_mode_u: wgpu::AddressMode::ClampToEdge,
             address_mode_v: wgpu::AddressMode::ClampToEdge,
@@ -59,141 +55,126 @@ impl Pipeline {
             ..Default::default()
         });
 
-        let constant_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("iced_wgpu::image constants layout"),
-                entries: &[
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::VERTEX,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Uniform,
-                            has_dynamic_offset: false,
-                            min_binding_size: wgpu::BufferSize::new(
-                                mem::size_of::<Uniforms>() as u64,
-                            ),
-                        },
-                        count: None,
-                    },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 1,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Sampler(
-                            wgpu::SamplerBindingType::Filtering,
-                        ),
-                        count: None,
-                    },
-                ],
-            });
-
-        let texture_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("iced_wgpu::image texture atlas layout"),
-                entries: &[wgpu::BindGroupLayoutEntry {
+        let constant_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("iced_wgpu::image constants layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        sample_type: wgpu::TextureSampleType::Float {
-                            filterable: true,
-                        },
-                        view_dimension: wgpu::TextureViewDimension::D2Array,
-                        multisampled: false,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: wgpu::BufferSize::new(mem::size_of::<Uniforms>() as u64),
                     },
                     count: None,
-                }],
-            });
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
 
-        let layout =
-            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("iced_wgpu::image pipeline layout"),
-                bind_group_layouts: &[&constant_layout, &texture_layout],
-                immediate_size: 0,
-            });
+        let texture_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("iced_wgpu::image texture atlas layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    view_dimension: wgpu::TextureViewDimension::D2Array,
+                    multisampled: false,
+                },
+                count: None,
+            }],
+        });
 
-        let shader =
-            device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("iced_wgpu image shader"),
-                source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
-                    concat!(
-                        include_str!("../shader/vertex.wgsl"),
-                        "\n",
-                        include_str!("../shader/image.wgsl"),
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("iced_wgpu::image pipeline layout"),
+            bind_group_layouts: &[&constant_layout, &texture_layout],
+            immediate_size: 0,
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("iced_wgpu image shader"),
+            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(concat!(
+                include_str!("../shader/vertex.wgsl"),
+                "\n",
+                include_str!("../shader/image.wgsl"),
+            ))),
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("iced_wgpu::image pipeline"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: mem::size_of::<Instance>() as u64,
+                    step_mode: wgpu::VertexStepMode::Instance,
+                    attributes: &wgpu::vertex_attr_array!(
+                        // Center
+                        0 => Float32x2,
+                        // Clip bounds
+                        1 => Float32x4,
+                        // Border radius
+                        2 => Float32x4,
+                        // Tile
+                        3 => Float32x4,
+                        // Rotation
+                        4 => Float32,
+                        // Opacity
+                        5 => Float32,
+                        // Atlas position
+                        6 => Float32x2,
+                        // Atlas scale
+                        7 => Float32x2,
+                        // Layer
+                        8 => Sint32,
+                        // Snap
+                        9 => Uint32,
                     ),
-                )),
-            });
-
-        let pipeline =
-            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("iced_wgpu::image pipeline"),
-                layout: Some(&layout),
-                vertex: wgpu::VertexState {
-                    module: &shader,
-                    entry_point: Some("vs_main"),
-                    buffers: &[wgpu::VertexBufferLayout {
-                        array_stride: mem::size_of::<Instance>() as u64,
-                        step_mode: wgpu::VertexStepMode::Instance,
-                        attributes: &wgpu::vertex_attr_array!(
-                            // Center
-                            0 => Float32x2,
-                            // Clip bounds
-                            1 => Float32x4,
-                            // Border radius
-                            2 => Float32x4,
-                            // Tile
-                            3 => Float32x4,
-                            // Rotation
-                            4 => Float32,
-                            // Opacity
-                            5 => Float32,
-                            // Atlas position
-                            6 => Float32x2,
-                            // Atlas scale
-                            7 => Float32x2,
-                            // Layer
-                            8 => Sint32,
-                            // Snap
-                            9 => Uint32,
-                        ),
-                    }],
-                    compilation_options:
-                        wgpu::PipelineCompilationOptions::default(),
-                },
-                fragment: Some(wgpu::FragmentState {
-                    module: &shader,
-                    entry_point: Some("fs_main"),
-                    targets: &[Some(wgpu::ColorTargetState {
-                        format,
-                        blend: Some(wgpu::BlendState {
-                            color: wgpu::BlendComponent {
-                                src_factor: wgpu::BlendFactor::SrcAlpha,
-                                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                                operation: wgpu::BlendOperation::Add,
-                            },
-                            alpha: wgpu::BlendComponent {
-                                src_factor: wgpu::BlendFactor::One,
-                                dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
-                                operation: wgpu::BlendOperation::Add,
-                            },
-                        }),
-                        write_mask: wgpu::ColorWrites::ALL,
-                    })],
-                    compilation_options:
-                        wgpu::PipelineCompilationOptions::default(),
-                }),
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleList,
-                    front_face: wgpu::FrontFace::Cw,
-                    ..Default::default()
-                },
-                depth_stencil: None,
-                multisample: wgpu::MultisampleState {
-                    count: 1,
-                    mask: !0,
-                    alpha_to_coverage_enabled: false,
-                },
-                multiview_mask: None,
-                cache: None,
-            });
+                }],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState {
+                        color: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::SrcAlpha,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                        alpha: wgpu::BlendComponent {
+                            src_factor: wgpu::BlendFactor::One,
+                            dst_factor: wgpu::BlendFactor::OneMinusSrcAlpha,
+                            operation: wgpu::BlendOperation::Add,
+                        },
+                    }),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                front_face: wgpu::FrontFace::Cw,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview_mask: None,
+            cache: None,
+        });
 
         Pipeline {
             raw: pipeline,
@@ -205,12 +186,7 @@ impl Pipeline {
         }
     }
 
-    pub fn create_cache(
-        &self,
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        shell: &Shell,
-    ) -> Cache {
+    pub fn create_cache(&self, device: &wgpu::Device, queue: &wgpu::Queue, shell: &Shell) -> Cache {
         Cache::new(
             device,
             queue,
@@ -266,19 +242,15 @@ impl State {
                     bounds,
                     clip_bounds,
                 } => {
-                    if let Some((atlas_entry, bind_group)) = cache
-                        .upload_raster(device, encoder, belt, &image.handle)
+                    if let Some((atlas_entry, bind_group)) =
+                        cache.upload_raster(device, encoder, belt, &image.handle)
                     {
                         match atlas.as_mut() {
                             None => {
                                 atlas = Some(bind_group.clone());
                             }
                             Some(atlas) if atlas != bind_group => {
-                                layer.push(
-                                    atlas,
-                                    &self.nearest_instances,
-                                    &self.linear_instances,
-                                );
+                                layer.push(atlas, &self.nearest_instances, &self.linear_instances);
 
                                 *atlas = Arc::clone(bind_group);
                             }
@@ -313,27 +285,21 @@ impl State {
                     bounds,
                     clip_bounds,
                 } => {
-                    if let Some((atlas_entry, bind_group)) = cache
-                        .upload_vector(
-                            device,
-                            encoder,
-                            belt,
-                            &svg.handle,
-                            svg.color,
-                            bounds.size(),
-                            scale,
-                        )
-                    {
+                    if let Some((atlas_entry, bind_group)) = cache.upload_vector(
+                        device,
+                        encoder,
+                        belt,
+                        &svg.handle,
+                        svg.color,
+                        bounds.size(),
+                        scale,
+                    ) {
                         match atlas.as_mut() {
                             None => {
                                 atlas = Some(bind_group.clone());
                             }
                             Some(atlas) if atlas != bind_group => {
-                                layer.push(
-                                    atlas,
-                                    &self.nearest_instances,
-                                    &self.linear_instances,
-                                );
+                                layer.push(atlas, &self.nearest_instances, &self.linear_instances);
 
                                 *atlas = bind_group.clone();
                             }
@@ -386,12 +352,7 @@ impl State {
         if let Some(layer) = self.layers.get(layer) {
             render_pass.set_pipeline(&pipeline.raw);
 
-            render_pass.set_scissor_rect(
-                bounds.x,
-                bounds.y,
-                bounds.width,
-                bounds.height,
-            );
+            render_pass.set_scissor_rect(bounds.x, bounds.y, bounds.width, bounds.height);
 
             layer.render(render_pass);
         }
@@ -445,53 +406,43 @@ impl Layer {
             wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
         );
 
-        let nearest_layout =
-            device.create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("iced_wgpu::image constants bind group"),
-                layout: constant_layout,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: wgpu::BindingResource::Buffer(
-                            wgpu::BufferBinding {
-                                buffer: &uniforms,
-                                offset: 0,
-                                size: None,
-                            },
-                        ),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 1,
-                        resource: wgpu::BindingResource::Sampler(
-                            nearest_sampler,
-                        ),
-                    },
-                ],
-            });
+        let nearest_layout = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("iced_wgpu::image constants bind group"),
+            layout: constant_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &uniforms,
+                        offset: 0,
+                        size: None,
+                    }),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(nearest_sampler),
+                },
+            ],
+        });
 
-        let linear_layout =
-            device.create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("iced_wgpu::image constants bind group"),
-                layout: constant_layout,
-                entries: &[
-                    wgpu::BindGroupEntry {
-                        binding: 0,
-                        resource: wgpu::BindingResource::Buffer(
-                            wgpu::BufferBinding {
-                                buffer: &uniforms,
-                                offset: 0,
-                                size: None,
-                            },
-                        ),
-                    },
-                    wgpu::BindGroupEntry {
-                        binding: 1,
-                        resource: wgpu::BindingResource::Sampler(
-                            linear_sampler,
-                        ),
-                    },
-                ],
-            });
+        let linear_layout = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("iced_wgpu::image constants bind group"),
+            layout: constant_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: &uniforms,
+                        offset: 0,
+                        size: None,
+                    }),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(linear_sampler),
+                },
+            ],
+        });
 
         Self {
             uniforms,
@@ -546,12 +497,7 @@ impl Layer {
         }
     }
 
-    fn push(
-        &mut self,
-        atlas: &Arc<wgpu::BindGroup>,
-        nearest: &[Instance],
-        linear: &[Instance],
-    ) {
+    fn push(&mut self, atlas: &Arc<wgpu::BindGroup>, nearest: &[Instance], linear: &[Instance]) {
         let new_nearest = nearest.len() - self.nearest_total;
 
         if new_nearest > 0 {
@@ -585,8 +531,7 @@ impl Layer {
 
             for group in &self.nearest {
                 render_pass.set_bind_group(1, group.atlas.as_ref(), &[]);
-                render_pass
-                    .draw(0..6, offset..offset + group.instance_count as u32);
+                render_pass.draw(0..6, offset..offset + group.instance_count as u32);
 
                 offset += group.instance_count as u32;
             }
@@ -597,8 +542,7 @@ impl Layer {
 
             for group in &self.linear {
                 render_pass.set_bind_group(1, group.atlas.as_ref(), &[]);
-                render_pass
-                    .draw(0..6, offset..offset + group.instance_count as u32);
+                render_pass.draw(0..6, offset..offset + group.instance_count as u32);
 
                 offset += group.instance_count as u32;
             }
@@ -741,10 +685,7 @@ fn add_instance(
         _tile: tile,
         _rotation: rotation,
         _opacity: opacity,
-        _position_in_atlas: [
-            x as f32 / atlas_size as f32,
-            y as f32 / atlas_size as f32,
-        ],
+        _position_in_atlas: [x as f32 / atlas_size as f32, y as f32 / atlas_size as f32],
         _size_in_atlas: [
             width as f32 / atlas_size as f32,
             height as f32 / atlas_size as f32,

--- a/wgpu/src/image/raster.rs
+++ b/wgpu/src/image/raster.rs
@@ -75,11 +75,7 @@ impl Cache {
         self.map.contains_key(&handle.id())
     }
 
-    pub fn trim(
-        &mut self,
-        atlas: &mut Atlas,
-        on_drop: impl Fn(Arc<wgpu::BindGroup>),
-    ) {
+    pub fn trim(&mut self, atlas: &mut Atlas, on_drop: impl Fn(Arc<wgpu::BindGroup>)) {
         // Only trim if new entries have landed in the `Cache`
         if !self.should_trim {
             return;

--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -71,17 +71,13 @@ impl Cache {
         let svg = match handle.data() {
             svg::Data::Path(path) => fs::read_to_string(path)
                 .ok()
-                .and_then(|contents| {
-                    usvg::Tree::from_str(&contents, &options).ok()
-                })
+                .and_then(|contents| usvg::Tree::from_str(&contents, &options).ok())
                 .map(Svg::Loaded)
                 .unwrap_or(Svg::NotFound),
-            svg::Data::Bytes(bytes) => {
-                match usvg::Tree::from_data(bytes, &options) {
-                    Ok(tree) => Svg::Loaded(tree),
-                    Err(_) => Svg::NotFound,
-                }
-            }
+            svg::Data::Bytes(bytes) => match usvg::Tree::from_data(bytes, &options) {
+                Ok(tree) => Svg::Loaded(tree),
+                Err(_) => Svg::NotFound,
+            },
         };
 
         self.should_trim = true;
@@ -157,15 +153,12 @@ impl Cache {
 
                 // SVG rendering can panic on malformed or complex vectors.
                 // We catch panics to prevent crashes and continue gracefully.
-                let render =
-                    panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                        resvg::render(tree, transform, &mut img.as_mut());
-                    }));
+                let render = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                    resvg::render(tree, transform, &mut img.as_mut());
+                }));
 
                 if let Err(error) = render {
-                    log::warn!(
-                        "SVG rendering for {handle:?} panicked: {error:?}"
-                    );
+                    log::warn!("SVG rendering for {handle:?} panicked: {error:?}");
                 }
 
                 let mut rgba = img.take();
@@ -180,8 +173,7 @@ impl Cache {
                     });
                 }
 
-                let allocation = atlas
-                    .upload(device, encoder, belt, width, height, &rgba)?;
+                let allocation = atlas.upload(device, encoder, belt, width, height, &rgba)?;
 
                 log::debug!("allocating {id} {width}x{height}");
 

--- a/wgpu/src/layer.rs
+++ b/wgpu/src/layer.rs
@@ -1,7 +1,5 @@
 use crate::core::Radians;
-use crate::core::{
-    self, Background, Color, Point, Rectangle, Svg, Transformation, renderer,
-};
+use crate::core::{self, Background, Color, Point, Rectangle, Svg, Transformation, renderer};
 use crate::graphics;
 use crate::graphics::Mesh;
 use crate::graphics::color;
@@ -51,14 +49,11 @@ impl Layer {
             position: [bounds.x, bounds.y],
             size: [bounds.width, bounds.height],
             border_color: color::pack(quad.border.color),
-            border_radius: (quad.border.radius * transformation.scale_factor())
-                .into(),
+            border_radius: (quad.border.radius * transformation.scale_factor()).into(),
             border_width: quad.border.width * transformation.scale_factor(),
             shadow_color: color::pack(quad.shadow.color),
-            shadow_offset: (quad.shadow.offset * transformation.scale_factor())
-                .into(),
-            shadow_blur_radius: quad.shadow.blur_radius
-                * transformation.scale_factor(),
+            shadow_offset: (quad.shadow.offset * transformation.scale_factor()).into(),
+            shadow_blur_radius: quad.shadow.blur_radius * transformation.scale_factor(),
             snap: quad.snap as u32,
         };
 
@@ -116,8 +111,7 @@ impl Layer {
             bounds: Rectangle::new(position, text.bounds) * transformation,
             color,
             size: text.size * transformation.scale_factor(),
-            line_height: text.line_height.to_absolute(text.size)
-                * transformation.scale_factor(),
+            line_height: text.line_height.to_absolute(text.size) * transformation.scale_factor(),
             font: text.font,
             align_x: text.align_x,
             align_y: text.align_y,
@@ -128,11 +122,7 @@ impl Layer {
         self.pending_text.push(text);
     }
 
-    pub fn draw_text_raw(
-        &mut self,
-        raw: graphics::text::Raw,
-        transformation: Transformation,
-    ) {
+    pub fn draw_text_raw(&mut self, raw: graphics::text::Raw, transformation: Transformation) {
         let raw = Text::Raw {
             raw,
             transformation,
@@ -169,8 +159,7 @@ impl Layer {
     ) {
         let image = Image::Raster {
             image: core::Image {
-                border_radius: image.border_radius
-                    * transformation.scale_factor(),
+                border_radius: image.border_radius * transformation.scale_factor(),
                 ..image
             },
             bounds: bounds * transformation,
@@ -196,11 +185,7 @@ impl Layer {
         self.images.push(svg);
     }
 
-    pub fn draw_mesh(
-        &mut self,
-        mut mesh: Mesh,
-        transformation: Transformation,
-    ) {
+    pub fn draw_mesh(&mut self, mut mesh: Mesh, transformation: Transformation) {
         match &mut mesh {
             Mesh::Solid {
                 transformation: local_transformation,
@@ -217,11 +202,7 @@ impl Layer {
         self.pending_meshes.push(mesh);
     }
 
-    pub fn draw_mesh_group(
-        &mut self,
-        meshes: Vec<Mesh>,
-        transformation: Transformation,
-    ) {
+    pub fn draw_mesh_group(&mut self, meshes: Vec<Mesh>, transformation: Transformation) {
         self.flush_meshes();
 
         self.triangles.push(triangle::Item::Group {
@@ -230,11 +211,7 @@ impl Layer {
         });
     }
 
-    pub fn draw_mesh_cache(
-        &mut self,
-        cache: mesh::Cache,
-        transformation: Transformation,
-    ) {
+    pub fn draw_mesh_cache(&mut self, cache: mesh::Cache, transformation: Transformation) {
         self.flush_meshes();
 
         self.triangles.push(triangle::Item::Cached {
@@ -243,11 +220,7 @@ impl Layer {
         });
     }
 
-    pub fn draw_text_group(
-        &mut self,
-        text: Vec<Text>,
-        transformation: Transformation,
-    ) {
+    pub fn draw_text_group(&mut self, text: Vec<Text>, transformation: Transformation) {
         self.flush_text();
 
         self.text.push(text::Item::Group {
@@ -256,11 +229,7 @@ impl Layer {
         });
     }
 
-    pub fn draw_text_cache(
-        &mut self,
-        cache: text::Cache,
-        transformation: Transformation,
-    ) {
+    pub fn draw_text_cache(&mut self, cache: text::Cache, transformation: Transformation) {
         self.flush_text();
 
         self.text.push(text::Item::Cached {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -64,8 +64,8 @@ pub use geometry::Geometry;
 
 use crate::core::renderer;
 use crate::core::{
-    Background, Color, Font, Pixels, Point, Radians, Rectangle, Size,
-    Transformation, Vector, image::FilterMethod,
+    Background, Color, Font, Pixels, Point, Radians, Rectangle, Size, Transformation, Vector,
+    image::FilterMethod,
 };
 use crate::graphics::mesh;
 use crate::graphics::text::{Editor, Paragraph};
@@ -98,21 +98,14 @@ pub struct Renderer {
 }
 
 impl Renderer {
-    pub fn new(
-        engine: Engine,
-        default_font: Font,
-        default_text_size: Pixels,
-    ) -> Self {
+    pub fn new(engine: Engine, default_font: Font, default_text_size: Pixels) -> Self {
         Self {
             default_font,
             default_text_size,
             layers: layer::Stack::new(),
 
             quad: quad::State::new(),
-            triangle: triangle::State::new(
-                &engine.device,
-                &engine.triangle_pipeline,
-            ),
+            triangle: triangle::State::new(&engine.device, &engine.triangle_pipeline),
             text: text::State::new(),
             text_viewport: engine.text_pipeline.create_viewport(&engine.device),
 
@@ -140,11 +133,12 @@ impl Renderer {
         target: &wgpu::TextureView,
         viewport: &Viewport,
     ) -> wgpu::CommandEncoder {
-        let mut encoder = self.engine.device.create_command_encoder(
-            &wgpu::CommandEncoderDescriptor {
-                label: Some("iced_wgpu encoder"),
-            },
-        );
+        let mut encoder =
+            self.engine
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("iced_wgpu encoder"),
+                });
 
         self.prepare(&mut encoder, viewport);
         self.render(&mut encoder, target, clear_color, viewport);
@@ -183,11 +177,7 @@ impl Renderer {
     /// Renders the current surface to an offscreen buffer.
     ///
     /// Returns RGBA bytes of the texture data.
-    pub fn screenshot(
-        &mut self,
-        viewport: &Viewport,
-        background_color: Color,
-    ) -> Vec<u8> {
+    pub fn screenshot(&mut self, viewport: &Viewport, background_color: Color) -> Vec<u8> {
         #[derive(Clone, Copy, Debug)]
         struct BufferDimensions {
             width: u32,
@@ -200,11 +190,9 @@ impl Renderer {
             fn new(size: Size<u32>) -> Self {
                 let unpadded_bytes_per_row = size.width as usize * 4; //slice of buffer per row; always RGBA
                 let alignment = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize; //256
-                let padded_bytes_per_row_padding = (alignment
-                    - unpadded_bytes_per_row % alignment)
-                    % alignment;
-                let padded_bytes_per_row =
-                    unpadded_bytes_per_row + padded_bytes_per_row_padding;
+                let padded_bytes_per_row_padding =
+                    (alignment - unpadded_bytes_per_row % alignment) % alignment;
+                let padded_bytes_per_row = unpadded_bytes_per_row + padded_bytes_per_row_padding;
 
                 Self {
                     width: size.width,
@@ -223,19 +211,18 @@ impl Renderer {
             depth_or_array_layers: 1,
         };
 
-        let texture =
-            self.engine.device.create_texture(&wgpu::TextureDescriptor {
-                label: Some("iced_wgpu.offscreen.source_texture"),
-                size: texture_extent,
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: wgpu::TextureDimension::D2,
-                format: self.engine.format,
-                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
-                    | wgpu::TextureUsages::COPY_SRC
-                    | wgpu::TextureUsages::TEXTURE_BINDING,
-                view_formats: &[],
-            });
+        let texture = self.engine.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("iced_wgpu.offscreen.source_texture"),
+            size: texture_extent,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: self.engine.format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
 
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 
@@ -252,15 +239,12 @@ impl Renderer {
             },
         );
 
-        let output_buffer =
-            self.engine.device.create_buffer(&wgpu::BufferDescriptor {
-                label: Some("iced_wgpu.offscreen.output_texture_buffer"),
-                size: (dimensions.padded_bytes_per_row
-                    * dimensions.height as usize) as u64,
-                usage: wgpu::BufferUsages::MAP_READ
-                    | wgpu::BufferUsages::COPY_DST,
-                mapped_at_creation: false,
-            });
+        let output_buffer = self.engine.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("iced_wgpu.offscreen.output_texture_buffer"),
+            size: (dimensions.padded_bytes_per_row * dimensions.height as usize) as u64,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
 
         encoder.copy_texture_to_buffer(
             texture.as_image_copy(),
@@ -289,28 +273,22 @@ impl Renderer {
 
         let mapped_buffer = slice.get_mapped_range();
 
-        mapped_buffer.chunks(dimensions.padded_bytes_per_row).fold(
-            vec![],
-            |mut acc, row| {
+        mapped_buffer
+            .chunks(dimensions.padded_bytes_per_row)
+            .fold(vec![], |mut acc, row| {
                 acc.extend(&row[..dimensions.unpadded_bytes_per_row]);
                 acc
-            },
-        )
+            })
     }
 
-    fn prepare(
-        &mut self,
-        encoder: &mut wgpu::CommandEncoder,
-        viewport: &Viewport,
-    ) {
+    fn prepare(&mut self, encoder: &mut wgpu::CommandEncoder, viewport: &Viewport) {
         let scale_factor = viewport.scale_factor();
 
         self.text_viewport
             .update(&self.engine.queue, viewport.physical_size());
 
-        let physical_bounds = Rectangle::<f32>::from(Rectangle::with_size(
-            viewport.physical_size(),
-        ));
+        let physical_bounds =
+            Rectangle::<f32>::from(Rectangle::with_size(viewport.physical_size()));
 
         self.layers.merge();
 
@@ -426,8 +404,8 @@ impl Renderer {
     ) {
         use std::mem::ManuallyDrop;
 
-        let mut render_pass = ManuallyDrop::new(encoder.begin_render_pass(
-            &wgpu::RenderPassDescriptor {
+        let mut render_pass =
+            ManuallyDrop::new(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                 label: Some("iced_wgpu render pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: frame,
@@ -437,8 +415,7 @@ impl Renderer {
                         load: match clear_color {
                             Some(background_color) => wgpu::LoadOp::Clear({
                                 let [r, g, b, a] =
-                                    graphics::color::pack(background_color)
-                                        .components();
+                                    graphics::color::pack(background_color).components();
 
                                 wgpu::Color {
                                     r: f64::from(r),
@@ -456,8 +433,7 @@ impl Renderer {
                 timestamp_writes: None,
                 occlusion_query_set: None,
                 multiview_mask: None,
-            },
-        ));
+            }));
 
         let mut quad_layer = 0;
         let mut mesh_layer = 0;
@@ -467,15 +443,14 @@ impl Renderer {
         let mut image_layer = 0;
 
         let scale_factor = viewport.scale_factor();
-        let physical_bounds = Rectangle::<f32>::from(Rectangle::with_size(
-            viewport.physical_size(),
-        ));
+        let physical_bounds =
+            Rectangle::<f32>::from(Rectangle::with_size(viewport.physical_size()));
 
         let scale = Transformation::scale(scale_factor as f32);
 
         for layer in self.layers.iter() {
-            let Some(physical_bounds) = physical_bounds
-                .intersection(&(layer.bounds * scale_factor as f32))
+            let Some(physical_bounds) =
+                physical_bounds.intersection(&(layer.bounds * scale_factor as f32))
             else {
                 continue;
             };
@@ -513,26 +488,23 @@ impl Renderer {
                 );
                 render_span.finish();
 
-                render_pass = ManuallyDrop::new(encoder.begin_render_pass(
-                    &wgpu::RenderPassDescriptor {
+                render_pass =
+                    ManuallyDrop::new(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                         label: Some("iced_wgpu render pass"),
-                        color_attachments: &[Some(
-                            wgpu::RenderPassColorAttachment {
-                                view: frame,
-                                depth_slice: None,
-                                resolve_target: None,
-                                ops: wgpu::Operations {
-                                    load: wgpu::LoadOp::Load,
-                                    store: wgpu::StoreOp::Store,
-                                },
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: frame,
+                            depth_slice: None,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Load,
+                                store: wgpu::StoreOp::Store,
                             },
-                        )],
+                        })],
                         depth_stencil_attachment: None,
                         timestamp_writes: None,
                         occlusion_query_set: None,
                         multiview_mask: None,
-                    },
-                ));
+                    }));
             }
 
             if !layer.primitives.is_empty() {
@@ -599,34 +571,28 @@ impl Renderer {
                     let _ = ManuallyDrop::into_inner(render_pass);
 
                     for (instance, clip_bounds) in need_render {
-                        instance.primitive.render(
-                            &primitive_storage,
-                            encoder,
-                            frame,
-                            &clip_bounds,
-                        );
+                        instance
+                            .primitive
+                            .render(&primitive_storage, encoder, frame, &clip_bounds);
                     }
 
-                    render_pass = ManuallyDrop::new(encoder.begin_render_pass(
-                        &wgpu::RenderPassDescriptor {
+                    render_pass =
+                        ManuallyDrop::new(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                             label: Some("iced_wgpu render pass"),
-                            color_attachments: &[Some(
-                                wgpu::RenderPassColorAttachment {
-                                    view: frame,
-                                    depth_slice: None,
-                                    resolve_target: None,
-                                    ops: wgpu::Operations {
-                                        load: wgpu::LoadOp::Load,
-                                        store: wgpu::StoreOp::Store,
-                                    },
+                            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                view: frame,
+                                depth_slice: None,
+                                resolve_target: None,
+                                ops: wgpu::Operations {
+                                    load: wgpu::LoadOp::Load,
+                                    store: wgpu::StoreOp::Store,
                                 },
-                            )],
+                            })],
                             depth_stencil_attachment: None,
                             timestamp_writes: None,
                             occlusion_query_set: None,
                             multiview_mask: None,
-                        },
-                    ));
+                        }));
                 }
 
                 render_span.finish();
@@ -675,49 +641,41 @@ impl Renderer {
         });
     }
 
-    fn draw_overlay(
-        &mut self,
-        overlay: &[impl AsRef<str>],
-        viewport: &Viewport,
-    ) {
+    fn draw_overlay(&mut self, overlay: &[impl AsRef<str>], viewport: &Viewport) {
         use crate::core::Renderer as _;
         use crate::core::alignment;
         use crate::core::text::Renderer as _;
 
-        self.with_layer(
-            Rectangle::with_size(viewport.logical_size()),
-            |renderer| {
-                for (i, line) in overlay.iter().enumerate() {
-                    let text = crate::core::Text {
-                        content: line.as_ref().to_owned(),
-                        bounds: viewport.logical_size(),
-                        size: Pixels(20.0),
-                        line_height: core::text::LineHeight::default(),
-                        font: Font::MONOSPACE,
-                        align_x: core::text::Alignment::Left,
-                        align_y: alignment::Vertical::Top,
-                        shaping: core::text::Shaping::Advanced,
-                        wrapping: core::text::Wrapping::Word,
-                        ellipsize: core::text::Ellipsize::None,
-                    };
+        self.with_layer(Rectangle::with_size(viewport.logical_size()), |renderer| {
+            for (i, line) in overlay.iter().enumerate() {
+                let text = crate::core::Text {
+                    content: line.as_ref().to_owned(),
+                    bounds: viewport.logical_size(),
+                    size: Pixels(20.0),
+                    line_height: core::text::LineHeight::default(),
+                    font: Font::MONOSPACE,
+                    align_x: core::text::Alignment::Left,
+                    align_y: alignment::Vertical::Top,
+                    shaping: core::text::Shaping::Advanced,
+                    wrapping: core::text::Wrapping::Word,
+                    ellipsize: core::text::Ellipsize::None,
+                };
 
-                    renderer.fill_text(
-                        text.clone(),
-                        Point::new(11.0, 11.0 + 25.0 * i as f32),
-                        Color::from_rgba(0.9, 0.9, 0.9, 1.0),
-                        Rectangle::with_size(Size::INFINITE),
-                    );
+                renderer.fill_text(
+                    text.clone(),
+                    Point::new(11.0, 11.0 + 25.0 * i as f32),
+                    Color::from_rgba(0.9, 0.9, 0.9, 1.0),
+                    Rectangle::with_size(Size::INFINITE),
+                );
 
-                    renderer.fill_text(
-                        text,
-                        Point::new(11.0, 11.0 + 25.0 * i as f32)
-                            + Vector::new(-1.0, -1.0),
-                        Color::BLACK,
-                        Rectangle::with_size(Size::INFINITE),
-                    );
-                }
-            },
-        );
+                renderer.fill_text(
+                    text,
+                    Point::new(11.0, 11.0 + 25.0 * i as f32) + Vector::new(-1.0, -1.0),
+                    Color::BLACK,
+                    Rectangle::with_size(Size::INFINITE),
+                );
+            }
+        });
     }
 }
 
@@ -738,11 +696,7 @@ impl core::Renderer for Renderer {
         self.layers.pop_transformation();
     }
 
-    fn fill_quad(
-        &mut self,
-        quad: core::renderer::Quad,
-        background: impl Into<Background>,
-    ) {
+    fn fill_quad(&mut self, quad: core::renderer::Quad, background: impl Into<Background>) {
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_quad(quad, background.into(), transformation);
     }
@@ -754,9 +708,7 @@ impl core::Renderer for Renderer {
     fn allocate_image(
         &mut self,
         _handle: &core::image::Handle,
-        _callback: impl FnOnce(Result<core::image::Allocation, core::image::Error>)
-        + Send
-        + 'static,
+        _callback: impl FnOnce(Result<core::image::Allocation, core::image::Error>) + Send + 'static,
     ) {
         #[cfg(feature = "image")]
         self.image_cache
@@ -797,13 +749,7 @@ impl core::text::Renderer for Renderer {
     ) {
         let (layer, transformation) = self.layers.current_mut();
 
-        layer.draw_paragraph(
-            text,
-            position,
-            color,
-            clip_bounds,
-            transformation,
-        );
+        layer.draw_paragraph(text, position, color, clip_bounds, transformation);
     }
 
     fn fill_editor(
@@ -849,23 +795,16 @@ impl core::image::Renderer for Renderer {
         &self,
         handle: &Self::Handle,
     ) -> Result<core::image::Allocation, core::image::Error> {
-        self.image_cache.borrow_mut().load_image(
-            &self.engine.device,
-            &self.engine.queue,
-            handle,
-        )
+        self.image_cache
+            .borrow_mut()
+            .load_image(&self.engine.device, &self.engine.queue, handle)
     }
 
     fn measure_image(&self, handle: &Self::Handle) -> Option<core::Size<u32>> {
         self.image_cache.borrow_mut().measure_image(handle)
     }
 
-    fn draw_image(
-        &mut self,
-        image: core::Image,
-        bounds: Rectangle,
-        clip_bounds: Rectangle,
-    ) {
+    fn draw_image(&mut self, image: core::Image, bounds: Rectangle, clip_bounds: Rectangle) {
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_raster(image, bounds, clip_bounds, transformation);
     }
@@ -877,12 +816,7 @@ impl core::svg::Renderer for Renderer {
         self.image_cache.borrow_mut().measure_svg(handle)
     }
 
-    fn draw_svg(
-        &mut self,
-        svg: core::Svg,
-        bounds: Rectangle,
-        clip_bounds: Rectangle,
-    ) {
+    fn draw_svg(&mut self, svg: core::Svg, bounds: Rectangle, clip_bounds: Rectangle) {
         let (layer, transformation) = self.layers.current_mut();
         layer.draw_svg(svg, bounds, clip_bounds, transformation);
     }
@@ -977,8 +911,7 @@ impl renderer::Headless for Renderer {
         }
 
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::from_env()
-                .unwrap_or(wgpu::Backends::PRIMARY),
+            backends: wgpu::Backends::from_env().unwrap_or(wgpu::Backends::PRIMARY),
             flags: wgpu::InstanceFlags::empty(),
             ..wgpu::InstanceDescriptor::default()
         });

--- a/wgpu/src/primitive.rs
+++ b/wgpu/src/primitive.rs
@@ -44,11 +44,7 @@ pub trait Primitive: Debug + MaybeSend + MaybeSync + 'static {
     /// [`render`](Self::render) by returning `false` here.
     ///
     /// By default, it does nothing and returns `false`.
-    fn draw(
-        &self,
-        _pipeline: &Self::Pipeline,
-        _render_pass: &mut wgpu::RenderPass<'_>,
-    ) -> bool {
+    fn draw(&self, _pipeline: &Self::Pipeline, _render_pass: &mut wgpu::RenderPass<'_>) -> bool {
         false
     }
 
@@ -73,11 +69,7 @@ pub trait Pipeline: Any + MaybeSend + MaybeSync {
     ///
     /// This will only be called once, when the first [`Primitive`] with this kind
     /// of [`Pipeline`] is encountered.
-    fn new(
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        format: wgpu::TextureFormat,
-    ) -> Self
+    fn new(device: &wgpu::Device, queue: &wgpu::Queue, format: wgpu::TextureFormat) -> Self
     where
         Self: Sized;
 
@@ -87,9 +79,7 @@ pub trait Pipeline: Any + MaybeSend + MaybeSync {
     fn trim(&mut self) {}
 }
 
-pub(crate) trait Stored:
-    Debug + MaybeSend + MaybeSync + 'static
-{
+pub(crate) trait Stored: Debug + MaybeSend + MaybeSync + 'static {
     fn prepare(
         &self,
         storage: &mut Storage,
@@ -100,11 +90,7 @@ pub(crate) trait Stored:
         viewport: &Viewport,
     );
 
-    fn draw(
-        &self,
-        storage: &Storage,
-        render_pass: &mut wgpu::RenderPass<'_>,
-    ) -> bool;
+    fn draw(&self, storage: &Storage, render_pass: &mut wgpu::RenderPass<'_>) -> bool;
 
     fn render(
         &self,
@@ -144,11 +130,7 @@ impl<P: Primitive> Stored for BlackBox<P> {
             .prepare(renderer, device, queue, bounds, viewport);
     }
 
-    fn draw(
-        &self,
-        storage: &Storage,
-        render_pass: &mut wgpu::RenderPass<'_>,
-    ) -> bool {
+    fn draw(&self, storage: &Storage, render_pass: &mut wgpu::RenderPass<'_>) -> bool {
         let renderer = storage
             .get::<P>()
             .expect("renderer should be initialized")

--- a/wgpu/src/quad.rs
+++ b/wgpu/src/quad.rs
@@ -94,12 +94,7 @@ impl State {
         render_pass: &mut wgpu::RenderPass<'a>,
     ) {
         if let Some(layer) = self.layers.get(layer) {
-            render_pass.set_scissor_rect(
-                bounds.x,
-                bounds.y,
-                bounds.width,
-                bounds.height,
-            );
+            render_pass.set_scissor_rect(bounds.x, bounds.y, bounds.width, bounds.height);
 
             let mut solid_offset = 0;
             let mut gradient_offset = 0;
@@ -138,22 +133,21 @@ impl State {
 
 impl Pipeline {
     pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Pipeline {
-        let constant_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("iced_wgpu::quad uniforms layout"),
-                entries: &[wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::VERTEX,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Uniform,
-                        has_dynamic_offset: false,
-                        min_binding_size: wgpu::BufferSize::new(
-                            mem::size_of::<Uniforms>() as wgpu::BufferAddress,
-                        ),
-                    },
-                    count: None,
-                }],
-            });
+        let constant_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("iced_wgpu::quad uniforms layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: wgpu::BufferSize::new(
+                        mem::size_of::<Uniforms>() as wgpu::BufferAddress
+                    ),
+                },
+                count: None,
+            }],
+        });
 
         Self {
             solid: solid::Pipeline::new(device, format, &constant_layout),
@@ -172,10 +166,7 @@ pub struct Layer {
 }
 
 impl Layer {
-    pub fn new(
-        device: &wgpu::Device,
-        constant_layout: &wgpu::BindGroupLayout,
-    ) -> Self {
+    pub fn new(device: &wgpu::Device, constant_layout: &wgpu::BindGroupLayout) -> Self {
         let constants_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("iced_wgpu::quad uniforms buffer"),
             size: mem::size_of::<Uniforms>() as wgpu::BufferAddress,
@@ -319,9 +310,7 @@ enum Kind {
     Gradient,
 }
 
-fn color_target_state(
-    format: wgpu::TextureFormat,
-) -> [Option<wgpu::ColorTargetState>; 1] {
+fn color_target_state(format: wgpu::TextureFormat) -> [Option<wgpu::ColorTargetState>; 1] {
     [Some(wgpu::ColorTargetState {
         format,
         blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),

--- a/wgpu/src/quad/gradient.rs
+++ b/wgpu/src/quad/gradient.rs
@@ -72,93 +72,83 @@ impl Pipeline {
     ) -> Self {
         #[cfg(not(target_arch = "wasm32"))]
         {
-            let layout = device.create_pipeline_layout(
-                &wgpu::PipelineLayoutDescriptor {
-                    label: Some("iced_wgpu.quad.gradient.pipeline"),
-                    bind_group_layouts: &[constants_layout],
-                    immediate_size: 0,
-                },
-            );
+            let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("iced_wgpu.quad.gradient.pipeline"),
+                bind_group_layouts: &[constants_layout],
+                immediate_size: 0,
+            });
 
-            let shader =
-                device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                    label: Some("iced_wgpu.quad.gradient.shader"),
-                    source: wgpu::ShaderSource::Wgsl(
-                        std::borrow::Cow::Borrowed(concat!(
-                            include_str!("../shader/quad.wgsl"),
-                            "\n",
-                            include_str!("../shader/vertex.wgsl"),
-                            "\n",
-                            include_str!("../shader/quad/gradient.wgsl"),
-                            "\n",
-                            include_str!("../shader/color.wgsl"),
-                            "\n",
-                            include_str!("../shader/color/linear_rgb.wgsl")
-                        )),
-                    ),
-                });
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("iced_wgpu.quad.gradient.shader"),
+                source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(concat!(
+                    include_str!("../shader/quad.wgsl"),
+                    "\n",
+                    include_str!("../shader/vertex.wgsl"),
+                    "\n",
+                    include_str!("../shader/quad/gradient.wgsl"),
+                    "\n",
+                    include_str!("../shader/color.wgsl"),
+                    "\n",
+                    include_str!("../shader/color/linear_rgb.wgsl")
+                ))),
+            });
 
-            let pipeline = device.create_render_pipeline(
-                &wgpu::RenderPipelineDescriptor {
-                    label: Some("iced_wgpu.quad.gradient.pipeline"),
-                    layout: Some(&layout),
-                    vertex: wgpu::VertexState {
-                        module: &shader,
-                        entry_point: Some("gradient_vs_main"),
-                        buffers: &[wgpu::VertexBufferLayout {
-                            array_stride: std::mem::size_of::<Gradient>()
-                                as u64,
-                            step_mode: wgpu::VertexStepMode::Instance,
-                            attributes: &wgpu::vertex_attr_array!(
-                                // Colors 1-2
-                                0 => Uint32x4,
-                                // Colors 3-4
-                                1 => Uint32x4,
-                                // Colors 5-6
-                                2 => Uint32x4,
-                                // Colors 7-8
-                                3 => Uint32x4,
-                                // Offsets 1-8
-                                4 => Uint32x4,
-                                // Direction
-                                5 => Float32x4,
-                                // Position & Scale
-                                6 => Float32x4,
-                                // Border color
-                                7 => Float32x4,
-                                // Border radius
-                                8 => Float32x4,
-                                // Border width
-                                9 => Float32,
-                                // Snap
-                                10 => Uint32,
-                            ),
-                        }],
-                        compilation_options:
-                            wgpu::PipelineCompilationOptions::default(),
-                    },
-                    fragment: Some(wgpu::FragmentState {
-                        module: &shader,
-                        entry_point: Some("gradient_fs_main"),
-                        targets: &quad::color_target_state(format),
-                        compilation_options:
-                            wgpu::PipelineCompilationOptions::default(),
-                    }),
-                    primitive: wgpu::PrimitiveState {
-                        topology: wgpu::PrimitiveTopology::TriangleList,
-                        front_face: wgpu::FrontFace::Cw,
-                        ..Default::default()
-                    },
-                    depth_stencil: None,
-                    multisample: wgpu::MultisampleState {
-                        count: 1,
-                        mask: !0,
-                        alpha_to_coverage_enabled: false,
-                    },
-                    multiview_mask: None,
-                    cache: None,
+            let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("iced_wgpu.quad.gradient.pipeline"),
+                layout: Some(&layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("gradient_vs_main"),
+                    buffers: &[wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<Gradient>() as u64,
+                        step_mode: wgpu::VertexStepMode::Instance,
+                        attributes: &wgpu::vertex_attr_array!(
+                            // Colors 1-2
+                            0 => Uint32x4,
+                            // Colors 3-4
+                            1 => Uint32x4,
+                            // Colors 5-6
+                            2 => Uint32x4,
+                            // Colors 7-8
+                            3 => Uint32x4,
+                            // Offsets 1-8
+                            4 => Uint32x4,
+                            // Direction
+                            5 => Float32x4,
+                            // Position & Scale
+                            6 => Float32x4,
+                            // Border color
+                            7 => Float32x4,
+                            // Border radius
+                            8 => Float32x4,
+                            // Border width
+                            9 => Float32,
+                            // Snap
+                            10 => Uint32,
+                        ),
+                    }],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                 },
-            );
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("gradient_fs_main"),
+                    targets: &quad::color_target_state(format),
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    front_face: wgpu::FrontFace::Cw,
+                    ..Default::default()
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState {
+                    count: 1,
+                    mask: !0,
+                    alpha_to_coverage_enabled: false,
+                },
+                multiview_mask: None,
+                cache: None,
+            });
 
             Self { pipeline }
         }

--- a/wgpu/src/quad/solid.rs
+++ b/wgpu/src/quad/solid.rs
@@ -62,86 +62,79 @@ impl Pipeline {
         format: wgpu::TextureFormat,
         constants_layout: &wgpu::BindGroupLayout,
     ) -> Self {
-        let layout =
-            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("iced_wgpu.quad.solid.pipeline"),
-                bind_group_layouts: &[constants_layout],
-                immediate_size: 0,
-            });
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("iced_wgpu.quad.solid.pipeline"),
+            bind_group_layouts: &[constants_layout],
+            immediate_size: 0,
+        });
 
-        let shader =
-            device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("iced_wgpu.quad.solid.shader"),
-                source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
-                    concat!(
-                        include_str!("../shader/color.wgsl"),
-                        "\n",
-                        include_str!("../shader/quad.wgsl"),
-                        "\n",
-                        include_str!("../shader/vertex.wgsl"),
-                        "\n",
-                        include_str!("../shader/quad/solid.wgsl"),
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("iced_wgpu.quad.solid.shader"),
+            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(concat!(
+                include_str!("../shader/color.wgsl"),
+                "\n",
+                include_str!("../shader/quad.wgsl"),
+                "\n",
+                include_str!("../shader/vertex.wgsl"),
+                "\n",
+                include_str!("../shader/quad/solid.wgsl"),
+            ))),
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("iced_wgpu.quad.solid.pipeline"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("solid_vs_main"),
+                buffers: &[wgpu::VertexBufferLayout {
+                    array_stride: std::mem::size_of::<Solid>() as u64,
+                    step_mode: wgpu::VertexStepMode::Instance,
+                    attributes: &wgpu::vertex_attr_array!(
+                        // Color
+                        0 => Float32x4,
+                        // Position
+                        1 => Float32x2,
+                        // Size
+                        2 => Float32x2,
+                        // Border color
+                        3 => Float32x4,
+                        // Border radius
+                        4 => Float32x4,
+                        // Border width
+                        5 => Float32,
+                        // Shadow color
+                        6 => Float32x4,
+                        // Shadow offset
+                        7 => Float32x2,
+                        // Shadow blur radius
+                        8 => Float32,
+                        // Snap
+                        9 => Uint32,
                     ),
-                )),
-            });
-
-        let pipeline =
-            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("iced_wgpu.quad.solid.pipeline"),
-                layout: Some(&layout),
-                vertex: wgpu::VertexState {
-                    module: &shader,
-                    entry_point: Some("solid_vs_main"),
-                    buffers: &[wgpu::VertexBufferLayout {
-                        array_stride: std::mem::size_of::<Solid>() as u64,
-                        step_mode: wgpu::VertexStepMode::Instance,
-                        attributes: &wgpu::vertex_attr_array!(
-                            // Color
-                            0 => Float32x4,
-                            // Position
-                            1 => Float32x2,
-                            // Size
-                            2 => Float32x2,
-                            // Border color
-                            3 => Float32x4,
-                            // Border radius
-                            4 => Float32x4,
-                            // Border width
-                            5 => Float32,
-                            // Shadow color
-                            6 => Float32x4,
-                            // Shadow offset
-                            7 => Float32x2,
-                            // Shadow blur radius
-                            8 => Float32,
-                            // Snap
-                            9 => Uint32,
-                        ),
-                    }],
-                    compilation_options:
-                        wgpu::PipelineCompilationOptions::default(),
-                },
-                fragment: Some(wgpu::FragmentState {
-                    module: &shader,
-                    entry_point: Some("solid_fs_main"),
-                    targets: &quad::color_target_state(format),
-                    compilation_options:
-                        wgpu::PipelineCompilationOptions::default(),
-                }),
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleList,
-                    front_face: wgpu::FrontFace::Cw,
-                    ..Default::default()
-                },
-                depth_stencil: None,
-                multisample: wgpu::MultisampleState {
-                    count: 1,
-                    mask: !0,
-                    alpha_to_coverage_enabled: false,
-                },
-                multiview_mask: None,
-                cache: None,
-            });
+                }],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("solid_fs_main"),
+                targets: &quad::color_target_state(format),
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                front_face: wgpu::FrontFace::Cw,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview_mask: None,
+            cache: None,
+        });
 
         Self { pipeline }
     }

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -160,8 +160,7 @@ impl Storage {
                     }
 
                     // Only trim if glyphs have changed
-                    group.should_trim =
-                        group.should_trim || upload.version != cache.version;
+                    group.should_trim = group.should_trim || upload.version != cache.version;
 
                     upload.text = Arc::downgrade(&cache.text);
                     upload.version = cache.version;
@@ -276,15 +275,10 @@ pub struct Pipeline {
 }
 
 impl Pipeline {
-    pub fn new(
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        format: wgpu::TextureFormat,
-    ) -> Self {
+    pub fn new(device: &wgpu::Device, queue: &wgpu::Queue, format: wgpu::TextureFormat) -> Self {
         let cache = cryoglyph::Cache::new(device);
-        let atlas = cryoglyph::TextAtlas::with_color_mode(
-            device, queue, &cache, format, COLOR_MODE,
-        );
+        let atlas =
+            cryoglyph::TextAtlas::with_color_mode(device, queue, &cache, format, COLOR_MODE);
 
         Pipeline {
             format,
@@ -400,12 +394,7 @@ impl State {
         let atlas = pipeline.atlas.read().expect("Read text atlas");
         let mut layer_count = 0;
 
-        render_pass.set_scissor_rect(
-            bounds.x,
-            bounds.y,
-            bounds.width,
-            bounds.height,
-        );
+        render_pass.set_scissor_rect(bounds.x, bounds.y, bounds.width, bounds.height);
 
         for item in batch {
             match item {
@@ -465,12 +454,8 @@ fn prepare(
     let allocations: Vec<_> = sections
         .iter()
         .map(|section| match section {
-            Text::Paragraph { paragraph, .. } => {
-                paragraph.upgrade().map(Allocation::Paragraph)
-            }
-            Text::Editor { editor, .. } => {
-                editor.upgrade().map(Allocation::Editor)
-            }
+            Text::Paragraph { paragraph, .. } => paragraph.upgrade().map(Allocation::Paragraph),
+            Text::Editor { editor, .. } => editor.upgrade().map(Allocation::Editor),
             Text::Cached {
                 content,
                 bounds,
@@ -503,127 +488,113 @@ fn prepare(
         })
         .collect();
 
-    let text_areas = sections.iter().zip(allocations.iter()).filter_map(
-        |(section, allocation)| {
-            let (buffer, position, color, clip_bounds, transformation) =
-                match section {
-                    Text::Paragraph {
+    let text_areas = sections
+        .iter()
+        .zip(allocations.iter())
+        .filter_map(|(section, allocation)| {
+            let (buffer, position, color, clip_bounds, transformation) = match section {
+                Text::Paragraph {
+                    position,
+                    color,
+                    clip_bounds,
+                    transformation,
+                    ..
+                } => {
+                    let Some(Allocation::Paragraph(paragraph)) = allocation else {
+                        return None;
+                    };
+
+                    (
+                        paragraph.buffer(),
+                        *position,
+                        *color,
+                        *clip_bounds,
+                        *transformation,
+                    )
+                }
+                Text::Editor {
+                    position,
+                    color,
+                    clip_bounds,
+                    transformation,
+                    ..
+                } => {
+                    let Some(Allocation::Editor(editor)) = allocation else {
+                        return None;
+                    };
+
+                    (
+                        editor.buffer(),
+                        *position,
+                        *color,
+                        *clip_bounds,
+                        *transformation,
+                    )
+                }
+                Text::Cached {
+                    bounds,
+                    align_x,
+                    align_y,
+                    color,
+                    clip_bounds,
+                    ..
+                } => {
+                    let Some(Allocation::Cache(key)) = allocation else {
+                        return None;
+                    };
+
+                    let entry = buffer_cache.get(key).expect("Get cached buffer");
+
+                    let mut position = bounds.position();
+
+                    position.x = match align_x {
+                        Alignment::Default | Alignment::Left | Alignment::Justified => position.x,
+                        Alignment::Center => position.x - entry.min_bounds.width / 2.0,
+                        Alignment::Right => position.x - entry.min_bounds.width,
+                    };
+
+                    position.y = match align_y {
+                        alignment::Vertical::Top => position.y,
+                        alignment::Vertical::Center => position.y - entry.min_bounds.height / 2.0,
+                        alignment::Vertical::Bottom => position.y - entry.min_bounds.height,
+                    };
+
+                    (
+                        &entry.buffer,
                         position,
-                        color,
-                        clip_bounds,
-                        transformation,
-                        ..
-                    } => {
-                        let Some(Allocation::Paragraph(paragraph)) = allocation
-                        else {
-                            return None;
-                        };
+                        *color,
+                        *clip_bounds,
+                        Transformation::IDENTITY,
+                    )
+                }
+                Text::Raw {
+                    raw,
+                    transformation,
+                } => {
+                    let Some(Allocation::Raw(buffer)) = allocation else {
+                        return None;
+                    };
 
-                        (
-                            paragraph.buffer(),
-                            *position,
-                            *color,
-                            *clip_bounds,
-                            *transformation,
-                        )
-                    }
-                    Text::Editor {
-                        position,
-                        color,
-                        clip_bounds,
-                        transformation,
-                        ..
-                    } => {
-                        let Some(Allocation::Editor(editor)) = allocation
-                        else {
-                            return None;
-                        };
-
-                        (
-                            editor.buffer(),
-                            *position,
-                            *color,
-                            *clip_bounds,
-                            *transformation,
-                        )
-                    }
-                    Text::Cached {
-                        bounds,
-                        align_x,
-                        align_y,
-                        color,
-                        clip_bounds,
-                        ..
-                    } => {
-                        let Some(Allocation::Cache(key)) = allocation else {
-                            return None;
-                        };
-
-                        let entry =
-                            buffer_cache.get(key).expect("Get cached buffer");
-
-                        let mut position = bounds.position();
-
-                        position.x = match align_x {
-                            Alignment::Default
-                            | Alignment::Left
-                            | Alignment::Justified => position.x,
-                            Alignment::Center => {
-                                position.x - entry.min_bounds.width / 2.0
-                            }
-                            Alignment::Right => {
-                                position.x - entry.min_bounds.width
-                            }
-                        };
-
-                        position.y = match align_y {
-                            alignment::Vertical::Top => position.y,
-                            alignment::Vertical::Center => {
-                                position.y - entry.min_bounds.height / 2.0
-                            }
-                            alignment::Vertical::Bottom => {
-                                position.y - entry.min_bounds.height
-                            }
-                        };
-
-                        (
-                            &entry.buffer,
-                            position,
-                            *color,
-                            *clip_bounds,
-                            Transformation::IDENTITY,
-                        )
-                    }
-                    Text::Raw {
-                        raw,
-                        transformation,
-                    } => {
-                        let Some(Allocation::Raw(buffer)) = allocation else {
-                            return None;
-                        };
-
-                        (
-                            buffer.as_ref(),
-                            raw.position,
-                            raw.color,
-                            raw.clip_bounds,
-                            *transformation,
-                        )
-                    }
-                };
+                    (
+                        buffer.as_ref(),
+                        raw.position,
+                        raw.color,
+                        raw.clip_bounds,
+                        *transformation,
+                    )
+                }
+            };
 
             let position = position * transformation * layer_transformation;
 
-            let clip_bounds = layer_bounds.intersection(
-                &(clip_bounds * transformation * layer_transformation),
-            )?;
+            let clip_bounds = layer_bounds
+                .intersection(&(clip_bounds * transformation * layer_transformation))?;
 
             Some(cryoglyph::TextArea {
                 text: buffer.layout_runs(),
                 left: position.x,
                 top: position.y,
-                scale: transformation.scale_factor()
-                    * layer_transformation.scale_factor(),
+                scale: transformation.scale_factor() * layer_transformation.scale_factor(),
                 bounds: cryoglyph::TextBounds {
                     left: clip_bounds.x.round() as i32,
                     top: clip_bounds.y.round() as i32,
@@ -632,8 +603,7 @@ fn prepare(
                 },
                 default_color: to_color(color),
             })
-        },
-    );
+        });
 
     renderer.prepare(
         device,

--- a/wgpu/src/triangle.rs
+++ b/wgpu/src/triangle.rs
@@ -158,14 +158,12 @@ impl State {
         scale: Transformation,
         target_size: Size<u32>,
     ) {
-        let projection = if let Some((state, pipeline)) =
-            self.msaa.as_mut().zip(pipeline.msaa.as_ref())
-        {
-            state.prepare(device, encoder, belt, pipeline, target_size) * scale
-        } else {
-            Transformation::orthographic(target_size.width, target_size.height)
-                * scale
-        };
+        let projection =
+            if let Some((state, pipeline)) = self.msaa.as_mut().zip(pipeline.msaa.as_ref()) {
+                state.prepare(device, encoder, belt, pipeline, target_size) * scale
+            } else {
+                Transformation::orthographic(target_size.width, target_size.height) * scale
+            };
 
         for item in items {
             match item {
@@ -174,11 +172,8 @@ impl State {
                     meshes,
                 } => {
                     if self.layers.len() <= self.prepare_layer {
-                        self.layers.push(Layer::new(
-                            device,
-                            &pipeline.solid,
-                            &pipeline.gradient,
-                        ));
+                        self.layers
+                            .push(Layer::new(device, &pipeline.solid, &pipeline.gradient));
                     }
 
                     let layer = &mut self.layers[self.prepare_layer];
@@ -342,11 +337,7 @@ pub struct Layer {
 }
 
 impl Layer {
-    fn new(
-        device: &wgpu::Device,
-        solid: &solid::Pipeline,
-        gradient: &gradient::Pipeline,
-    ) -> Self {
+    fn new(device: &wgpu::Device, solid: &solid::Pipeline, gradient: &gradient::Pipeline) -> Self {
         Self {
             index_buffer: Buffer::new(
                 device,
@@ -384,11 +375,8 @@ impl Layer {
             .resize(device, count.gradient_vertices);
 
         if self.solid.uniforms.resize(device, count.solids) {
-            self.solid.constants = solid::Layer::bind_group(
-                device,
-                &self.solid.uniforms.raw,
-                &solid.constants_layout,
-            );
+            self.solid.constants =
+                solid::Layer::bind_group(device, &self.solid.uniforms.raw, &solid.constants_layout);
         }
 
         if self.gradient.uniforms.resize(device, count.gradients) {
@@ -418,17 +406,14 @@ impl Layer {
             let uniforms = Uniforms::new(
                 transformation
                     * mesh.transformation()
-                    * Transformation::translate(
-                        snap_distance.x,
-                        snap_distance.y,
-                    ),
+                    * Transformation::translate(snap_distance.x, snap_distance.y),
             );
 
             let indices = mesh.indices();
 
-            index_offset +=
-                self.index_buffer
-                    .write(encoder, belt, index_offset, indices);
+            index_offset += self
+                .index_buffer
+                .write(encoder, belt, index_offset, indices);
 
             match mesh {
                 Mesh::Solid { buffers, .. } => {
@@ -439,12 +424,10 @@ impl Layer {
                         &buffers.vertices,
                     );
 
-                    solid_uniform_offset += self.solid.uniforms.write(
-                        encoder,
-                        belt,
-                        solid_uniform_offset,
-                        &[uniforms],
-                    )
+                    solid_uniform_offset +=
+                        self.solid
+                            .uniforms
+                            .write(encoder, belt, solid_uniform_offset, &[uniforms])
                 }
                 Mesh::Gradient { buffers, .. } => {
                     gradient_vertex_offset += self.gradient.vertices.write(
@@ -517,16 +500,14 @@ impl Layer {
                     render_pass.set_bind_group(
                         0,
                         &self.solid.constants,
-                        &[(num_solids * std::mem::size_of::<Uniforms>())
-                            as u32],
+                        &[(num_solids * std::mem::size_of::<Uniforms>()) as u32],
                     );
 
                     render_pass.set_vertex_buffer(
                         0,
-                        self.solid.vertices.range(
-                            solid_offset,
-                            solid_offset + buffers.vertices.len(),
-                        ),
+                        self.solid
+                            .vertices
+                            .range(solid_offset, solid_offset + buffers.vertices.len()),
                     );
 
                     num_solids += 1;
@@ -542,16 +523,14 @@ impl Layer {
                     render_pass.set_bind_group(
                         0,
                         &self.gradient.constants,
-                        &[(num_gradients * std::mem::size_of::<Uniforms>())
-                            as u32],
+                        &[(num_gradients * std::mem::size_of::<Uniforms>()) as u32],
                     );
 
                     render_pass.set_vertex_buffer(
                         0,
-                        self.gradient.vertices.range(
-                            gradient_offset,
-                            gradient_offset + buffers.vertices.len(),
-                        ),
+                        self.gradient
+                            .vertices
+                            .range(gradient_offset, gradient_offset + buffers.vertices.len()),
                     );
 
                     num_gradients += 1;
@@ -572,9 +551,7 @@ impl Layer {
     }
 }
 
-fn fragment_target(
-    texture_format: wgpu::TextureFormat,
-) -> wgpu::ColorTargetState {
+fn fragment_target(texture_format: wgpu::TextureFormat) -> wgpu::ColorTargetState {
     wgpu::ColorTargetState {
         format: texture_format,
         blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
@@ -590,9 +567,7 @@ fn primitive_state() -> wgpu::PrimitiveState {
     }
 }
 
-fn multisample_state(
-    antialiasing: Option<Antialiasing>,
-) -> wgpu::MultisampleState {
+fn multisample_state(antialiasing: Option<Antialiasing>) -> wgpu::MultisampleState {
     wgpu::MultisampleState {
         count: antialiasing.map(Antialiasing::sample_count).unwrap_or(1),
         mask: !0,
@@ -624,9 +599,7 @@ impl Uniforms {
             ty: wgpu::BindingType::Buffer {
                 ty: wgpu::BufferBindingType::Uniform,
                 has_dynamic_offset: true,
-                min_binding_size: wgpu::BufferSize::new(
-                    std::mem::size_of::<Self>() as u64,
-                ),
+                min_binding_size: wgpu::BufferSize::new(std::mem::size_of::<Self>() as u64),
             },
             count: None,
         }
@@ -657,10 +630,7 @@ mod solid {
     }
 
     impl Layer {
-        pub fn new(
-            device: &wgpu::Device,
-            constants_layout: &wgpu::BindGroupLayout,
-        ) -> Self {
+        pub fn new(device: &wgpu::Device, constants_layout: &wgpu::BindGroupLayout) -> Self {
             let vertices = Buffer::new(
                 device,
                 "iced_wgpu.triangle.solid.vertex_buffer",
@@ -675,8 +645,7 @@ mod solid {
                 wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             );
 
-            let constants =
-                Self::bind_group(device, &uniforms.raw, constants_layout);
+            let constants = Self::bind_group(device, &uniforms.raw, constants_layout);
 
             Self {
                 vertices,
@@ -695,13 +664,11 @@ mod solid {
                 layout,
                 entries: &[wgpu::BindGroupEntry {
                     binding: 0,
-                    resource: wgpu::BindingResource::Buffer(
-                        wgpu::BufferBinding {
-                            buffer,
-                            offset: 0,
-                            size: triangle::Uniforms::min_size(),
-                        },
-                    ),
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer,
+                        offset: 0,
+                        size: triangle::Uniforms::min_size(),
+                    }),
                 }],
             })
         }
@@ -713,74 +680,59 @@ mod solid {
             format: wgpu::TextureFormat,
             antialiasing: Option<Antialiasing>,
         ) -> Self {
-            let constants_layout = device.create_bind_group_layout(
-                &wgpu::BindGroupLayoutDescriptor {
+            let constants_layout =
+                device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
                     label: Some("iced_wgpu.triangle.solid.bind_group_layout"),
                     entries: &[triangle::Uniforms::entry()],
-                },
-            );
-
-            let layout = device.create_pipeline_layout(
-                &wgpu::PipelineLayoutDescriptor {
-                    label: Some("iced_wgpu.triangle.solid.pipeline_layout"),
-                    bind_group_layouts: &[&constants_layout],
-                    immediate_size: 0,
-                },
-            );
-
-            let shader =
-                device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                    label: Some("iced_wgpu.triangle.solid.shader"),
-                    source: wgpu::ShaderSource::Wgsl(
-                        std::borrow::Cow::Borrowed(concat!(
-                            include_str!("shader/triangle.wgsl"),
-                            "\n",
-                            include_str!("shader/triangle/solid.wgsl"),
-                            "\n",
-                            include_str!("shader/color.wgsl"),
-                        )),
-                    ),
                 });
 
-            let pipeline =
-                device.create_render_pipeline(
-                    &wgpu::RenderPipelineDescriptor {
-                        label: Some("iced_wgpu::triangle::solid pipeline"),
-                        layout: Some(&layout),
-                        vertex: wgpu::VertexState {
-                            module: &shader,
-                            entry_point: Some("solid_vs_main"),
-                            buffers: &[wgpu::VertexBufferLayout {
-                                array_stride: std::mem::size_of::<
-                                    mesh::SolidVertex2D,
-                                >(
-                                )
-                                    as u64,
-                                step_mode: wgpu::VertexStepMode::Vertex,
-                                attributes: &wgpu::vertex_attr_array!(
-                                    // Position
-                                    0 => Float32x2,
-                                    // Color
-                                    1 => Float32x4,
-                                ),
-                            }],
-                            compilation_options:
-                                wgpu::PipelineCompilationOptions::default(),
-                        },
-                        fragment: Some(wgpu::FragmentState {
-                            module: &shader,
-                            entry_point: Some("solid_fs_main"),
-                            targets: &[Some(triangle::fragment_target(format))],
-                            compilation_options:
-                                wgpu::PipelineCompilationOptions::default(),
-                        }),
-                        primitive: triangle::primitive_state(),
-                        depth_stencil: None,
-                        multisample: triangle::multisample_state(antialiasing),
-                        multiview_mask: None,
-                        cache: None,
-                    },
-                );
+            let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("iced_wgpu.triangle.solid.pipeline_layout"),
+                bind_group_layouts: &[&constants_layout],
+                immediate_size: 0,
+            });
+
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("iced_wgpu.triangle.solid.shader"),
+                source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(concat!(
+                    include_str!("shader/triangle.wgsl"),
+                    "\n",
+                    include_str!("shader/triangle/solid.wgsl"),
+                    "\n",
+                    include_str!("shader/color.wgsl"),
+                ))),
+            });
+
+            let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("iced_wgpu::triangle::solid pipeline"),
+                layout: Some(&layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("solid_vs_main"),
+                    buffers: &[wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<mesh::SolidVertex2D>() as u64,
+                        step_mode: wgpu::VertexStepMode::Vertex,
+                        attributes: &wgpu::vertex_attr_array!(
+                            // Position
+                            0 => Float32x2,
+                            // Color
+                            1 => Float32x4,
+                        ),
+                    }],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("solid_fs_main"),
+                    targets: &[Some(triangle::fragment_target(format))],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                primitive: triangle::primitive_state(),
+                depth_stencil: None,
+                multisample: triangle::multisample_state(antialiasing),
+                multiview_mask: None,
+                cache: None,
+            });
 
             Self {
                 pipeline,
@@ -810,10 +762,7 @@ mod gradient {
     }
 
     impl Layer {
-        pub fn new(
-            device: &wgpu::Device,
-            constants_layout: &wgpu::BindGroupLayout,
-        ) -> Self {
+        pub fn new(device: &wgpu::Device, constants_layout: &wgpu::BindGroupLayout) -> Self {
             let vertices = Buffer::new(
                 device,
                 "iced_wgpu.triangle.gradient.vertex_buffer",
@@ -828,8 +777,7 @@ mod gradient {
                 wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             );
 
-            let constants =
-                Self::bind_group(device, &uniforms.raw, constants_layout);
+            let constants = Self::bind_group(device, &uniforms.raw, constants_layout);
 
             Self {
                 vertices,
@@ -848,13 +796,11 @@ mod gradient {
                 layout,
                 entries: &[wgpu::BindGroupEntry {
                     binding: 0,
-                    resource: wgpu::BindingResource::Buffer(
-                        wgpu::BufferBinding {
-                            buffer: uniform_buffer,
-                            offset: 0,
-                            size: triangle::Uniforms::min_size(),
-                        },
-                    ),
+                    resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                        buffer: uniform_buffer,
+                        offset: 0,
+                        size: triangle::Uniforms::min_size(),
+                    }),
                 }],
             })
         }
@@ -866,86 +812,71 @@ mod gradient {
             format: wgpu::TextureFormat,
             antialiasing: Option<Antialiasing>,
         ) -> Self {
-            let constants_layout = device.create_bind_group_layout(
-                &wgpu::BindGroupLayoutDescriptor {
-                    label: Some(
-                        "iced_wgpu.triangle.gradient.bind_group_layout",
-                    ),
+            let constants_layout =
+                device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("iced_wgpu.triangle.gradient.bind_group_layout"),
                     entries: &[triangle::Uniforms::entry()],
-                },
-            );
-
-            let layout = device.create_pipeline_layout(
-                &wgpu::PipelineLayoutDescriptor {
-                    label: Some("iced_wgpu.triangle.gradient.pipeline_layout"),
-                    bind_group_layouts: &[&constants_layout],
-                    immediate_size: 0,
-                },
-            );
-
-            let shader =
-                device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                    label: Some("iced_wgpu.triangle.gradient.shader"),
-                    source: wgpu::ShaderSource::Wgsl(
-                        std::borrow::Cow::Borrowed(concat!(
-                            include_str!("shader/triangle.wgsl"),
-                            "\n",
-                            include_str!("shader/triangle/gradient.wgsl"),
-                            "\n",
-                            include_str!("shader/color.wgsl"),
-                            "\n",
-                            include_str!("shader/color/linear_rgb.wgsl")
-                        )),
-                    ),
                 });
 
-            let pipeline = device.create_render_pipeline(
-                &wgpu::RenderPipelineDescriptor {
-                    label: Some("iced_wgpu.triangle.gradient.pipeline"),
-                    layout: Some(&layout),
-                    vertex: wgpu::VertexState {
-                        module: &shader,
-                        entry_point: Some("gradient_vs_main"),
-                        buffers: &[wgpu::VertexBufferLayout {
-                            array_stride: std::mem::size_of::<
-                                mesh::GradientVertex2D,
-                            >()
-                                as u64,
-                            step_mode: wgpu::VertexStepMode::Vertex,
-                            attributes: &wgpu::vertex_attr_array!(
-                                // Position
-                                0 => Float32x2,
-                                // Colors 1-2
-                                1 => Uint32x4,
-                                // Colors 3-4
-                                2 => Uint32x4,
-                                // Colors 5-6
-                                3 => Uint32x4,
-                                // Colors 7-8
-                                4 => Uint32x4,
-                                // Offsets
-                                5 => Uint32x4,
-                                // Direction
-                                6 => Float32x4
-                            ),
-                        }],
-                        compilation_options:
-                            wgpu::PipelineCompilationOptions::default(),
-                    },
-                    fragment: Some(wgpu::FragmentState {
-                        module: &shader,
-                        entry_point: Some("gradient_fs_main"),
-                        targets: &[Some(triangle::fragment_target(format))],
-                        compilation_options:
-                            wgpu::PipelineCompilationOptions::default(),
-                    }),
-                    primitive: triangle::primitive_state(),
-                    depth_stencil: None,
-                    multisample: triangle::multisample_state(antialiasing),
-                    multiview_mask: None,
-                    cache: None,
+            let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("iced_wgpu.triangle.gradient.pipeline_layout"),
+                bind_group_layouts: &[&constants_layout],
+                immediate_size: 0,
+            });
+
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some("iced_wgpu.triangle.gradient.shader"),
+                source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(concat!(
+                    include_str!("shader/triangle.wgsl"),
+                    "\n",
+                    include_str!("shader/triangle/gradient.wgsl"),
+                    "\n",
+                    include_str!("shader/color.wgsl"),
+                    "\n",
+                    include_str!("shader/color/linear_rgb.wgsl")
+                ))),
+            });
+
+            let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("iced_wgpu.triangle.gradient.pipeline"),
+                layout: Some(&layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("gradient_vs_main"),
+                    buffers: &[wgpu::VertexBufferLayout {
+                        array_stride: std::mem::size_of::<mesh::GradientVertex2D>() as u64,
+                        step_mode: wgpu::VertexStepMode::Vertex,
+                        attributes: &wgpu::vertex_attr_array!(
+                            // Position
+                            0 => Float32x2,
+                            // Colors 1-2
+                            1 => Uint32x4,
+                            // Colors 3-4
+                            2 => Uint32x4,
+                            // Colors 5-6
+                            3 => Uint32x4,
+                            // Colors 7-8
+                            4 => Uint32x4,
+                            // Offsets
+                            5 => Uint32x4,
+                            // Direction
+                            6 => Float32x4
+                        ),
+                    }],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
                 },
-            );
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("gradient_fs_main"),
+                    targets: &[Some(triangle::fragment_target(format))],
+                    compilation_options: wgpu::PipelineCompilationOptions::default(),
+                }),
+                primitive: triangle::primitive_state(),
+                depth_stencil: None,
+                multisample: triangle::multisample_state(antialiasing),
+                multiview_mask: None,
+                cache: None,
+            });
 
             Self {
                 pipeline,

--- a/wgpu/src/triangle/msaa.rs
+++ b/wgpu/src/triangle/msaa.rs
@@ -21,104 +21,90 @@ impl Pipeline {
         format: wgpu::TextureFormat,
         antialiasing: graphics::Antialiasing,
     ) -> Pipeline {
-        let sampler =
-            device.create_sampler(&wgpu::SamplerDescriptor::default());
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor::default());
 
-        let constant_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("iced_wgpu::triangle:msaa uniforms layout"),
-                entries: &[
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 0,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Sampler(
-                            wgpu::SamplerBindingType::NonFiltering,
-                        ),
-                        count: None,
-                    },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 1,
-                        visibility: wgpu::ShaderStages::VERTEX,
-                        ty: wgpu::BindingType::Buffer {
-                            ty: wgpu::BufferBindingType::Uniform,
-                            has_dynamic_offset: false,
-                            min_binding_size: None,
-                        },
-                        count: None,
-                    },
-                ],
-            });
-
-        let texture_layout =
-            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("iced_wgpu::triangle::msaa texture layout"),
-                entries: &[wgpu::BindGroupLayoutEntry {
+        let constant_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("iced_wgpu::triangle:msaa uniforms layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
                     binding: 0,
                     visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        sample_type: wgpu::TextureSampleType::Float {
-                            filterable: false,
-                        },
-                        view_dimension: wgpu::TextureViewDimension::D2,
-                        multisampled: false,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
                     },
                     count: None,
-                }],
-            });
-
-        let layout =
-            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("iced_wgpu::triangle::msaa pipeline layout"),
-                bind_group_layouts: &[&constant_layout, &texture_layout],
-                immediate_size: 0,
-            });
-
-        let shader =
-            device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("iced_wgpu triangle blit_shader"),
-                source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(
-                    include_str!("../shader/blit.wgsl"),
-                )),
-            });
-
-        let pipeline =
-            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("iced_wgpu::triangle::msaa pipeline"),
-                layout: Some(&layout),
-                vertex: wgpu::VertexState {
-                    module: &shader,
-                    entry_point: Some("vs_main"),
-                    buffers: &[],
-                    compilation_options:
-                        wgpu::PipelineCompilationOptions::default(),
                 },
-                fragment: Some(wgpu::FragmentState {
-                    module: &shader,
-                    entry_point: Some("fs_main"),
-                    targets: &[Some(wgpu::ColorTargetState {
-                        format,
-                        blend: Some(
-                            wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING,
-                        ),
-                        write_mask: wgpu::ColorWrites::ALL,
-                    })],
-                    compilation_options:
-                        wgpu::PipelineCompilationOptions::default(),
-                }),
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleList,
-                    front_face: wgpu::FrontFace::Cw,
-                    ..Default::default()
+            ],
+        });
+
+        let texture_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("iced_wgpu::triangle::msaa texture layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
                 },
-                depth_stencil: None,
-                multisample: wgpu::MultisampleState {
-                    count: 1,
-                    mask: !0,
-                    alpha_to_coverage_enabled: false,
-                },
-                multiview_mask: None,
-                cache: None,
-            });
+                count: None,
+            }],
+        });
+
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("iced_wgpu::triangle::msaa pipeline layout"),
+            bind_group_layouts: &[&constant_layout, &texture_layout],
+            immediate_size: 0,
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("iced_wgpu triangle blit_shader"),
+            source: wgpu::ShaderSource::Wgsl(std::borrow::Cow::Borrowed(include_str!(
+                "../shader/blit.wgsl"
+            ))),
+        });
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("iced_wgpu::triangle::msaa pipeline"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format,
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: wgpu::PipelineCompilationOptions::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                front_face: wgpu::FrontFace::Cw,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview_mask: None,
+            cache: None,
+        });
 
         Self {
             format,
@@ -131,11 +117,7 @@ impl Pipeline {
         }
     }
 
-    fn targets(
-        &self,
-        device: &wgpu::Device,
-        region_size: Size<u32>,
-    ) -> Targets {
+    fn targets(&self, device: &wgpu::Device, region_size: Size<u32>) -> Targets {
         let mut targets = self.targets.write().expect("Write MSAA targets");
 
         match targets.as_mut() {
@@ -156,10 +138,7 @@ impl Pipeline {
         targets.as_ref().unwrap().clone()
     }
 
-    pub fn render_pass<'a>(
-        &self,
-        encoder: &'a mut wgpu::CommandEncoder,
-    ) -> wgpu::RenderPass<'a> {
+    pub fn render_pass<'a>(&self, encoder: &'a mut wgpu::CommandEncoder) -> wgpu::RenderPass<'a> {
         let targets = self.targets.read().expect("Read MSAA targets");
         let targets = targets.as_ref().unwrap();
 
@@ -222,16 +201,13 @@ impl Targets {
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format,
-            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
-                | wgpu::TextureUsages::TEXTURE_BINDING,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
             view_formats: &[],
         });
 
-        let attachment =
-            attachment.create_view(&wgpu::TextureViewDescriptor::default());
+        let attachment = attachment.create_view(&wgpu::TextureViewDescriptor::default());
 
-        let resolve =
-            resolve.create_view(&wgpu::TextureViewDescriptor::default());
+        let resolve = resolve.create_view(&wgpu::TextureViewDescriptor::default());
 
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("iced_wgpu::triangle::msaa texture bind group"),
@@ -319,8 +295,7 @@ impl State {
                 encoder,
                 &self.ratio,
                 0,
-                NonZeroU64::new(std::mem::size_of::<Ratio>() as u64)
-                    .expect("non-empty ratio"),
+                NonZeroU64::new(std::mem::size_of::<Ratio>() as u64).expect("non-empty ratio"),
             )
             .copy_from_slice(bytemuck::bytes_of(&ratio));
 
@@ -336,23 +311,22 @@ impl State {
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
     ) {
-        let mut render_pass =
-            encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("iced_wgpu::triangle::msaa render pass"),
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: target,
-                    depth_slice: None,
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Load,
-                        store: wgpu::StoreOp::Store,
-                    },
-                })],
-                depth_stencil_attachment: None,
-                timestamp_writes: None,
-                occlusion_query_set: None,
-                multiview_mask: None,
-            });
+        let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("iced_wgpu::triangle::msaa render pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
 
         render_pass.set_pipeline(&pipeline.raw);
         render_pass.set_bind_group(0, &self.constants, &[]);

--- a/wgpu/src/window.rs
+++ b/wgpu/src/window.rs
@@ -30,16 +30,14 @@ fn ids_from_dev(dev: u64) -> Option<(u16, u16)> {
         let mut file = File::open(&path).ok()?;
         let mut contents = String::new();
         let _ = file.read_to_string(&mut contents).ok()?;
-        u16::from_str_radix(contents.trim().trim_start_matches("0x"), 16)
-            .ok()?
+        u16::from_str_radix(contents.trim().trim_start_matches("0x"), 16).ok()?
     };
     let device = {
         let path = path.join("device");
         let mut file = File::open(&path).ok()?;
         let mut contents = String::new();
         let _ = file.read_to_string(&mut contents).ok()?;
-        u16::from_str_radix(contents.trim().trim_start_matches("0x"), 16)
-            .ok()?
+        u16::from_str_radix(contents.trim().trim_start_matches("0x"), 16).ok()?
     };
 
     Some((vendor, device))

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -72,8 +72,7 @@ impl Compositor {
             not(target_os = "redox")
         ))]
         let ids = compatible_window.as_ref().and_then(|window| {
-            get_wayland_device_ids(window)
-                .or_else(|| get_x11_device_ids(window))
+            get_wayland_device_ids(window).or_else(|| get_x11_device_ids(window))
         });
 
         // HACK:
@@ -89,8 +88,7 @@ impl Compositor {
             not(target_os = "redox")
         ))]
         if !matches!(ids, Some((0x10de, _)))
-            && std::env::var_os("__NV_PRIME_RENDER_OFFLOAD")
-                .is_none_or(|var| var == "0")
+            && std::env::var_os("__NV_PRIME_RENDER_OFFLOAD").is_none_or(|var| var == "0")
             && std::env::var_os("WGPU_ADAPTER_NAME").is_none()
             && std::env::var("WGPU_POWER_PREF").as_deref() != Ok("high")
         {
@@ -103,8 +101,8 @@ impl Compositor {
         // Otherwise it will panic when it drops the available adapters!
         let non_gl_backends = settings.backends.difference(Backends::GL);
         // only load the instance after setting environment variables, this initializes the vulkan loader
-        let mut instance = wgpu::util::new_instance_with_webgpu_detection(
-            &wgpu::InstanceDescriptor {
+        let mut instance =
+            wgpu::util::new_instance_with_webgpu_detection(&wgpu::InstanceDescriptor {
                 backends: non_gl_backends,
                 flags: if cfg!(feature = "strict-assertions") {
                     wgpu::InstanceFlags::debugging()
@@ -112,9 +110,8 @@ impl Compositor {
                     wgpu::InstanceFlags::empty()
                 },
                 ..Default::default()
-            },
-        )
-        .await;
+            })
+            .await;
 
         log::info!("{settings:#?}");
 
@@ -160,8 +157,7 @@ impl Compositor {
                     .into_iter()
                     .filter(|adapter| {
                         let info = adapter.get_info();
-                        info.device == device_id as u32
-                            && info.vendor == vendor_id as u32
+                        info.device == device_id as u32 && info.vendor == vendor_id as u32
                     })
                     .find(|adapter| {
                         if let Some(surface) = compatible_surface.as_ref() {
@@ -193,8 +189,8 @@ impl Compositor {
             Some(adapter) => adapter,
             None => {
                 // fall back to allowing GL backend if enabled
-                instance = wgpu::util::new_instance_with_webgpu_detection(
-                    &wgpu::InstanceDescriptor {
+                instance =
+                    wgpu::util::new_instance_with_webgpu_detection(&wgpu::InstanceDescriptor {
                         backends: settings.backends,
                         flags: if cfg!(feature = "strict-assertions") {
                             wgpu::InstanceFlags::debugging()
@@ -202,20 +198,20 @@ impl Compositor {
                             wgpu::InstanceFlags::empty()
                         },
                         ..Default::default()
-                    },
-                )
-                .await;
-                compatible_surface = compatible_window
-                    .and_then(|window| instance.create_surface(window).ok());
+                    })
+                    .await;
+                compatible_surface =
+                    compatible_window.and_then(|window| instance.create_surface(window).ok());
                 adapter_options = wgpu::RequestAdapterOptions {
                     power_preference: wgpu::PowerPreference::from_env()
                         .unwrap_or(wgpu::PowerPreference::HighPerformance),
                     compatible_surface: compatible_surface.as_ref(),
                     force_fallback_adapter: false,
                 };
-                instance.request_adapter(&adapter_options).await.map_err(
-                    |_| Error::NoAdapterFound(format!("{:?}", adapter_options)),
-                )?
+                instance
+                    .request_adapter(&adapter_options)
+                    .await
+                    .map_err(|_| Error::NoAdapterFound(format!("{:?}", adapter_options)))?
             }
         };
         log::info!("Selected: {:#?}", adapter.get_info());
@@ -255,33 +251,26 @@ impl Compositor {
 
                 log::info!("Available alpha modes: {alpha_modes:#?}");
 
-                let preferred_alpha = if alpha_modes
-                    .contains(&wgpu::CompositeAlphaMode::PostMultiplied)
-                {
-                    wgpu::CompositeAlphaMode::PostMultiplied
-                } else if alpha_modes
-                    .contains(&wgpu::CompositeAlphaMode::PreMultiplied)
-                {
-                    wgpu::CompositeAlphaMode::PreMultiplied
-                } else {
-                    wgpu::CompositeAlphaMode::Auto
-                };
+                let preferred_alpha =
+                    if alpha_modes.contains(&wgpu::CompositeAlphaMode::PostMultiplied) {
+                        wgpu::CompositeAlphaMode::PostMultiplied
+                    } else if alpha_modes.contains(&wgpu::CompositeAlphaMode::PreMultiplied) {
+                        wgpu::CompositeAlphaMode::PreMultiplied
+                    } else {
+                        wgpu::CompositeAlphaMode::Auto
+                    };
 
                 format.zip(Some(preferred_alpha))
             })
             .ok_or(Error::IncompatibleSurface)?;
 
-        log::info!(
-            "Selected format: {format:?} with alpha mode: {alpha_mode:?}"
-        );
+        log::info!("Selected format: {format:?} with alpha mode: {alpha_mode:?}");
 
         #[cfg(target_arch = "wasm32")]
-        let limits = [wgpu::Limits::downlevel_webgl2_defaults()
-            .using_resolution(adapter.limits())];
+        let limits = [wgpu::Limits::downlevel_webgl2_defaults().using_resolution(adapter.limits())];
 
         #[cfg(not(target_arch = "wasm32"))]
-        let limits =
-            [wgpu::Limits::default(), wgpu::Limits::downlevel_defaults()];
+        let limits = [wgpu::Limits::default(), wgpu::Limits::downlevel_defaults()];
 
         let limits = limits.into_iter().map(|limits| wgpu::Limits {
             max_bind_groups: 2,
@@ -294,15 +283,12 @@ impl Compositor {
         for required_limits in limits {
             let result = adapter
                 .request_device(&wgpu::DeviceDescriptor {
-                    label: Some(
-                        "iced_wgpu::window::compositor device descriptor",
-                    ),
+                    label: Some("iced_wgpu::window::compositor device descriptor"),
                     required_features: wgpu::Features::SHADER_F16,
                     required_limits: required_limits.clone(),
                     memory_hints: wgpu::MemoryHints::MemoryUsage,
                     trace: wgpu::Trace::Off,
-                    experimental_features: wgpu::ExperimentalFeatures::disabled(
-                    ),
+                    experimental_features: wgpu::ExperimentalFeatures::disabled(),
                 })
                 .await;
 
@@ -373,16 +359,10 @@ pub fn present(
             Ok(())
         }
         Err(error) => match error {
-            wgpu::SurfaceError::Timeout => {
-                Err(compositor::SurfaceError::Timeout)
-            }
-            wgpu::SurfaceError::Outdated => {
-                Err(compositor::SurfaceError::Outdated)
-            }
+            wgpu::SurfaceError::Timeout => Err(compositor::SurfaceError::Timeout),
+            wgpu::SurfaceError::Outdated => Err(compositor::SurfaceError::Outdated),
             wgpu::SurfaceError::Lost => Err(compositor::SurfaceError::Lost),
-            wgpu::SurfaceError::OutOfMemory => {
-                Err(compositor::SurfaceError::OutOfMemory)
-            }
+            wgpu::SurfaceError::OutOfMemory => Err(compositor::SurfaceError::OutOfMemory),
             wgpu::SurfaceError::Other => Err(compositor::SurfaceError::Other),
         },
     }
@@ -448,12 +428,7 @@ impl graphics::Compositor for Compositor {
         surface
     }
 
-    fn configure_surface(
-        &mut self,
-        surface: &mut Self::Surface,
-        width: u32,
-        height: u32,
-    ) {
+    fn configure_surface(&mut self, surface: &mut Self::Surface, width: u32, height: u32) {
         surface.configure(
             &self.engine.device,
             &wgpu::SurfaceConfiguration {

--- a/wgpu/src/window/wayland.rs
+++ b/wgpu/src/window/wayland.rs
@@ -6,8 +6,7 @@ use cctk::sctk::{
 };
 use raw_window_handle::{RawDisplayHandle, WaylandDisplayHandle};
 use wayland_client::{
-    Connection, QueueHandle, backend::Backend, globals::registry_queue_init,
-    protocol::wl_buffer,
+    Connection, QueueHandle, backend::Backend, globals::registry_queue_init, protocol::wl_buffer,
 };
 use wayland_protocols::wp::linux_dmabuf::zv1::client::{
     zwp_linux_buffer_params_v1, zwp_linux_dmabuf_feedback_v1,
@@ -74,11 +73,11 @@ pub fn get_wayland_device_ids<W: Window>(window: &W) -> Option<(u16, u16)> {
 
     let conn = match window.display_handle().map(|handle| handle.as_raw()) {
         #[allow(unsafe_code)]
-        Ok(RawDisplayHandle::Wayland(WaylandDisplayHandle {
-            display, ..
-        })) => Connection::from_backend(unsafe {
-            Backend::from_foreign_display(display.as_ptr() as *mut _)
-        }),
+        Ok(RawDisplayHandle::Wayland(WaylandDisplayHandle { display, .. })) => {
+            Connection::from_backend(unsafe {
+                Backend::from_foreign_display(display.as_ptr() as *mut _)
+            })
+        }
         _ => {
             return None;
         }

--- a/wgpu/src/window/x11.rs
+++ b/wgpu/src/window/x11.rs
@@ -7,19 +7,14 @@ use std::{
 use crate::graphics::compositor::Window;
 
 use as_raw_xcb_connection::AsRawXcbConnection;
-use raw_window_handle::{
-    RawDisplayHandle, XcbDisplayHandle, XlibDisplayHandle,
-};
+use raw_window_handle::{RawDisplayHandle, XcbDisplayHandle, XlibDisplayHandle};
 use rustix::fs::{fstat, stat};
 use tiny_xlib::Display;
 use x11rb::{
     connection::{Connection, RequestConnection},
     protocol::{
         dri3::{ConnectionExt as _, X11_EXTENSION_NAME as DRI3_NAME},
-        randr::{
-            ConnectionExt as _, ProviderCapability,
-            X11_EXTENSION_NAME as RANDR_NAME,
-        },
+        randr::{ConnectionExt as _, ProviderCapability, X11_EXTENSION_NAME as RANDR_NAME},
     },
     xcb_ffi::XCBConnection,
 };
@@ -28,15 +23,10 @@ pub fn get_x11_device_ids<W: Window>(window: &W) -> Option<(u16, u16)> {
     x11rb::xcb_ffi::load_libxcb().ok()?;
 
     #[allow(unsafe_code)]
-    let (conn, screen) = match window
-        .display_handle()
-        .map(|handle| handle.as_raw())
-    {
+    let (conn, screen) = match window.display_handle().map(|handle| handle.as_raw()) {
         #[allow(unsafe_code)]
         Ok(RawDisplayHandle::Xlib(XlibDisplayHandle {
-            display,
-            screen,
-            ..
+            display, screen, ..
         })) => match display {
             Some(ptr) => unsafe {
                 let xlib_display = Display::from_ptr(ptr.as_ptr());
@@ -52,15 +42,10 @@ pub fn get_x11_device_ids<W: Window>(window: &W) -> Option<(u16, u16)> {
             None => (XCBConnection::connect(None).ok()?.0, screen),
         },
         Ok(RawDisplayHandle::Xcb(XcbDisplayHandle {
-            connection,
-            screen,
-            ..
+            connection, screen, ..
         })) => match connection {
             Some(ptr) => (
-                unsafe {
-                    XCBConnection::from_raw_xcb_connection(ptr.as_ptr(), false)
-                        .ok()?
-                },
+                unsafe { XCBConnection::from_raw_xcb_connection(ptr.as_ptr(), false).ok()? },
                 screen,
             ),
             None => (XCBConnection::connect(None).ok()?.0, screen),
@@ -82,9 +67,7 @@ pub fn get_x11_device_ids<W: Window>(window: &W) -> Option<(u16, u16)> {
     let _ = conn.extension_information(RANDR_NAME).ok()??;
     // check version, because we need providers to exist
     let version = conn.randr_query_version(1, 4).ok()?.reply().ok()?;
-    if version.major_version < 1
-        || (version.major_version == 1 && version.minor_version < 4)
-    {
+    if version.major_version < 1 || (version.major_version == 1 && version.minor_version < 4) {
         return None;
     }
 
@@ -109,19 +92,17 @@ pub fn get_x11_device_ids<W: Window>(window: &W) -> Option<(u16, u16)> {
     }
 
     // if that name is formatted `NVIDIA-x`, then x represents the /dev/nvidiaX number, which we can relate to /dev/dri
-    if let Some(number) = name.and_then(|name| {
-        name.trim().strip_prefix("NVIDIA-")?.parse::<u32>().ok()
-    }) {
+    if let Some(number) =
+        name.and_then(|name| name.trim().strip_prefix("NVIDIA-")?.parse::<u32>().ok())
+    {
         // let it be known, that I hate this "interface"...
         for busid in fs::read_dir("/proc/driver/nvidia/gpus")
             .ok()?
             .map(Result::ok)
             .flatten()
         {
-            for line in BufReader::new(
-                fs::File::open(busid.path().join("information")).ok()?,
-            )
-            .lines()
+            for line in
+                BufReader::new(fs::File::open(busid.path().join("information")).ok()?).lines()
             {
                 if let Ok(line) = line {
                     if line.starts_with("Device Minor") {
@@ -142,8 +123,7 @@ pub fn get_x11_device_ids<W: Window>(window: &W) -> Option<(u16, u16)> {
                                     if device.to_string_lossy().starts_with("card")
                                         || device.to_string_lossy().starts_with("render")
                                     {
-                                        let stat =
-                                            stat(Path::new("/dev/dri").join(device)).ok()?;
+                                        let stat = stat(Path::new("/dev/dri").join(device)).ok()?;
                                         let dev = stat.st_rdev;
                                         return super::ids_from_dev(dev);
                                     }

--- a/widget/src/action.rs
+++ b/widget/src/action.rs
@@ -73,9 +73,7 @@ impl<Message> Action<Message> {
     ///
     /// This method is meant to be used by runtimes, libraries, or internal
     /// widget implementations.
-    pub fn into_inner(
-        self,
-    ) -> (Option<Message>, window::RedrawRequest, event::Status) {
+    pub fn into_inner(self) -> (Option<Message>, window::RedrawRequest, event::Status) {
         (
             self.message_to_publish,
             self.redraw_request,

--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -34,8 +34,8 @@ use crate::core::widget::Operation;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    Background, Clipboard, Color, Element, Event, Layout, Length, Padding,
-    Rectangle, Shadow, Shell, Size, Theme, Vector, Widget,
+    Background, Clipboard, Color, Element, Event, Layout, Length, Padding, Rectangle, Shadow,
+    Shell, Size, Theme, Vector, Widget,
 };
 
 use iced_renderer::core::widget::operation;
@@ -119,9 +119,7 @@ where
     Theme: Catalog,
 {
     /// Creates a new [`Button`] with the given content.
-    pub fn new(
-        content: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn new(content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         let content = content.into();
         let size = content.as_widget().size_hint();
 
@@ -178,10 +176,7 @@ where
     /// This closure will only be called when the [`Button`] is actually pressed and,
     /// therefore, this method is useful to reduce overhead if creating the resulting
     /// message is slow.
-    pub fn on_press_with(
-        mut self,
-        on_press: impl Fn() -> Message + 'a,
-    ) -> Self {
+    pub fn on_press_with(mut self, on_press: impl Fn() -> Message + 'a) -> Self {
         self.on_press = Some(OnPress::Closure(Box::new(on_press)));
         self
     }
@@ -235,10 +230,7 @@ where
 
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Button`].
-    pub fn description_widget<T: iced_accessibility::Describes>(
-        mut self,
-        description: &T,
-    ) -> Self {
+    pub fn description_widget<T: iced_accessibility::Describes>(mut self, description: &T) -> Self {
         self.description = Some(iced_accessibility::Description::Id(
             description.description(),
         ));
@@ -248,16 +240,14 @@ where
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Button`].
     pub fn description(mut self, description: impl Into<Cow<'a, str>>) -> Self {
-        self.description =
-            Some(iced_accessibility::Description::Text(description.into()));
+        self.description = Some(iced_accessibility::Description::Text(description.into()));
         self
     }
 
     #[cfg(feature = "a11y")]
     /// Sets the label of the [`Button`].
     pub fn label(mut self, label: &dyn iced_accessibility::Labels) -> Self {
-        self.label =
-            Some(label.label().into_iter().map(|l| l.into()).collect());
+        self.label = Some(label.label().into_iter().map(|l| l.into()).collect());
         self
     }
 }
@@ -305,19 +295,11 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        layout::padded(
-            limits,
-            self.width,
-            self.height,
-            self.padding,
-            |limits| {
-                self.content.as_widget_mut().layout(
-                    &mut tree.children[0],
-                    renderer,
-                    limits,
-                )
-            },
-        )
+        layout::padded(limits, self.width, self.height, self.padding, |limits| {
+            self.content
+                .as_widget_mut()
+                .layout(&mut tree.children[0], renderer, limits)
+        })
     }
 
     fn operate(
@@ -406,16 +388,10 @@ where
                 }
             }
             #[cfg(feature = "a11y")]
-            Event::A11y(
-                event_id,
-                iced_accessibility::accesskit::ActionRequest { action, .. },
-            ) => {
+            Event::A11y(event_id, iced_accessibility::accesskit::ActionRequest { action, .. }) => {
                 let state = tree.state.downcast_mut::<State>();
                 if let Some(Some(on_press)) = (self.id == *event_id
-                    && matches!(
-                        action,
-                        iced_accessibility::accesskit::Action::Click
-                    ))
+                    && matches!(action, iced_accessibility::accesskit::Action::Click))
                 .then(|| self.on_press.as_ref())
                 {
                     state.is_pressed = false;
@@ -427,10 +403,7 @@ where
                 if let Some(on_press) = self.on_press.as_ref() {
                     let state = tree.state.downcast_mut::<State>();
                     if state.is_focused
-                        && matches!(
-                            key,
-                            keyboard::Key::Named(keyboard::key::Named::Enter)
-                        )
+                        && matches!(key, keyboard::Key::Named(keyboard::key::Named::Enter))
                     {
                         state.is_pressed = true;
                         shell.publish(on_press.get());
@@ -485,13 +458,9 @@ where
             .next()
             .unwrap()
             .with_virtual_offset(layout.virtual_offset());
-        let style =
-            theme.style(&self.class, self.status.unwrap_or(Status::Disabled));
+        let style = theme.style(&self.class, self.status.unwrap_or(Status::Disabled));
 
-        if style.background.is_some()
-            || style.border.width > 0.0
-            || style.shadow.color.a > 0.0
-        {
+        if style.background.is_some() || style.border.width > 0.0 || style.shadow.color.a > 0.0 {
             renderer.fill_quad(
                 renderer::Quad {
                     bounds,
@@ -517,9 +486,7 @@ where
             theme,
             &renderer::Style {
                 text_color: style.text_color,
-                icon_color: style
-                    .icon_color
-                    .unwrap_or(renderer_style.icon_color),
+                icon_color: style.icon_color.unwrap_or(renderer_style.icon_color),
                 scale_factor: renderer_style.scale_factor,
             },
             content_layout,
@@ -593,12 +560,7 @@ where
             width,
             height,
         } = layout.bounds();
-        let bounds = Rect::new(
-            x as f64,
-            y as f64,
-            (x + width) as f64,
-            (y + height) as f64,
-        );
+        let bounds = Rect::new(x as f64, y as f64, (x + width) as f64, (y + height) as f64);
         let is_hovered = state.state.downcast_ref::<State>().is_hovered;
 
         let mut node = Node::new(Role::Button);
@@ -637,10 +599,7 @@ where
         //     node.set_busy()
         // }
 
-        A11yTree::node_with_child_tree(
-            A11yNode::new(node, self.id.clone()),
-            child_tree,
-        )
+        A11yTree::node_with_child_tree(A11yNode::new(node, self.id.clone()), child_tree)
     }
 
     fn id(&self) -> Option<Id> {
@@ -934,9 +893,7 @@ pub fn background(theme: &Theme, status: Status) -> Style {
     match status {
         Status::Active => base,
         Status::Pressed => Style {
-            background: Some(Background::Color(
-                palette.background.strong.color,
-            )),
+            background: Some(Background::Color(palette.background.strong.color)),
             ..base
         },
         Status::Hovered => Style {
@@ -955,15 +912,11 @@ pub fn subtle(theme: &Theme, status: Status) -> Style {
     match status {
         Status::Active => base,
         Status::Pressed => Style {
-            background: Some(Background::Color(
-                palette.background.strong.color,
-            )),
+            background: Some(Background::Color(palette.background.strong.color)),
             ..base
         },
         Status::Hovered => Style {
-            background: Some(Background::Color(
-                palette.background.weaker.color,
-            )),
+            background: Some(Background::Color(palette.background.weaker.color)),
             ..base
         },
         Status::Disabled => disabled(base),

--- a/widget/src/canvas.rs
+++ b/widget/src/canvas.rs
@@ -56,8 +56,8 @@ pub use crate::Action;
 pub use crate::core::event::Event;
 pub use crate::graphics::cache::Group;
 pub use crate::graphics::geometry::{
-    Fill, Gradient, Image, LineCap, LineDash, LineJoin, Path, Stroke, Style,
-    Text, fill, gradient, path, stroke,
+    Fill, Gradient, Image, LineCap, LineDash, LineJoin, Path, Stroke, Style, Text, fill, gradient,
+    path, stroke,
 };
 
 use crate::core::event;
@@ -66,9 +66,7 @@ use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
-use crate::core::{
-    Clipboard, Element, Length, Rectangle, Shell, Size, Vector, Widget,
-};
+use crate::core::{Clipboard, Element, Length, Rectangle, Shell, Size, Vector, Widget};
 use crate::graphics::geometry;
 
 use std::marker::PhantomData;
@@ -80,8 +78,7 @@ use std::marker::PhantomData;
 pub type Cache<Renderer = crate::Renderer> = geometry::Cache<Renderer>;
 
 /// The geometry supported by a renderer.
-pub type Geometry<Renderer = crate::Renderer> =
-    <Renderer as geometry::Renderer>::Geometry;
+pub type Geometry<Renderer = crate::Renderer> = <Renderer as geometry::Renderer>::Geometry;
 
 /// The frame supported by a renderer.
 pub type Frame<Renderer = crate::Renderer> = geometry::Frame<Renderer>;
@@ -229,13 +226,10 @@ where
         let bounds = layout.bounds();
 
         let state = tree.state.downcast_mut::<P::State>();
-        let is_redraw_request = matches!(
-            event,
-            Event::Window(window::Event::RedrawRequested(_now)),
-        );
+        let is_redraw_request =
+            matches!(event, Event::Window(window::Event::RedrawRequested(_now)),);
 
-        if let Some(action) = self.program.update(state, event, bounds, cursor)
-        {
+        if let Some(action) = self.program.update(state, event, bounds, cursor) {
             let (message, redraw_request, event_status) = action.into_inner();
 
             shell.request_redraw_at(redraw_request);
@@ -250,16 +244,15 @@ where
         }
 
         if shell.redraw_request() != window::RedrawRequest::NextFrame {
-            let mouse_interaction = self
-                .mouse_interaction(tree, layout, cursor, viewport, renderer);
+            let mouse_interaction =
+                self.mouse_interaction(tree, layout, cursor, viewport, renderer);
 
             if is_redraw_request {
                 self.last_mouse_interaction = Some(mouse_interaction);
-            } else if self.last_mouse_interaction.is_some_and(
-                |last_mouse_interaction| {
-                    last_mouse_interaction != mouse_interaction
-                },
-            ) {
+            } else if self
+                .last_mouse_interaction
+                .is_some_and(|last_mouse_interaction| last_mouse_interaction != mouse_interaction)
+            {
                 shell.request_redraw();
             }
         }
@@ -297,17 +290,13 @@ where
 
         let state = tree.state.downcast_ref::<P::State>();
 
-        renderer.with_translation(
-            Vector::new(bounds.x, bounds.y),
-            |renderer| {
-                let layers =
-                    self.program.draw(state, renderer, theme, bounds, cursor);
+        renderer.with_translation(Vector::new(bounds.x, bounds.y), |renderer| {
+            let layers = self.program.draw(state, renderer, theme, bounds, cursor);
 
-                for layer in layers {
-                    renderer.draw_geometry(layer);
-                }
-            },
-        );
+            for layer in layers {
+                renderer.draw_geometry(layer);
+            }
+        });
     }
 }
 
@@ -319,9 +308,7 @@ where
     Renderer: 'a + geometry::Renderer,
     P: 'a + Program<Message, Theme, Renderer>,
 {
-    fn from(
-        canvas: Canvas<P, Message, Theme, Renderer>,
-    ) -> Element<'a, Message, Theme, Renderer> {
+    fn from(canvas: Canvas<P, Message, Theme, Renderer>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(canvas)
     }
 }

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -47,8 +47,8 @@ use crate::core::widget;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    Background, Border, Clipboard, Color, Element, Event, Layout, Length,
-    Pixels, Rectangle, Shell, Size, Theme, Widget, id::Internal,
+    Background, Border, Clipboard, Color, Element, Event, Layout, Length, Pixels, Rectangle, Shell,
+    Size, Theme, Widget, id::Internal,
 };
 
 /// A box that can be checked.
@@ -84,12 +84,8 @@ use crate::core::{
 /// }
 /// ```
 /// ![Checkbox drawn by `iced_wgpu`](https://github.com/iced-rs/iced/blob/7760618fb112074bc40b148944521f312152012a/docs/images/checkbox.png?raw=true)
-pub struct Checkbox<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct Checkbox<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Renderer: text::Renderer,
     Theme: Catalog,
 {
@@ -217,10 +213,7 @@ where
     }
 
     /// Sets the text [`text::LineHeight`] of the [`Checkbox`].
-    pub fn text_line_height(
-        mut self,
-        line_height: impl Into<text::LineHeight>,
-    ) -> Self {
+    pub fn text_line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
         self.text_line_height = line_height.into();
         self
     }
@@ -278,10 +271,7 @@ where
 
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Checkbox`].
-    pub fn description_widget<T: iced_accessibility::Describes>(
-        mut self,
-        description: &T,
-    ) -> Self {
+    pub fn description_widget<T: iced_accessibility::Describes>(mut self, description: &T) -> Self {
         self.description = Some(iced_accessibility::Description::Id(
             description.description(),
         ));
@@ -291,8 +281,7 @@ where
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Checkbox`].
     pub fn description(mut self, description: impl Into<Cow<'a, str>>) -> Self {
-        self.description =
-            Some(iced_accessibility::Description::Text(description.into()));
+        self.description = Some(iced_accessibility::Description::Text(description.into()));
         self
     }
 }
@@ -335,8 +324,8 @@ where
             |limits| {
                 if let Some(label) = self.label.as_deref() {
                     let state = tree
-                    .state
-                    .downcast_mut::<widget::text::State<Renderer::Paragraph>>();
+                        .state
+                        .downcast_mut::<widget::text::State<Renderer::Paragraph>>();
 
                     widget::text::layout(
                         state,
@@ -495,8 +484,7 @@ where
 
         {
             let label_layout = children.next().unwrap();
-            let state: &widget::text::State<Renderer::Paragraph> =
-                tree.state.downcast_ref();
+            let state: &widget::text::State<Renderer::Paragraph> = tree.state.downcast_ref();
 
             crate::text::draw(
                 renderer,
@@ -544,12 +532,7 @@ where
             height,
         } = bounds;
 
-        let bounds = Rect::new(
-            x as f64,
-            y as f64,
-            (x + width) as f64,
-            (y + height) as f64,
-        );
+        let bounds = Rect::new(x as f64, y as f64, (x + width) as f64, (y + height) as f64);
 
         let mut node = Node::new(Role::CheckBox);
         node.add_action(Action::Focus);

--- a/widget/src/column.rs
+++ b/widget/src/column.rs
@@ -6,8 +6,8 @@ use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::widget::{Operation, Tree};
 use crate::core::{
-    Clipboard, Element, Event, Layout, Length, Padding, Pixels, Rectangle,
-    Shell, Size, Vector, Widget,
+    Clipboard, Element, Event, Layout, Length, Padding, Pixels, Rectangle, Shell, Size, Vector,
+    Widget,
 };
 
 /// A container that distributes its contents vertically.
@@ -32,8 +32,7 @@ use crate::core::{
 ///     ].into()
 /// }
 /// ```
-pub struct Column<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
-{
+pub struct Column<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     spacing: f32,
     padding: Padding,
     width: Length,
@@ -74,9 +73,7 @@ where
     ///
     /// If any of the children have a [`Length::Fill`] strategy, you will need to
     /// call [`Column::width`] or [`Column::height`] accordingly.
-    pub fn from_vec(
-        children: Vec<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn from_vec(children: Vec<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             spacing: 0.0,
             padding: Padding::ZERO,
@@ -137,10 +134,7 @@ where
     }
 
     /// Adds an element to the [`Column`].
-    pub fn push(
-        mut self,
-        child: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn push(mut self, child: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         let child = child.into();
         let child_size = child.as_widget().size_hint();
 
@@ -195,14 +189,9 @@ where
 }
 
 impl<'a, Message, Theme, Renderer: crate::core::Renderer>
-    FromIterator<Element<'a, Message, Theme, Renderer>>
-    for Column<'a, Message, Theme, Renderer>
+    FromIterator<Element<'a, Message, Theme, Renderer>> for Column<'a, Message, Theme, Renderer>
 {
-    fn from_iter<
-        T: IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
-    >(
-        iter: T,
-    ) -> Self {
+    fn from_iter<T: IntoIterator<Item = Element<'a, Message, Theme, Renderer>>>(iter: T) -> Self {
         Self::with_children(iter)
     }
 }
@@ -449,12 +438,7 @@ where
 ///
 /// The original alignment of the [`Column`] is preserved per column wrapped.
 #[allow(missing_debug_implementations)]
-pub struct Wrapping<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> {
+pub struct Wrapping<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     column: Column<'a, Message, Theme, Renderer>,
     horizontal_spacing: Option<f32>,
     align_y: alignment::Vertical,
@@ -527,20 +511,15 @@ where
                 for node in &mut children[column_start] {
                     let width = node.size().width;
 
-                    node.translate_mut(Vector::new(
-                        (column_width - width) / align_factor,
-                        0.0,
-                    ));
+                    node.translate_mut(Vector::new((column_width - width) / align_factor, 0.0));
                 }
             }
         };
 
         for (i, child) in self.column.children.iter_mut().enumerate() {
-            let node = child.as_widget_mut().layout(
-                &mut tree.children[i],
-                renderer,
-                &child_limits,
-            );
+            let node = child
+                .as_widget_mut()
+                .layout(&mut tree.children[i], renderer, &child_limits);
 
             let child_size = node.size();
 
@@ -557,10 +536,8 @@ where
 
             column_width = column_width.max(child_size.width);
 
-            children.push(node.move_to((
-                x + self.column.padding.left,
-                y + self.column.padding.top,
-            )));
+            children
+                .push(node.move_to((x + self.column.padding.left, y + self.column.padding.top)));
 
             y += child_size.height + spacing;
         }
@@ -593,10 +570,8 @@ where
                     .unwrap_or_default();
 
                 if next_y == 0.0 {
-                    let translation = Vector::new(
-                        0.0,
-                        (total_height - column_height) / align_factor,
-                    );
+                    let translation =
+                        Vector::new(0.0, (total_height - column_height) / align_factor);
 
                     for node in &mut children[column_start..=i] {
                         node.translate_mut(translation);
@@ -607,11 +582,7 @@ where
             }
         }
 
-        let size = limits.resolve(
-            self.column.width,
-            self.column.height,
-            intrinsic_size,
-        );
+        let size = limits.resolve(self.column.width, self.column.height, intrinsic_size);
 
         layout::Node::with_children(size.expand(self.column.padding), children)
     }

--- a/widget/src/combo_box.rs
+++ b/widget/src/combo_box.rs
@@ -64,8 +64,7 @@ use crate::core::text;
 use crate::core::time::Instant;
 use crate::core::widget::{self, Widget};
 use crate::core::{
-    Clipboard, Element, Event, Length, Padding, Pixels, Rectangle, Shell, Size,
-    Theme, Vector,
+    Clipboard, Element, Event, Length, Padding, Pixels, Rectangle, Shell, Size, Theme, Vector,
 };
 use crate::overlay::menu;
 use crate::text::LineHeight;
@@ -130,13 +129,8 @@ use std::fmt::Display;
 ///     }
 /// }
 /// ```
-pub struct ComboBox<
-    'a,
-    T,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct ComboBox<'a, T, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Theme: Catalog,
     Renderer: text::Renderer,
 {
@@ -197,20 +191,14 @@ where
 
     /// Sets the message that should be produced when some text is typed into
     /// the [`TextInput`] of the [`ComboBox`].
-    pub fn on_input(
-        mut self,
-        on_input: impl Fn(String) -> Message + 'static,
-    ) -> Self {
+    pub fn on_input(mut self, on_input: impl Fn(String) -> Message + 'static) -> Self {
         self.on_input = Some(Box::new(on_input));
         self
     }
 
     /// Sets the message that will be produced when an option of the
     /// [`ComboBox`] is hovered using the arrow keys.
-    pub fn on_option_hovered(
-        mut self,
-        on_option_hovered: impl Fn(T) -> Message + 'static,
-    ) -> Self {
+    pub fn on_option_hovered(mut self, on_option_hovered: impl Fn(T) -> Message + 'static) -> Self {
         self.on_option_hovered = Some(Box::new(on_option_hovered));
         self
     }
@@ -296,8 +284,7 @@ where
         style: impl Fn(&Theme, text_input::Status) -> text_input::Style + 'a,
     ) -> Self
     where
-        <Theme as text_input::Catalog>::Class<'a>:
-            From<text_input::StyleFn<'a, Theme>>,
+        <Theme as text_input::Catalog>::Class<'a>: From<text_input::StyleFn<'a, Theme>>,
     {
         self.text_input = self.text_input.style(style);
         self
@@ -305,10 +292,7 @@ where
 
     /// Sets the style of the menu of the [`ComboBox`].
     #[must_use]
-    pub fn menu_style(
-        mut self,
-        style: impl Fn(&Theme) -> menu::Style + 'a,
-    ) -> Self
+    pub fn menu_style(mut self, style: impl Fn(&Theme) -> menu::Style + 'a) -> Self
     where
         <Theme as menu::Catalog>::Class<'a>: From<menu::StyleFn<'a, Theme>>,
     {
@@ -330,10 +314,7 @@ where
     /// Sets the style class of the menu of the [`ComboBox`].
     #[cfg(feature = "advanced")]
     #[must_use]
-    pub fn menu_class(
-        mut self,
-        class: impl Into<<Theme as menu::Catalog>::Class<'a>>,
-    ) -> Self {
+    pub fn menu_class(mut self, class: impl Into<<Theme as menu::Catalog>::Class<'a>>) -> Self {
         self.menu_class = class.into();
         self
     }
@@ -613,13 +594,9 @@ where
                 state.value = new_value;
 
                 state.filtered_options.update(
-                    search(
-                        &self.state.options,
-                        &state.option_matchers,
-                        &state.value,
-                    )
-                    .cloned()
-                    .collect(),
+                    search(&self.state.options, &state.option_matchers, &state.value)
+                        .cloned()
+                        .collect(),
                 );
             });
             shell.invalidate_layout();
@@ -636,14 +613,10 @@ where
 
         if is_focused {
             self.state.with_inner(|state| {
-                if !started_focused
-                    && let Some(on_option_hovered) = &mut self.on_option_hovered
-                {
+                if !started_focused && let Some(on_option_hovered) = &mut self.on_option_hovered {
                     let hovered_option = menu.hovered_option.unwrap_or(0);
 
-                    if let Some(option) =
-                        state.filtered_options.options.get(hovered_option)
-                    {
+                    if let Some(option) = state.filtered_options.options.get(hovered_option) {
                         shell.publish(on_option_hovered(option.clone()));
                         published_message_to_shell = true;
                     }
@@ -659,8 +632,7 @@ where
                     match (named_key, shift_modifier) {
                         (key::Named::Enter, _) => {
                             if let Some(index) = &menu.hovered_option
-                                && let Some(option) =
-                                    state.filtered_options.options.get(*index)
+                                && let Some(option) = state.filtered_options.options.get(*index)
                             {
                                 menu.new_selection = Some(option.clone());
                             }
@@ -671,11 +643,7 @@ where
                         (key::Named::ArrowUp, _) | (key::Named::Tab, true) => {
                             if let Some(index) = &mut menu.hovered_option {
                                 if *index == 0 {
-                                    *index = state
-                                        .filtered_options
-                                        .options
-                                        .len()
-                                        .saturating_sub(1);
+                                    *index = state.filtered_options.options.len().saturating_sub(1);
                                 } else {
                                     *index = index.saturating_sub(1);
                                 }
@@ -683,66 +651,42 @@ where
                                 menu.hovered_option = Some(0);
                             }
 
-                            if let Some(on_option_hovered) =
-                                &mut self.on_option_hovered
-                                && let Some(option) =
-                                    menu.hovered_option.and_then(|index| {
-                                        state
-                                            .filtered_options
-                                            .options
-                                            .get(index)
-                                    })
+                            if let Some(on_option_hovered) = &mut self.on_option_hovered
+                                && let Some(option) = menu
+                                    .hovered_option
+                                    .and_then(|index| state.filtered_options.options.get(index))
                             {
                                 // Notify the selection
-                                shell.publish((on_option_hovered)(
-                                    option.clone(),
-                                ));
+                                shell.publish((on_option_hovered)(option.clone()));
                                 published_message_to_shell = true;
                             }
 
                             shell.capture_event();
                             shell.request_redraw();
                         }
-                        (key::Named::ArrowDown, _)
-                        | (key::Named::Tab, false)
+                        (key::Named::ArrowDown, _) | (key::Named::Tab, false)
                             if !modifiers.shift() =>
                         {
                             if let Some(index) = &mut menu.hovered_option {
-                                if *index
-                                    >= state
-                                        .filtered_options
-                                        .options
-                                        .len()
-                                        .saturating_sub(1)
+                                if *index >= state.filtered_options.options.len().saturating_sub(1)
                                 {
                                     *index = 0;
                                 } else {
                                     *index = index.saturating_add(1).min(
-                                        state
-                                            .filtered_options
-                                            .options
-                                            .len()
-                                            .saturating_sub(1),
+                                        state.filtered_options.options.len().saturating_sub(1),
                                     );
                                 }
                             } else {
                                 menu.hovered_option = Some(0);
                             }
 
-                            if let Some(on_option_hovered) =
-                                &mut self.on_option_hovered
-                                && let Some(option) =
-                                    menu.hovered_option.and_then(|index| {
-                                        state
-                                            .filtered_options
-                                            .options
-                                            .get(index)
-                                    })
+                            if let Some(on_option_hovered) = &mut self.on_option_hovered
+                                && let Some(option) = menu
+                                    .hovered_option
+                                    .and_then(|index| state.filtered_options.options.get(index))
                             {
                                 // Notify the selection
-                                shell.publish((on_option_hovered)(
-                                    option.clone(),
-                                ));
+                                shell.publish((on_option_hovered)(option.clone()));
                                 published_message_to_shell = true;
                             }
 
@@ -772,9 +716,7 @@ where
                 let mut local_shell = Shell::new(&mut local_messages);
                 self.text_input.update(
                     &mut tree.children[0],
-                    &Event::Mouse(mouse::Event::ButtonPressed(
-                        mouse::Button::Left,
-                    )),
+                    &Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)),
                     layout,
                     mouse::Cursor::Unavailable,
                     renderer,
@@ -818,13 +760,8 @@ where
         viewport: &Rectangle,
         renderer: &Renderer,
     ) -> mouse::Interaction {
-        self.text_input.mouse_interaction(
-            &tree.children[0],
-            layout,
-            cursor,
-            viewport,
-            renderer,
-        )
+        self.text_input
+            .mouse_interaction(&tree.children[0], layout, cursor, viewport, renderer)
     }
 
     fn draw(
@@ -938,8 +875,7 @@ where
     }
 }
 
-impl<'a, T, Message, Theme, Renderer>
-    From<ComboBox<'a, T, Message, Theme, Renderer>>
+impl<'a, T, Message, Theme, Renderer> From<ComboBox<'a, T, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
     T: Display + Clone + 'static,
@@ -995,9 +931,7 @@ where
         })
 }
 
-fn build_matchers<'a, T>(
-    options: impl IntoIterator<Item = T> + 'a,
-) -> Vec<String>
+fn build_matchers<'a, T>(options: impl IntoIterator<Item = T> + 'a) -> Vec<String>
 where
     T: Display + 'a,
 {

--- a/widget/src/container.rs
+++ b/widget/src/container.rs
@@ -30,9 +30,8 @@ use crate::core::theme;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::widget::{self, Id, Operation};
 use crate::core::{
-    self, Background, Clipboard, Color, Element, Event, Layout, Length,
-    Padding, Pixels, Rectangle, Shadow, Shell, Size, Theme, Vector, Widget,
-    color,
+    self, Background, Clipboard, Color, Element, Event, Layout, Length, Padding, Pixels, Rectangle,
+    Shadow, Shell, Size, Theme, Vector, Widget, color,
 };
 
 use iced_runtime::{Action, Task, task};
@@ -58,12 +57,8 @@ use iced_runtime::{Action, Task, task};
 ///         .into()
 /// }
 /// ```
-pub struct Container<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct Container<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Theme: Catalog,
     Renderer: core::Renderer,
 {
@@ -86,9 +81,7 @@ where
     Renderer: core::Renderer,
 {
     /// Creates a [`Container`] with the given content.
-    pub fn new(
-        content: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn new(content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         let content = content.into();
         let size = content.as_widget().size_hint();
 
@@ -187,19 +180,13 @@ where
     }
 
     /// Sets the content alignment for the horizontal axis of the [`Container`].
-    pub fn align_x(
-        mut self,
-        alignment: impl Into<alignment::Horizontal>,
-    ) -> Self {
+    pub fn align_x(mut self, alignment: impl Into<alignment::Horizontal>) -> Self {
         self.horizontal_alignment = alignment.into();
         self
     }
 
     /// Sets the content alignment for the vertical axis of the [`Container`].
-    pub fn align_y(
-        mut self,
-        alignment: impl Into<alignment::Vertical>,
-    ) -> Self {
+    pub fn align_y(mut self, alignment: impl Into<alignment::Vertical>) -> Self {
         self.vertical_alignment = alignment.into();
         self
     }
@@ -273,9 +260,7 @@ where
             self.padding,
             self.horizontal_alignment,
             self.vertical_alignment,
-            |limits| {
-                self.content.as_widget_mut().layout(tree, renderer, limits)
-            },
+            |limits| self.content.as_widget_mut().layout(tree, renderer, limits),
         )
     }
 
@@ -370,12 +355,8 @@ where
                 renderer,
                 theme,
                 &renderer::Style {
-                    icon_color: style
-                        .icon_color
-                        .unwrap_or(renderer_style.icon_color),
-                    text_color: style
-                        .text_color
-                        .unwrap_or(renderer_style.text_color),
+                    icon_color: style.icon_color.unwrap_or(renderer_style.icon_color),
+                    text_color: style.text_color.unwrap_or(renderer_style.text_color),
                     scale_factor: renderer_style.scale_factor,
                 },
                 layout
@@ -500,17 +481,11 @@ pub fn layout(
 }
 
 /// Draws the background of a [`Container`] given its [`Style`] and its `bounds`.
-pub fn draw_background<Renderer>(
-    renderer: &mut Renderer,
-    style: &Style,
-    bounds: Rectangle,
-) where
+pub fn draw_background<Renderer>(renderer: &mut Renderer, style: &Style, bounds: Rectangle)
+where
     Renderer: core::Renderer,
 {
-    if style.background.is_some()
-        || style.border.width > 0.0
-        || style.shadow.color.a > 0.0
-    {
+    if style.background.is_some() || style.border.width > 0.0 || style.shadow.color.a > 0.0 {
         renderer.fill_quad(
             renderer::Quad {
                 bounds,
@@ -548,16 +523,10 @@ pub fn visible_bounds(id: Id) -> Task<Option<Rectangle>> {
                 Some((last_translation, last_viewport, _depth)) => {
                     let viewport = last_viewport
                         .intersection(&(bounds - *last_translation))
-                        .unwrap_or(Rectangle::new(
-                            crate::core::Point::ORIGIN,
-                            Size::ZERO,
-                        ));
+                        .unwrap_or(Rectangle::new(crate::core::Point::ORIGIN, Size::ZERO));
 
-                    self.scrollables.push((
-                        translation + *last_translation,
-                        viewport,
-                        self.depth,
-                    ));
+                    self.scrollables
+                        .push((translation + *last_translation, viewport, self.depth));
                 }
                 None => {
                     self.scrollables.push((translation, bounds, self.depth));
@@ -573,8 +542,7 @@ pub fn visible_bounds(id: Id) -> Task<Option<Rectangle>> {
             if id == Some(&self.target) {
                 match self.scrollables.last() {
                     Some((translation, viewport, _)) => {
-                        self.bounds =
-                            viewport.intersection(&(bounds - *translation));
+                        self.bounds = viewport.intersection(&(bounds - *translation));
                     }
                     None => {
                         self.bounds = Some(bounds);
@@ -596,10 +564,7 @@ pub fn visible_bounds(id: Id) -> Task<Option<Rectangle>> {
             }
         }
 
-        fn traverse(
-            &mut self,
-            operate: &mut dyn FnMut(&mut dyn Operation<Option<Rectangle>>),
-        ) {
+        fn traverse(&mut self, operate: &mut dyn FnMut(&mut dyn Operation<Option<Rectangle>>)) {
             self.depth += 1;
             self.traverse(operate);
             self.depth -= 1;

--- a/widget/src/float.rs
+++ b/widget/src/float.rs
@@ -8,8 +8,8 @@ use crate::core::renderer;
 use crate::core::widget;
 use crate::core::widget::tree;
 use crate::core::{
-    Clipboard, Element, Event, Layout, Length, Rectangle, Shadow, Shell, Size,
-    Transformation, Vector, Widget,
+    Clipboard, Element, Event, Layout, Length, Rectangle, Shadow, Shell, Size, Transformation,
+    Vector, Widget,
 };
 
 /// A widget that can make its contents float over other widgets.
@@ -28,9 +28,7 @@ where
     Theme: Catalog,
 {
     /// Creates a new [`Float`] widget with the given content.
-    pub fn new(
-        content: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn new(content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             content: content.into(),
             scale: 1.0,
@@ -50,10 +48,7 @@ where
     /// The logic takes the original (non-scaled) bounds of the contents and the
     /// viewport bounds. These bounds can be useful to ensure the floating elements
     /// always stay on screen.
-    pub fn translate(
-        mut self,
-        translate: impl Fn(Rectangle, Rectangle) -> Vector + 'a,
-    ) -> Self {
+    pub fn translate(mut self, translate: impl Fn(Rectangle, Rectangle) -> Vector + 'a) -> Self {
         self.translate = Some(Box::new(translate));
         self
     }
@@ -78,9 +73,10 @@ where
 
     fn is_floating(&self, bounds: Rectangle, viewport: Rectangle) -> bool {
         self.scale > 1.0
-            || self.translate.as_ref().is_some_and(|translate| {
-                translate(bounds, viewport) != Vector::ZERO
-            })
+            || self
+                .translate
+                .as_ref()
+                .is_some_and(|translate| translate(bounds, viewport) != Vector::ZERO)
     }
 }
 
@@ -346,9 +342,7 @@ where
                             renderer::Quad {
                                 bounds: bounds.shrink(1.0),
                                 shadow: style.shadow,
-                                border: border::rounded(
-                                    style.shadow_border_radius,
-                                ),
+                                border: border::rounded(style.shadow_border_radius),
                                 snap: false,
                             },
                             style.shadow.color,

--- a/widget/src/grid.rs
+++ b/widget/src/grid.rs
@@ -5,8 +5,7 @@ use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::widget::{Operation, Tree};
 use crate::core::{
-    Clipboard, Element, Event, Length, Pixels, Rectangle, Shell, Size, Vector,
-    Widget,
+    Clipboard, Element, Event, Length, Pixels, Rectangle, Shell, Size, Vector, Widget,
 };
 
 /// A container that distributes its contents on a responsive grid.
@@ -47,9 +46,7 @@ where
     }
 
     /// Creates a [`Grid`] from an already allocated [`Vec`].
-    pub fn from_vec(
-        children: Vec<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn from_vec(children: Vec<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             spacing: 0.0,
             columns: Constraint::Amount(3),
@@ -97,10 +94,7 @@ where
     }
 
     /// Adds an [`Element`] to the [`Grid`].
-    pub fn push(
-        mut self,
-        child: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn push(mut self, child: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         self.children.push(child.into());
         self
     }
@@ -136,14 +130,9 @@ where
 }
 
 impl<'a, Message, Theme, Renderer: crate::core::Renderer>
-    FromIterator<Element<'a, Message, Theme, Renderer>>
-    for Grid<'a, Message, Theme, Renderer>
+    FromIterator<Element<'a, Message, Theme, Renderer>> for Grid<'a, Message, Theme, Renderer>
 {
-    fn from_iter<
-        T: IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
-    >(
-        iter: T,
-    ) -> Self {
+    fn from_iter<T: IntoIterator<Item = Element<'a, Message, Theme, Renderer>>>(iter: T) -> Self {
         Self::with_children(iter)
     }
 }
@@ -186,23 +175,18 @@ where
 
         let cells_per_row = match self.columns {
             // width = n * (cell + spacing) - spacing, given n > 0
-            Constraint::MaxWidth(pixels) => ((available.width + self.spacing)
-                / (pixels.0 + self.spacing))
-                .ceil() as usize,
+            Constraint::MaxWidth(pixels) => {
+                ((available.width + self.spacing) / (pixels.0 + self.spacing)).ceil() as usize
+            }
             Constraint::Amount(amount) => amount,
         };
 
         if self.children.is_empty() || cells_per_row == 0 {
-            return layout::Node::new(limits.resolve(
-                size.width,
-                size.height,
-                Size::ZERO,
-            ));
+            return layout::Node::new(limits.resolve(size.width, size.height, Size::ZERO));
         }
 
-        let cell_width = (available.width
-            - self.spacing * (cells_per_row - 1) as f32)
-            / cells_per_row as f32;
+        let cell_width =
+            (available.width - self.spacing * (cells_per_row - 1) as f32) / cells_per_row as f32;
 
         let cell_height = match self.height {
             Sizing::AspectRatio(ratio) => Some(cell_width / ratio),
@@ -210,8 +194,7 @@ where
             Sizing::EvenlyDistribute(_) => {
                 let total_rows = self.children.len().div_ceil(cells_per_row);
                 Some(
-                    (available.height - self.spacing * (total_rows - 1) as f32)
-                        / total_rows as f32,
+                    (available.height - self.spacing * (total_rows - 1) as f32) / total_rows as f32,
                 )
             }
         };
@@ -226,9 +209,7 @@ where
         let mut y = 0.0;
         let mut row_height = 0.0f32;
 
-        for (i, (child, tree)) in
-            self.children.iter_mut().zip(&mut tree.children).enumerate()
-        {
+        for (i, (child, tree)) in self.children.iter_mut().zip(&mut tree.children).enumerate() {
             let node = child
                 .as_widget_mut()
                 .layout(tree, renderer, &cell_limits)
@@ -296,8 +277,7 @@ where
             .zip(layout.children())
         {
             child.as_widget_mut().update(
-                tree, event, layout, cursor, renderer, clipboard, shell,
-                viewport,
+                tree, event, layout, cursor, renderer, clipboard, shell, viewport,
             );
         }
     }
@@ -341,9 +321,9 @@ where
                 .zip(layout.children())
                 .filter(|(_, layout)| layout.bounds().intersects(&viewport))
             {
-                child.as_widget().draw(
-                    tree, renderer, theme, style, layout, cursor, &viewport,
-                );
+                child
+                    .as_widget()
+                    .draw(tree, renderer, theme, style, layout, cursor, &viewport);
             }
         }
     }
@@ -407,9 +387,6 @@ impl From<Length> for Sizing {
 }
 
 /// Creates a new [`Sizing`] strategy that maintains the given aspect ratio.
-pub fn aspect_ratio(
-    width: impl Into<Pixels>,
-    height: impl Into<Pixels>,
-) -> Sizing {
+pub fn aspect_ratio(width: impl Into<Pixels>, height: impl Into<Pixels>) -> Sizing {
     Sizing::AspectRatio(width.into().0 / height.into().0)
 }

--- a/widget/src/helpers.rs
+++ b/widget/src/helpers.rs
@@ -24,9 +24,7 @@ use crate::text_input::{self, TextInput};
 use crate::toggler::{self, Toggler};
 use crate::tooltip::{self, Tooltip};
 use crate::vertical_slider::{self, VerticalSlider};
-use crate::{
-    Column, Grid, MouseArea, Pin, Responsive, Row, Sensor, Space, Stack, Themer,
-};
+use crate::{Column, Grid, MouseArea, Pin, Responsive, Row, Sensor, Space, Stack, Themer};
 
 use std::borrow::Borrow;
 
@@ -670,14 +668,11 @@ where
             shell: &mut Shell<'_, Message>,
             viewport: &Rectangle,
         ) {
-            let is_mouse_press = matches!(
-                event,
-                core::Event::Mouse(mouse::Event::ButtonPressed(_))
-            );
+            let is_mouse_press =
+                matches!(event, core::Event::Mouse(mouse::Event::ButtonPressed(_)));
 
             self.content.as_widget_mut().update(
-                tree, event, layout, cursor, renderer, clipboard, shell,
-                viewport,
+                tree, event, layout, cursor, renderer, clipboard, shell, viewport,
             );
 
             if is_mouse_press && cursor.is_over(layout.bounds()) {
@@ -698,9 +693,7 @@ where
                 .as_widget()
                 .mouse_interaction(state, layout, cursor, viewport, renderer);
 
-            if interaction == mouse::Interaction::None
-                && cursor.is_over(layout.bounds())
-            {
+            if interaction == mouse::Interaction::None && cursor.is_over(layout.bounds()) {
                 mouse::Interaction::Idle
             } else {
                 interaction
@@ -714,15 +707,10 @@ where
             renderer: &Renderer,
             viewport: &Rectangle,
             translation: core::Vector,
-        ) -> Option<core::overlay::Element<'b, Message, Theme, Renderer>>
-        {
-            self.content.as_widget_mut().overlay(
-                state,
-                layout,
-                renderer,
-                viewport,
-                translation,
-            )
+        ) -> Option<core::overlay::Element<'b, Message, Theme, Renderer>> {
+            self.content
+                .as_widget_mut()
+                .overlay(state, layout, renderer, viewport, translation)
         }
     }
 
@@ -792,11 +780,10 @@ where
             renderer: &Renderer,
             limits: &layout::Limits,
         ) -> layout::Node {
-            let base = self.base.as_widget_mut().layout(
-                &mut tree.children[0],
-                renderer,
-                limits,
-            );
+            let base = self
+                .base
+                .as_widget_mut()
+                .layout(&mut tree.children[0], renderer, limits);
 
             let top = self.top.as_widget_mut().layout(
                 &mut tree.children[1],
@@ -840,8 +827,7 @@ where
 
                     renderer.with_layer(bounds, |renderer| {
                         self.top.as_widget().draw(
-                            top_tree, renderer, theme, style, top_layout,
-                            cursor, viewport,
+                            top_tree, renderer, theme, style, top_layout, cursor, viewport,
                         );
                     });
                 }
@@ -883,8 +869,7 @@ where
 
             let is_hovered = cursor.is_over(layout.bounds());
 
-            if matches!(event, Event::Window(window::Event::RedrawRequested(_)))
-            {
+            if matches!(event, Event::Window(window::Event::RedrawRequested(_))) {
                 let mut count_focused = operation::focusable::count();
 
                 self.top.as_widget_mut().operate(
@@ -904,22 +889,17 @@ where
                 shell.request_redraw();
             }
 
-            let is_visible =
-                is_hovered || self.is_top_focused || self.is_top_overlay_active;
+            let is_visible = is_hovered || self.is_top_focused || self.is_top_overlay_active;
 
             if matches!(
                 event,
-                Event::Mouse(
-                    mouse::Event::CursorMoved { .. }
-                        | mouse::Event::ButtonReleased(_)
-                )
+                Event::Mouse(mouse::Event::CursorMoved { .. } | mouse::Event::ButtonReleased(_))
             ) || is_visible
             {
                 let redraw_request = shell.redraw_request();
 
                 self.top.as_widget_mut().update(
-                    top_tree, event, top_layout, cursor, renderer, clipboard,
-                    shell, viewport,
+                    top_tree, event, top_layout, cursor, renderer, clipboard, shell, viewport,
                 );
 
                 // Ignore redraw requests of invisible content
@@ -957,9 +937,9 @@ where
                 .rev()
                 .zip(layout.children().rev().zip(tree.children.iter().rev()))
                 .map(|(child, (layout, tree))| {
-                    child.as_widget().mouse_interaction(
-                        tree, layout, cursor, viewport, renderer,
-                    )
+                    child
+                        .as_widget()
+                        .mouse_interaction(tree, layout, cursor, viewport, renderer)
                 })
                 .find(|&interaction| interaction != mouse::Interaction::None)
                 .unwrap_or_default()
@@ -972,19 +952,14 @@ where
             renderer: &Renderer,
             viewport: &Rectangle,
             translation: core::Vector,
-        ) -> Option<core::overlay::Element<'b, Message, Theme, Renderer>>
-        {
+        ) -> Option<core::overlay::Element<'b, Message, Theme, Renderer>> {
             let mut overlays = [&mut self.base, &mut self.top]
                 .into_iter()
                 .zip(layout.children().zip(tree.children.iter_mut()))
                 .map(|(child, (layout, tree))| {
-                    child.as_widget_mut().overlay(
-                        tree,
-                        layout,
-                        renderer,
-                        viewport,
-                        translation,
-                    )
+                    child
+                        .as_widget_mut()
+                        .overlay(tree, layout, renderer, viewport, translation)
                 });
 
             if let Some(base_overlay) = overlays.next()? {
@@ -1154,9 +1129,7 @@ where
 ///         .into()
 /// }
 /// ```
-pub fn text<'a, Theme, Renderer>(
-    text: impl text::IntoFragment<'a>,
-) -> Text<'a, Theme, Renderer>
+pub fn text<'a, Theme, Renderer>(text: impl text::IntoFragment<'a>) -> Text<'a, Theme, Renderer>
 where
     Theme: text::Catalog + 'a,
     Renderer: core::text::Renderer,
@@ -1165,9 +1138,7 @@ where
 }
 
 /// Creates a new [`Text`] widget that displays the provided value.
-pub fn value<'a, Theme, Renderer>(
-    value: impl ToString,
-) -> Text<'a, Theme, Renderer>
+pub fn value<'a, Theme, Renderer>(value: impl ToString) -> Text<'a, Theme, Renderer>
 where
     Theme: text::Catalog + 'a,
     Renderer: core::text::Renderer,
@@ -1249,9 +1220,7 @@ where
 ///     .into()
 /// }
 /// ```
-pub fn span<'a, Link, Font>(
-    text: impl text::IntoFragment<'a>,
-) -> text::Span<'a, Link, Font> {
+pub fn span<'a, Link, Font>(text: impl text::IntoFragment<'a>) -> text::Span<'a, Link, Font> {
     text::Span::new(text)
 }
 
@@ -1790,10 +1759,7 @@ pub fn space() -> Space {
 ///     progress_bar(0.0..=100.0, state.progress).into()
 /// }
 /// ```
-pub fn progress_bar<'a, Theme>(
-    range: RangeInclusive<f32>,
-    value: f32,
-) -> ProgressBar<'a, Theme>
+pub fn progress_bar<'a, Theme>(range: RangeInclusive<f32>, value: f32) -> ProgressBar<'a, Theme>
 where
     Theme: progress_bar::Catalog + 'a,
 {
@@ -1824,9 +1790,7 @@ where
 /// <img src="https://github.com/iced-rs/iced/blob/9712b319bb7a32848001b96bd84977430f14b623/examples/resources/ferris.png?raw=true" width="300">
 #[cfg(feature = "image")]
 #[cfg_attr(docsrs, doc(cfg(feature = "image")))]
-pub fn image<'a, Handle>(
-    handle: impl Into<Handle>,
-) -> crate::Image<'a, Handle> {
+pub fn image<'a, Handle>(handle: impl Into<Handle>) -> crate::Image<'a, Handle> {
     crate::Image::new(handle.into())
 }
 
@@ -1853,9 +1817,7 @@ pub fn image<'a, Handle>(
 /// }
 /// ```
 #[cfg(feature = "svg")]
-pub fn svg<'a, Theme>(
-    handle: impl Into<core::svg::Handle>,
-) -> crate::Svg<'a, Theme>
+pub fn svg<'a, Theme>(handle: impl Into<core::svg::Handle>) -> crate::Svg<'a, Theme>
 where
     Theme: crate::svg::Catalog,
 {
@@ -1873,8 +1835,7 @@ where
     Message: 'a,
     Renderer: core::Renderer + core::text::Renderer<Font = core::Font> + 'a,
     Theme: text::Catalog + container::Catalog + 'a,
-    <Theme as container::Catalog>::Class<'a>:
-        From<container::StyleFn<'a, Theme>>,
+    <Theme as container::Catalog>::Class<'a>: From<container::StyleFn<'a, Theme>>,
     <Theme as text::Catalog>::Class<'a>: From<text::StyleFn<'a, Theme>>,
 {
     use crate::core::border;
@@ -1965,9 +1926,7 @@ where
 /// }
 /// ```
 #[cfg(feature = "canvas")]
-pub fn canvas<P, Message, Theme, Renderer>(
-    program: P,
-) -> crate::Canvas<P, Message, Theme, Renderer>
+pub fn canvas<P, Message, Theme, Renderer>(program: P) -> crate::Canvas<P, Message, Theme, Renderer>
 where
     Renderer: crate::graphics::geometry::Renderer,
     P: crate::canvas::Program<Message, Theme, Renderer>,
@@ -2003,9 +1962,7 @@ where
 /// }
 /// ```
 #[cfg(feature = "qr_code")]
-pub fn qr_code<'a, Theme>(
-    data: &'a crate::qr_code::Data,
-) -> crate::QRCode<'a, Theme>
+pub fn qr_code<'a, Theme>(data: &'a crate::qr_code::Data) -> crate::QRCode<'a, Theme>
 where
     Theme: crate::qr_code::Catalog + 'a,
 {
@@ -2084,11 +2041,7 @@ where
 /// ```
 pub fn pane_grid<'a, T, Message, Theme, Renderer>(
     state: &'a pane_grid::State<T>,
-    view: impl Fn(
-        pane_grid::Pane,
-        &'a T,
-        bool,
-    ) -> pane_grid::Content<'a, Message, Theme, Renderer>,
+    view: impl Fn(pane_grid::Pane, &'a T, bool) -> pane_grid::Content<'a, Message, Theme, Renderer>,
 ) -> PaneGrid<'a, Message, Theme, Renderer>
 where
     Theme: pane_grid::Catalog,

--- a/widget/src/image.rs
+++ b/widget/src/image.rs
@@ -27,8 +27,7 @@ use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::widget::Tree;
 use crate::core::{
-    ContentFit, Element, Layout, Length, Point, Rectangle, Rotation, Size,
-    Vector, Widget,
+    ContentFit, Element, Layout, Length, Point, Rectangle, Rotation, Size, Vector, Widget,
 };
 
 pub use image::{FilterMethod, Handle};
@@ -193,10 +192,7 @@ impl<'a, Handle> Image<'a, Handle> {
     ///
     /// Currently, it will only be applied around the rectangular bounding box
     /// of the [`Image`].
-    pub fn border_radius(
-        mut self,
-        border_radius: impl Into<border::Radius>,
-    ) -> Self {
+    pub fn border_radius(mut self, border_radius: impl Into<border::Radius>) -> Self {
         self.border_radius = border_radius.into();
         self
     }
@@ -210,10 +206,7 @@ impl<'a, Handle> Image<'a, Handle> {
 
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Image`].
-    pub fn description_widget<T: iced_accessibility::Describes>(
-        mut self,
-        description: &T,
-    ) -> Self {
+    pub fn description_widget<T: iced_accessibility::Describes>(mut self, description: &T) -> Self {
         self.description = Some(iced_accessibility::Description::Id(
             description.description(),
         ));
@@ -223,16 +216,14 @@ impl<'a, Handle> Image<'a, Handle> {
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Image`].
     pub fn description(mut self, description: impl Into<Cow<'a, str>>) -> Self {
-        self.description =
-            Some(iced_accessibility::Description::Text(description.into()));
+        self.description = Some(iced_accessibility::Description::Text(description.into()));
         self
     }
 
     #[cfg(feature = "a11y")]
     /// Sets the label of the [`Image`].
     pub fn label(mut self, label: &dyn iced_accessibility::Labels) -> Self {
-        self.label =
-            Some(label.label().into_iter().map(|l| l.into()).collect());
+        self.label = Some(label.label().into_iter().map(|l| l.into()).collect());
         self
     }
 }
@@ -254,8 +245,7 @@ where
     Renderer: image::Renderer<Handle = Handle>,
 {
     // The raw w/h of the underlying image
-    let image_size =
-        crop(renderer.measure_image(handle).unwrap_or_default(), region);
+    let image_size = crop(renderer.measure_image(handle).unwrap_or_default(), region);
 
     // The rotated size of the image
     let rotated_size = rotation.apply(image_size);
@@ -410,8 +400,7 @@ pub fn draw<Renderer, Handle>(
     );
 }
 
-impl<'a, Message, Theme, Renderer, Handle> Widget<Message, Theme, Renderer>
-    for Image<'a, Handle>
+impl<'a, Message, Theme, Renderer, Handle> Widget<Message, Theme, Renderer> for Image<'a, Handle>
 where
     Renderer: image::Renderer<Handle = Handle>,
     Handle: Clone,
@@ -486,12 +475,7 @@ where
             width,
             height,
         } = bounds;
-        let bounds = Rect::new(
-            x as f64,
-            y as f64,
-            (x + width) as f64,
-            (y + height) as f64,
-        );
+        let bounds = Rect::new(x as f64, y as f64, (x + width) as f64, (y + height) as f64);
         let mut node = Node::new(Role::Image);
         node.set_bounds(bounds);
         if let Some(name) = self.name.as_ref() {

--- a/widget/src/image/viewer.rs
+++ b/widget/src/image/viewer.rs
@@ -6,8 +6,8 @@ use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
-    Clipboard, ContentFit, Element, Event, Image, Layout, Length, Pixels,
-    Point, Radians, Rectangle, Shell, Size, Vector, Widget,
+    Clipboard, ContentFit, Element, Event, Image, Layout, Length, Pixels, Point, Radians,
+    Rectangle, Shell, Size, Vector, Widget,
 };
 
 /// A frame that displays an image with the ability to zoom in/out and pan.
@@ -95,8 +95,7 @@ impl<Handle> Viewer<Handle> {
     }
 }
 
-impl<Message, Theme, Renderer, Handle> Widget<Message, Theme, Renderer>
-    for Viewer<Handle>
+impl<Message, Theme, Renderer, Handle> Widget<Message, Theme, Renderer> for Viewer<Handle>
 where
     Renderer: image::Renderer<Handle = Handle>,
     Handle: Clone,
@@ -123,11 +122,9 @@ where
         limits: &layout::Limits,
     ) -> layout::Node {
         // The raw w/h of the underlying image
-        let image_size =
-            renderer.measure_image(&self.handle).unwrap_or_default();
+        let image_size = renderer.measure_image(&self.handle).unwrap_or_default();
 
-        let image_size =
-            Size::new(image_size.width as f32, image_size.height as f32);
+        let image_size = Size::new(image_size.width as f32, image_size.height as f32);
 
         // The size to be available to the widget prior to `Shrink`ing
         let raw_size = limits.resolve(self.width, self.height, image_size);
@@ -170,8 +167,7 @@ where
                 };
 
                 match *delta {
-                    mouse::ScrollDelta::Lines { y, .. }
-                    | mouse::ScrollDelta::Pixels { y, .. } => {
+                    mouse::ScrollDelta::Lines { y, .. } | mouse::ScrollDelta::Pixels { y, .. } => {
                         let state = tree.state.downcast_mut::<State>();
                         let previous_scale = state.scale;
 
@@ -195,11 +191,10 @@ where
 
                             let factor = state.scale / previous_scale - 1.0;
 
-                            let cursor_to_center =
-                                cursor_position - bounds.center();
+                            let cursor_to_center = cursor_position - bounds.center();
 
-                            let adjustment = cursor_to_center * factor
-                                + state.current_offset * factor;
+                            let adjustment =
+                                cursor_to_center * factor + state.current_offset * factor;
 
                             state.current_offset = Vector::new(
                                 if scaled_size.width > bounds.width {
@@ -248,27 +243,20 @@ where
                         bounds.size(),
                         self.content_fit,
                     );
-                    let hidden_width = (scaled_size.width - bounds.width / 2.0)
-                        .max(0.0)
-                        .round();
+                    let hidden_width = (scaled_size.width - bounds.width / 2.0).max(0.0).round();
 
-                    let hidden_height = (scaled_size.height
-                        - bounds.height / 2.0)
-                        .max(0.0)
-                        .round();
+                    let hidden_height = (scaled_size.height - bounds.height / 2.0).max(0.0).round();
 
                     let delta = *position - origin;
 
                     let x = if bounds.width < scaled_size.width {
-                        (state.starting_offset.x - delta.x)
-                            .clamp(-hidden_width, hidden_width)
+                        (state.starting_offset.x - delta.x).clamp(-hidden_width, hidden_width)
                     } else {
                         0.0
                     };
 
                     let y = if bounds.height < scaled_size.height {
-                        (state.starting_offset.y - delta.y)
-                            .clamp(-hidden_height, hidden_height)
+                        (state.starting_offset.y - delta.y).clamp(-hidden_height, hidden_height)
                     } else {
                         0.0
                     };
@@ -329,9 +317,7 @@ where
             let diff_h = bounds.height - final_size.height;
 
             let image_top_left = match self.content_fit {
-                ContentFit::None => {
-                    Vector::new(diff_w.max(0.0) / 2.0, diff_h.max(0.0) / 2.0)
-                }
+                ContentFit::None => Vector::new(diff_w.max(0.0) / 2.0, diff_h.max(0.0) / 2.0),
                 _ => Vector::new(diff_w / 2.0, diff_h / 2.0),
             };
 
@@ -390,11 +376,9 @@ impl State {
     /// Returns the current offset of the [`State`], given the bounds
     /// of the [`Viewer`] and its image.
     fn offset(&self, bounds: Rectangle, image_size: Size) -> Vector {
-        let hidden_width =
-            (image_size.width - bounds.width / 2.0).max(0.0).round();
+        let hidden_width = (image_size.width - bounds.width / 2.0).max(0.0).round();
 
-        let hidden_height =
-            (image_size.height - bounds.height / 2.0).max(0.0).round();
+        let hidden_height = (image_size.height - bounds.height / 2.0).max(0.0).round();
 
         Vector::new(
             self.current_offset.x.clamp(-hidden_width, hidden_width),
@@ -433,8 +417,7 @@ pub fn scaled_image_size<Renderer>(
 where
     Renderer: image::Renderer,
 {
-    let Size { width, height } =
-        renderer.measure_image(handle).unwrap_or_default();
+    let Size { width, height } = renderer.measure_image(handle).unwrap_or_default();
 
     let image_size = Size::new(width as f32, height as f32);
 

--- a/widget/src/keyed/column.rs
+++ b/widget/src/keyed/column.rs
@@ -9,8 +9,8 @@ use crate::core::renderer;
 use crate::core::widget::Operation;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
-    Alignment, Clipboard, Element, Event, Layout, Length, Padding, Pixels,
-    Rectangle, Shell, Size, Vector, Widget,
+    Alignment, Clipboard, Element, Event, Layout, Length, Padding, Pixels, Rectangle, Shell, Size,
+    Vector, Widget,
 };
 
 /// A container that distributes its contents vertically while keeping continuity.
@@ -32,13 +32,8 @@ use crate::core::{
 ///     })).into()
 /// }
 /// ```
-pub struct Column<
-    'a,
-    Key,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct Column<'a, Key, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Key: Copy + PartialEq,
 {
     spacing: f32,
@@ -51,8 +46,7 @@ pub struct Column<
     children: Vec<Element<'a, Message, Theme, Renderer>>,
 }
 
-impl<'a, Key, Message, Theme, Renderer>
-    Column<'a, Key, Message, Theme, Renderer>
+impl<'a, Key, Message, Theme, Renderer> Column<'a, Key, Message, Theme, Renderer>
 where
     Key: Copy + PartialEq,
     Renderer: crate::core::Renderer,
@@ -69,10 +63,7 @@ where
     ///
     /// If any of the children have a [`Length::Fill`] strategy, you will need to
     /// call [`Column::width`] or [`Column::height`] accordingly.
-    pub fn from_vecs(
-        keys: Vec<Key>,
-        children: Vec<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn from_vecs(keys: Vec<Key>, children: Vec<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             spacing: 0.0,
             padding: Padding::ZERO,
@@ -87,17 +78,12 @@ where
 
     /// Creates a [`Column`] with the given capacity.
     pub fn with_capacity(capacity: usize) -> Self {
-        Self::from_vecs(
-            Vec::with_capacity(capacity),
-            Vec::with_capacity(capacity),
-        )
+        Self::from_vecs(Vec::with_capacity(capacity), Vec::with_capacity(capacity))
     }
 
     /// Creates a [`Column`] with the given elements.
     pub fn with_children(
-        children: impl IntoIterator<
-            Item = (Key, Element<'a, Message, Theme, Renderer>),
-        >,
+        children: impl IntoIterator<Item = (Key, Element<'a, Message, Theme, Renderer>)>,
     ) -> Self {
         let iterator = children.into_iter();
 
@@ -177,9 +163,7 @@ where
     /// Extends the [`Column`] with the given children.
     pub fn extend(
         self,
-        children: impl IntoIterator<
-            Item = (Key, Element<'a, Message, Theme, Renderer>),
-        >,
+        children: impl IntoIterator<Item = (Key, Element<'a, Message, Theme, Renderer>)>,
     ) -> Self {
         children
             .into_iter()
@@ -293,9 +277,12 @@ where
                 .zip(&mut tree.children)
                 .zip(layout.children())
                 .for_each(|((child, state), c_layout)| {
-                    child
-                        .as_widget_mut()
-                        .operate(state, c_layout.with_virtual_offset(layout.virtual_offset()), renderer, operation);
+                    child.as_widget_mut().operate(
+                        state,
+                        c_layout.with_virtual_offset(layout.virtual_offset()),
+                        renderer,
+                        operation,
+                    );
                 });
         });
     }
@@ -318,7 +305,13 @@ where
             .zip(layout.children())
         {
             child.as_widget_mut().update(
-                tree, event, c_layout.with_virtual_offset(layout.virtual_offset()), cursor, renderer, clipboard, shell,
+                tree,
+                event,
+                c_layout.with_virtual_offset(layout.virtual_offset()),
+                cursor,
+                renderer,
+                clipboard,
+                shell,
                 viewport,
             );
         }
@@ -337,9 +330,13 @@ where
             .zip(&tree.children)
             .zip(layout.children())
             .map(|((child, tree), c_layout)| {
-                child
-                    .as_widget()
-                    .mouse_interaction(tree, c_layout.with_virtual_offset(layout.virtual_offset()), cursor, viewport, renderer)
+                child.as_widget().mouse_interaction(
+                    tree,
+                    c_layout.with_virtual_offset(layout.virtual_offset()),
+                    cursor,
+                    viewport,
+                    renderer,
+                )
             })
             .max()
             .unwrap_or_default()
@@ -392,8 +389,7 @@ where
     }
 }
 
-impl<'a, Key, Message, Theme, Renderer>
-    From<Column<'a, Key, Message, Theme, Renderer>>
+impl<'a, Key, Message, Theme, Renderer> From<Column<'a, Key, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
     Key: Copy + PartialEq + 'static,

--- a/widget/src/lazy.rs
+++ b/widget/src/lazy.rs
@@ -16,9 +16,7 @@ use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::widget::{self, Widget};
-use crate::core::{
-    self, Clipboard, Event, Length, Rectangle, Shell, Size, Vector,
-};
+use crate::core::{self, Clipboard, Event, Length, Rectangle, Shell, Size, Vector};
 
 use ouroboros::self_referencing;
 use rustc_hash::FxHasher;
@@ -31,9 +29,7 @@ use std::rc::Rc;
 pub struct Lazy<'a, Message, Theme, Renderer, Dependency, View> {
     dependency: Dependency,
     view: Box<dyn Fn(&Dependency) -> View + 'a>,
-    element: RefCell<
-        Option<Rc<RefCell<Option<Element<'static, Message, Theme, Renderer>>>>>,
-    >,
+    element: RefCell<Option<Rc<RefCell<Option<Element<'static, Message, Theme, Renderer>>>>>>,
 }
 
 impl<'a, Message, Theme, Renderer, Dependency, View>
@@ -44,10 +40,7 @@ where
 {
     /// Creates a new [`Lazy`] widget with the given data `Dependency` and a
     /// closure that can turn this data into a widget tree.
-    pub fn new(
-        dependency: Dependency,
-        view: impl Fn(&Dependency) -> View + 'a,
-    ) -> Self {
+    pub fn new(dependency: Dependency, view: impl Fn(&Dependency) -> View + 'a) -> Self {
         Self {
             dependency,
             view: Box::new(view),
@@ -55,10 +48,7 @@ where
         }
     }
 
-    fn with_element<T>(
-        &self,
-        f: impl FnOnce(&Element<'_, Message, Theme, Renderer>) -> T,
-    ) -> T {
+    fn with_element<T>(&self, f: impl FnOnce(&Element<'_, Message, Theme, Renderer>) -> T) -> T {
         f(self
             .element
             .borrow()
@@ -89,8 +79,7 @@ struct Internal<Message, Theme, Renderer> {
     hash: u64,
 }
 
-impl<'a, Message, Theme, Renderer, Dependency, View>
-    Widget<Message, Theme, Renderer>
+impl<'a, Message, Theme, Renderer, Dependency, View> Widget<Message, Theme, Renderer>
     for Lazy<'a, Message, Theme, Renderer, Dependency, View>
 where
     View: Into<Element<'static, Message, Theme, Renderer>> + 'static,
@@ -112,8 +101,7 @@ where
             hasher.finish()
         };
 
-        let element =
-            Rc::new(RefCell::new(Some((self.view)(&self.dependency).into())));
+        let element = Rc::new(RefCell::new(Some((self.view)(&self.dependency).into())));
 
         (*self.element.borrow_mut()) = Some(element.clone());
 
@@ -144,9 +132,7 @@ where
 
             (*self.element.borrow_mut()) = Some(current.element.clone());
             self.with_element_mut(|element| {
-                tree.diff_children(std::slice::from_mut(
-                    &mut element.as_widget_mut(),
-                ))
+                tree.diff_children(std::slice::from_mut(&mut element.as_widget_mut()))
             });
         } else {
             (*self.element.borrow_mut()) = Some(current.element.clone());
@@ -171,11 +157,9 @@ where
         limits: &layout::Limits,
     ) -> layout::Node {
         self.with_element_mut(|element| {
-            element.as_widget_mut().layout(
-                &mut tree.children[0],
-                renderer,
-                limits,
-            )
+            element
+                .as_widget_mut()
+                .layout(&mut tree.children[0], renderer, limits)
         })
     }
 
@@ -187,12 +171,9 @@ where
         operation: &mut dyn crate::core::widget::Operation,
     ) {
         self.with_element_mut(|element| {
-            element.as_widget_mut().operate(
-                &mut tree.children[0],
-                layout,
-                renderer,
-                operation,
-            );
+            element
+                .as_widget_mut()
+                .operate(&mut tree.children[0], layout, renderer, operation);
         });
     }
 
@@ -301,8 +282,7 @@ where
             // - You may not like it, but this is what peak performance looks like
             // - TODO: Get rid of ouroboros, for good
             // - What?!
-            *self.element.borrow().as_ref().unwrap().borrow_mut() =
-                Some(heads.element);
+            *self.element.borrow().as_ref().unwrap().borrow_mut() = Some(heads.element);
 
             None
         }
@@ -355,9 +335,7 @@ struct Inner<'a, Message: 'a, Theme: 'a, Renderer: 'a> {
     overlay: Option<RefCell<overlay::Nested<'this, Message, Theme, Renderer>>>,
 }
 
-struct Overlay<'a, Message, Theme, Renderer>(
-    Option<Inner<'a, Message, Theme, Renderer>>,
-);
+struct Overlay<'a, Message, Theme, Renderer>(Option<Inner<'a, Message, Theme, Renderer>>);
 
 impl<Message, Theme, Renderer> Drop for Overlay<'_, Message, Theme, Renderer> {
     fn drop(&mut self) {
@@ -371,18 +349,20 @@ impl<Message, Theme, Renderer> Overlay<'_, Message, Theme, Renderer> {
         &self,
         f: impl FnOnce(&mut overlay::Nested<'_, Message, Theme, Renderer>) -> T,
     ) -> Option<T> {
-        self.0.as_ref().unwrap().with_overlay(|overlay| {
-            overlay.as_ref().map(|nested| (f)(&mut nested.borrow_mut()))
-        })
+        self.0
+            .as_ref()
+            .unwrap()
+            .with_overlay(|overlay| overlay.as_ref().map(|nested| (f)(&mut nested.borrow_mut())))
     }
 
     fn with_overlay_mut_maybe<T>(
         &mut self,
         f: impl FnOnce(&mut overlay::Nested<'_, Message, Theme, Renderer>) -> T,
     ) -> Option<T> {
-        self.0.as_mut().unwrap().with_overlay_mut(|overlay| {
-            overlay.as_mut().map(|nested| (f)(nested.get_mut()))
-        })
+        self.0
+            .as_mut()
+            .unwrap()
+            .with_overlay_mut(|overlay| overlay.as_mut().map(|nested| (f)(nested.get_mut())))
     }
 }
 
@@ -415,10 +395,8 @@ where
         cursor: mouse::Cursor,
         renderer: &Renderer,
     ) -> mouse::Interaction {
-        self.with_overlay_maybe(|overlay| {
-            overlay.mouse_interaction(layout, cursor, renderer)
-        })
-        .unwrap_or_default()
+        self.with_overlay_maybe(|overlay| overlay.mouse_interaction(layout, cursor, renderer))
+            .unwrap_or_default()
     }
 
     fn update(
@@ -446,9 +424,7 @@ where
     Theme: 'static,
     Dependency: Hash + 'a,
 {
-    fn from(
-        lazy: Lazy<'a, Message, Theme, Renderer, Dependency, View>,
-    ) -> Self {
+    fn from(lazy: Lazy<'a, Message, Theme, Renderer, Dependency, View>) -> Self {
         Self::new(lazy)
     }
 }

--- a/widget/src/lazy/component.rs
+++ b/widget/src/lazy/component.rs
@@ -6,9 +6,7 @@ use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::widget;
 use crate::core::widget::tree::{self, Tree};
-use crate::core::{
-    self, Clipboard, Element, Length, Rectangle, Shell, Size, Vector, Widget,
-};
+use crate::core::{self, Clipboard, Element, Length, Rectangle, Shell, Size, Vector, Widget};
 
 use iced_renderer::core::widget::Operation;
 use ouroboros::self_referencing;
@@ -58,18 +56,11 @@ pub trait Component<Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     /// Processes an [`Event`](Component::Event) and updates the [`Component`] state accordingly.
     ///
     /// It can produce a `Message` for the parent application.
-    fn update(
-        &mut self,
-        state: &mut Self::State,
-        event: Self::Event,
-    ) -> Option<Message>;
+    fn update(&mut self, state: &mut Self::State, event: Self::Event) -> Option<Message>;
 
     /// Produces the widgets of the [`Component`], which may trigger an [`Event`](Component::Event)
     /// on user interaction.
-    fn view(
-        &self,
-        state: &Self::State,
-    ) -> Element<'_, Self::Event, Theme, Renderer>;
+    fn view(&self, state: &Self::State) -> Element<'_, Self::Event, Theme, Renderer>;
 
     /// Update the [`Component`] state based on the provided [`Operation`](widget::Operation)
     ///
@@ -98,9 +89,7 @@ struct Tag<T>(T);
 
 /// Turns an implementor of [`Component`] into an [`Element`] that can be
 /// embedded in any application.
-pub fn view<'a, C, Message, Theme, Renderer>(
-    component: C,
-) -> Element<'a, Message, Theme, Renderer>
+pub fn view<'a, C, Message, Theme, Renderer>(component: C) -> Element<'a, Message, Theme, Renderer>
 where
     C: Component<Message, Theme, Renderer> + 'a,
     C::State: 'static,
@@ -129,9 +118,7 @@ struct Instance<'a, Message, Theme, Renderer, Event, S> {
 
 #[self_referencing]
 struct State<'a, Message: 'a, Theme: 'a, Renderer: 'a, Event: 'a, S: 'a> {
-    component: Box<
-        dyn Component<Message, Theme, Renderer, Event = Event, State = S> + 'a,
-    >,
+    component: Box<dyn Component<Message, Theme, Renderer, Event = Event, State = S> + 'a>,
     message: PhantomData<Message>,
     state: PhantomData<S>,
 
@@ -140,8 +127,7 @@ struct State<'a, Message: 'a, Theme: 'a, Renderer: 'a, Event: 'a, S: 'a> {
     element: Option<Element<'this, Event, Theme, Renderer>>,
 }
 
-impl<Message, Theme, Renderer, Event, S>
-    Instance<'_, Message, Theme, Renderer, Event, S>
+impl<Message, Theme, Renderer, Event, S> Instance<'_, Message, Theme, Renderer, Event, S>
 where
     S: Default + 'static,
     Renderer: renderer::Renderer,
@@ -232,10 +218,7 @@ where
         self.diff_self();
     }
 
-    fn with_element<T>(
-        &self,
-        f: impl FnOnce(&Element<'_, Event, Theme, Renderer>) -> T,
-    ) -> T {
+    fn with_element<T>(&self, f: impl FnOnce(&Element<'_, Event, Theme, Renderer>) -> T) -> T {
         self.with_element_mut(|element| f(element))
     }
 
@@ -460,8 +443,12 @@ where
             tree,
             types: PhantomData,
             overlay_builder: |instance, tree| {
-                instance.state.get_mut().as_mut().unwrap().with_element_mut(
-                    move |element| {
+                instance
+                    .state
+                    .get_mut()
+                    .as_mut()
+                    .unwrap()
+                    .with_element_mut(move |element| {
                         element
                             .as_mut()
                             .unwrap()
@@ -473,11 +460,8 @@ where
                                 viewport,
                                 translation,
                             )
-                            .map(|overlay| {
-                                RefCell::new(overlay::Nested::new(overlay))
-                            })
-                    },
-                )
+                            .map(|overlay| RefCell::new(overlay::Nested::new(overlay)))
+                    })
             },
         }
         .build();
@@ -509,11 +493,9 @@ where
         let tree = tree.state.downcast_ref::<Rc<RefCell<Option<Tree>>>>();
         self.with_element(|element| {
             if let Some(tree) = tree.borrow().as_ref() {
-                element.as_widget().a11y_nodes(
-                    layout,
-                    &tree.children[0],
-                    cursor,
-                )
+                element
+                    .as_widget()
+                    .a11y_nodes(layout, &tree.children[0], cursor)
             } else {
                 iced_accessibility::A11yTree::default()
             }
@@ -585,9 +567,7 @@ impl<Message, Theme, Renderer, Event, S>
             .0
             .as_ref()
             .unwrap()
-            .with_overlay(|overlay| {
-                overlay.as_ref().map(|nested| (f)(&mut nested.borrow_mut()))
-            })
+            .with_overlay(|overlay| overlay.as_ref().map(|nested| (f)(&mut nested.borrow_mut())))
     }
 
     fn with_overlay_mut_maybe<T>(
@@ -600,14 +580,11 @@ impl<Message, Theme, Renderer, Event, S>
             .0
             .as_mut()
             .unwrap()
-            .with_overlay_mut(|overlay| {
-                overlay.as_mut().map(|nested| (f)(nested.get_mut()))
-            })
+            .with_overlay_mut(|overlay| overlay.as_mut().map(|nested| (f)(nested.get_mut())))
     }
 }
 
-impl<Message, Theme, Renderer, Event, S>
-    overlay::Overlay<Message, Theme, Renderer>
+impl<Message, Theme, Renderer, Event, S> overlay::Overlay<Message, Theme, Renderer>
     for OverlayInstance<'_, '_, Message, Theme, Renderer, Event, S>
 where
     Renderer: core::Renderer,
@@ -637,10 +614,8 @@ where
         cursor: mouse::Cursor,
         renderer: &Renderer,
     ) -> mouse::Interaction {
-        self.with_overlay_maybe(|overlay| {
-            overlay.mouse_interaction(layout, cursor, renderer)
-        })
-        .unwrap_or_default()
+        self.with_overlay_maybe(|overlay| overlay.mouse_interaction(layout, cursor, renderer))
+            .unwrap_or_default()
     }
 
     fn update(
@@ -656,14 +631,7 @@ where
         let mut local_shell = Shell::new(&mut local_messages);
 
         let _ = self.with_overlay_mut_maybe(|overlay| {
-            overlay.update(
-                event,
-                layout,
-                cursor,
-                renderer,
-                clipboard,
-                &mut local_shell,
-            );
+            overlay.update(event, layout, cursor, renderer, clipboard, &mut local_shell);
         });
 
         if local_shell.is_event_captured() {
@@ -675,8 +643,7 @@ where
         shell.request_input_method(local_shell.input_method());
 
         if !local_messages.is_empty() {
-            let mut inner =
-                self.overlay.take().unwrap().0.take().unwrap().into_heads();
+            let mut inner = self.overlay.take().unwrap().0.take().unwrap().into_heads();
             let mut heads = inner.instance.state.take().unwrap().into_heads();
 
             for message in local_messages.into_iter().filter_map(|message| {

--- a/widget/src/list.rs
+++ b/widget/src/list.rs
@@ -8,8 +8,7 @@ use crate::core::widget;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    self, Clipboard, Element, Layout, Length, Pixels, Point, Rectangle, Shell,
-    Size, Vector, Widget,
+    self, Clipboard, Element, Layout, Length, Pixels, Point, Rectangle, Shell, Size, Vector, Widget,
 };
 
 use std::cell::RefCell;
@@ -20,16 +19,14 @@ use std::collections::VecDeque;
 pub struct List<'a, T, Message, Theme, Renderer> {
     content: &'a Content<T>,
     spacing: f32,
-    view_item:
-        Box<dyn Fn(usize, &'a T) -> Element<'a, Message, Theme, Renderer> + 'a>,
+    view_item: Box<dyn Fn(usize, &'a T) -> Element<'a, Message, Theme, Renderer> + 'a>,
     visible_elements: Vec<Element<'a, Message, Theme, Renderer>>,
 }
 
 impl<'a, T, Message, Theme, Renderer> List<'a, T, Message, Theme, Renderer> {
     pub fn new(
         content: &'a Content<T>,
-        view_item: impl Fn(usize, &'a T) -> Element<'a, Message, Theme, Renderer>
-        + 'a,
+        view_item: impl Fn(usize, &'a T) -> Element<'a, Message, Theme, Renderer> + 'a,
     ) -> Self {
         Self {
             content,
@@ -134,10 +131,8 @@ where
                 while let Some(change) = changes.pop_front() {
                     match change {
                         Change::Updated { original, current } => {
-                            let mut new_element = (self.view_item)(
-                                current,
-                                &self.content.items[current],
-                            );
+                            let mut new_element =
+                                (self.view_item)(current, &self.content.items[current]);
 
                             let visible_index = state
                                 .visible_layouts
@@ -147,30 +142,29 @@ where
                             let mut new_tree;
 
                             // Update if visible
-                            let tree =
-                                if let Some(visible_index) = visible_index {
-                                    let (_i, _layout, tree) = &mut state
-                                        .visible_layouts[visible_index];
+                            let tree = if let Some(visible_index) = visible_index {
+                                let (_i, _layout, tree) = &mut state.visible_layouts[visible_index];
 
-                                    tree.diff(&mut new_element);
-                                    state.visible_outdated = true;
+                                tree.diff(&mut new_element);
+                                state.visible_outdated = true;
 
-                                    tree
-                                } else {
-                                    new_tree = Tree::new(&new_element);
+                                tree
+                            } else {
+                                new_tree = Tree::new(&new_element);
 
-                                    &mut new_tree
-                                };
+                                &mut new_tree
+                            };
 
-                            let new_layout = new_element
-                                .as_widget_mut()
-                                .layout(tree, renderer, &state.last_limits);
+                            let new_layout = new_element.as_widget_mut().layout(
+                                tree,
+                                renderer,
+                                &state.last_limits,
+                            );
 
                             let new_size = new_layout.size();
 
                             let height_difference = new_size.height
-                                - (state.offsets[original + 1]
-                                    - state.offsets[original]);
+                                - (state.offsets[original + 1] - state.offsets[original]);
 
                             for offset in &mut state.offsets[original + 1..] {
                                 *offset += height_difference;
@@ -180,27 +174,16 @@ where
                             state.widths[original] = new_size.width;
 
                             if let Some(visible_index) = visible_index {
-                                state.visible_layouts[visible_index].1 =
-                                    new_layout;
+                                state.visible_layouts[visible_index].1 = new_layout;
 
-                                for (i, layout, _) in
-                                    &mut state.visible_layouts[visible_index..]
-                                {
-                                    layout
-                                        .move_to_mut((0.0, state.offsets[*i]));
+                                for (i, layout, _) in &mut state.visible_layouts[visible_index..] {
+                                    layout.move_to_mut((0.0, state.offsets[*i]));
                                 }
-                            } else if let Some(first_visible) =
-                                state.visible_layouts.first()
-                            {
+                            } else if let Some(first_visible) = state.visible_layouts.first() {
                                 let first_visible_index = first_visible.0;
                                 if original < first_visible_index {
-                                    for (i, layout, _) in
-                                        &mut state.visible_layouts[..]
-                                    {
-                                        layout.move_to_mut((
-                                            0.0,
-                                            state.offsets[*i],
-                                        ));
+                                    for (i, layout, _) in &mut state.visible_layouts[..] {
+                                        layout.move_to_mut((0.0, state.offsets[*i]));
                                     }
                                 }
                             }
@@ -208,17 +191,14 @@ where
                             state.size.height += height_difference;
 
                             if original_width == state.size.width {
-                                state.size.width = state.widths.iter().fold(
-                                    0.0,
-                                    |current, candidate| {
-                                        current.max(*candidate)
-                                    },
-                                );
+                                state.size.width = state
+                                    .widths
+                                    .iter()
+                                    .fold(0.0, |current, candidate| current.max(*candidate));
                             }
                         }
                         Change::Removed { original, .. } => {
-                            let height = state.offsets[original + 1]
-                                - state.offsets[original];
+                            let height = state.offsets[original + 1] - state.offsets[original];
 
                             let original_width = state.widths.remove(original);
                             let _ = state.offsets.remove(original + 1);
@@ -233,19 +213,15 @@ where
                             state.size.height -= height;
 
                             if original_width == state.size.width {
-                                state.size.width = state.widths.iter().fold(
-                                    0.0,
-                                    |current, candidate| {
-                                        current.max(*candidate)
-                                    },
-                                );
+                                state.size.width = state
+                                    .widths
+                                    .iter()
+                                    .fold(0.0, |current, candidate| current.max(*candidate));
                             }
                         }
                         Change::Pushed { current, .. } => {
-                            let mut new_element = (self.view_item)(
-                                current,
-                                &self.content.items[current],
-                            );
+                            let mut new_element =
+                                (self.view_item)(current, &self.content.items[current]);
 
                             let mut tree = Tree::new(&new_element);
 
@@ -258,9 +234,9 @@ where
                             let size = layout.size();
 
                             state.widths.push(size.width);
-                            state.offsets.push(
-                                state.offsets.last().unwrap() + size.height,
-                            );
+                            state
+                                .offsets
+                                .push(state.offsets.last().unwrap() + size.height);
 
                             state.size.width = state.size.width.max(size.width);
                             state.size.height += size.height;
@@ -303,8 +279,7 @@ where
                 let batch = &self.content.items[*current..end];
 
                 let mut max_width = size.width;
-                let mut accumulated_height =
-                    offsets.last().copied().unwrap_or(0.0);
+                let mut accumulated_height = offsets.last().copied().unwrap_or(0.0);
 
                 for (i, item) in batch.iter().enumerate() {
                     let mut element = (self.view_item)(*current + i, item);
@@ -339,12 +314,10 @@ where
 
         let intrinsic_size = Size::new(
             state.size.width,
-            state.size.height
-                + self.content.len().saturating_sub(1) as f32 * self.spacing,
+            state.size.height + self.content.len().saturating_sub(1) as f32 * self.spacing,
         );
 
-        let size =
-            limits.resolve(Length::Shrink, Length::Shrink, intrinsic_size);
+        let size = limits.resolve(Length::Shrink, Length::Shrink, intrinsic_size);
 
         layout::Node::new(size)
     }
@@ -393,16 +366,15 @@ where
 
             let offsets = &state.offsets;
 
-            let start =
-                match binary_search_with_index_by(offsets, |i, height| {
-                    (*height + i.saturating_sub(1) as f32 * self.spacing)
-                        .partial_cmp(&(viewport.y - offset.y))
-                        .unwrap_or(Ordering::Equal)
-                }) {
-                    Ok(i) => i,
-                    Err(i) => i.saturating_sub(1),
-                }
-                .min(self.content.len());
+            let start = match binary_search_with_index_by(offsets, |i, height| {
+                (*height + i.saturating_sub(1) as f32 * self.spacing)
+                    .partial_cmp(&(viewport.y - offset.y))
+                    .unwrap_or(Ordering::Equal)
+            }) {
+                Ok(i) => i,
+                Err(i) => i.saturating_sub(1),
+            }
+            .min(self.content.len());
 
             let end = match binary_search_with_index_by(offsets, |i, height| {
                 (*height + i.saturating_sub(1) as f32 * self.spacing)
@@ -414,8 +386,7 @@ where
             }
             .min(self.content.len());
 
-            if state.visible_outdated
-                || state.visible_layouts.len() != self.visible_elements.len()
+            if state.visible_outdated || state.visible_layouts.len() != self.visible_elements.len()
             {
                 self.visible_elements.clear();
                 state.visible_outdated = false;
@@ -427,9 +398,7 @@ where
                 self.visible_elements = state
                     .visible_layouts
                     .iter()
-                    .map(|(i, _, _)| {
-                        (self.view_item)(*i, &self.content.items[*i])
-                    })
+                    .map(|(i, _, _)| (self.view_item)(*i, &self.content.items[*i]))
                     .collect();
             }
 
@@ -458,29 +427,18 @@ where
                 .splice(state.visible_layouts.len() - bottom.., []);
 
             // Prepend new visible elements
-            if let Some(first_visible) =
-                state.visible_layouts.first().map(|(i, _, _)| *i)
-            {
+            if let Some(first_visible) = state.visible_layouts.first().map(|(i, _, _)| *i) {
                 if start < first_visible {
-                    for (i, item) in self.content.items[start..first_visible]
-                        .iter()
-                        .enumerate()
-                    {
+                    for (i, item) in self.content.items[start..first_visible].iter().enumerate() {
                         let mut element = (self.view_item)(start + i, item);
                         let mut tree = Tree::new(&element);
 
                         let layout = element
                             .as_widget_mut()
                             .layout(&mut tree, renderer, &state.last_limits)
-                            .move_to((
-                                0.0,
-                                offsets[start + i]
-                                    + (start + i) as f32 * self.spacing,
-                            ));
+                            .move_to((0.0, offsets[start + i] + (start + i) as f32 * self.spacing));
 
-                        state
-                            .visible_layouts
-                            .insert(i, (start + i, layout, tree));
+                        state.visible_layouts.insert(i, (start + i, layout, tree));
                         self.visible_elements.insert(i, element);
                     }
                 }
@@ -494,9 +452,7 @@ where
                 .unwrap_or(start);
 
             if last_visible < end {
-                for (i, item) in
-                    self.content.items[last_visible..end].iter().enumerate()
-                {
+                for (i, item) in self.content.items[last_visible..end].iter().enumerate() {
                     let mut element = (self.view_item)(last_visible + i, item);
                     let mut tree = Tree::new(&element);
 
@@ -505,15 +461,10 @@ where
                         .layout(&mut tree, renderer, &state.last_limits)
                         .move_to((
                             0.0,
-                            offsets[last_visible + i]
-                                + (last_visible + i) as f32 * self.spacing,
+                            offsets[last_visible + i] + (last_visible + i) as f32 * self.spacing,
                         ));
 
-                    state.visible_layouts.push((
-                        last_visible + i,
-                        layout,
-                        tree,
-                    ));
+                    state.visible_layouts.push((last_visible + i, layout, tree));
                     self.visible_elements.push(element);
                 }
             }
@@ -625,13 +576,11 @@ where
             })
             .collect::<Vec<_>>();
 
-        (!children.is_empty())
-            .then(|| overlay::Group::with_children(children).overlay())
+        (!children.is_empty()).then(|| overlay::Group::with_children(children).overlay())
     }
 }
 
-impl<'a, T, Message, Theme, Renderer>
-    From<List<'a, T, Message, Theme, Renderer>>
+impl<'a, T, Message, Theme, Renderer> From<List<'a, T, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
@@ -750,10 +699,7 @@ impl<T> FromIterator<T> for Content<T> {
 
 /// SAFETY: Copied from the `std` library.
 #[allow(unsafe_code)]
-fn binary_search_with_index_by<'a, T, F>(
-    slice: &'a [T],
-    mut f: F,
-) -> Result<usize, usize>
+fn binary_search_with_index_by<'a, T, F>(slice: &'a [T], mut f: F) -> Result<usize, usize>
 where
     F: FnMut(usize, &'a T) -> Ordering,
 {

--- a/widget/src/markdown.rs
+++ b/widget/src/markdown.rs
@@ -48,12 +48,8 @@ use crate::core::border;
 use crate::core::font::{self, Font};
 use crate::core::padding;
 use crate::core::theme;
-use crate::core::{
-    self, Color, Element, Length, Padding, Pixels, Theme, color,
-};
-use crate::{
-    checkbox, column, container, rich_text, row, rule, scrollable, span, text,
-};
+use crate::core::{self, Color, Element, Length, Padding, Pixels, Theme, color};
+use crate::{checkbox, column, container, rich_text, row, rule, scrollable, span, text};
 
 use std::borrow::BorrowMut;
 use std::cell::{Cell, RefCell};
@@ -424,8 +420,7 @@ impl Bullet {
 /// }
 /// ```
 pub fn parse(markdown: &str) -> impl Iterator<Item = Item> + '_ {
-    parse_with(State::default(), markdown)
-        .map(|(item, _source, _broken_links)| item)
+    parse_with(State::default(), markdown).map(|(item, _source, _broken_links)| item)
 }
 
 #[derive(Debug, Default)]
@@ -451,12 +446,10 @@ impl Highlighter {
     pub fn new(language: &str) -> Self {
         Self {
             lines: Vec::new(),
-            parser: iced_highlighter::Stream::new(
-                &iced_highlighter::Settings {
-                    theme: iced_highlighter::Theme::Base16Ocean,
-                    token: language.to_owned(),
-                },
-            ),
+            parser: iced_highlighter::Stream::new(&iced_highlighter::Settings {
+                theme: iced_highlighter::Theme::Base16Ocean,
+                token: language.to_owned(),
+            }),
             language: language.to_owned(),
             current: 0,
         }
@@ -476,10 +469,7 @@ impl Highlighter {
                     self.lines.truncate(self.current);
 
                     for line in &self.lines {
-                        log::debug!(
-                            "Refeeding {n} lines",
-                            n = self.lines.len()
-                        );
+                        log::debug!("Refeeding {n} lines", n = self.lines.len());
 
                         let _ = self.parser.highlight_line(&line.0);
                     }
@@ -569,9 +559,7 @@ fn parse_with<'a>(
             let broken_links = broken_links.clone();
 
             Some(move |broken_link: pulldown_cmark::BrokenLink<'_>| {
-                if let Some(reference) =
-                    references.get(broken_link.reference.as_ref())
-                {
+                if let Some(reference) = references.get(broken_link.reference.as_ref()) {
                     Some((
                         pulldown_cmark::CowStr::from(reference.to_owned()),
                         broken_link.reference.into_static(),
@@ -589,14 +577,10 @@ fn parse_with<'a>(
     let references = &mut state.borrow_mut().references;
 
     for reference in parser.reference_definitions().iter() {
-        let _ = references
-            .insert(reference.0.to_owned(), reference.1.dest.to_string());
+        let _ = references.insert(reference.0.to_owned(), reference.1.dest.to_string());
     }
 
-    let produce = move |state: &mut State,
-                        stack: &mut Vec<Scope>,
-                        item,
-                        source: Range<usize>| {
+    let produce = move |state: &mut State, stack: &mut Vec<Scope>, item, source: Range<usize>| {
         if let Some(scope) = stack.last_mut() {
             match scope {
                 Scope::List(list) => {
@@ -692,9 +676,9 @@ fn parse_with<'a>(
 
                 prev
             }
-            pulldown_cmark::Tag::CodeBlock(
-                pulldown_cmark::CodeBlockKind::Fenced(language),
-            ) if !metadata => {
+            pulldown_cmark::Tag::CodeBlock(pulldown_cmark::CodeBlockKind::Fenced(language))
+                if !metadata =>
+            {
                 #[cfg(feature = "highlighter")]
                 {
                     highlighter = Some({
@@ -702,16 +686,9 @@ fn parse_with<'a>(
                             .borrow_mut()
                             .highlighter
                             .take()
-                            .filter(|highlighter| {
-                                highlighter.language == language.as_ref()
-                            })
+                            .filter(|highlighter| highlighter.language == language.as_ref())
                             .unwrap_or_else(|| {
-                                Highlighter::new(
-                                    language
-                                        .split(',')
-                                        .next()
-                                        .unwrap_or_default(),
-                                )
+                                Highlighter::new(language.split(',').next().unwrap_or_default())
                             });
 
                         highlighter.prepare();
@@ -721,8 +698,7 @@ fn parse_with<'a>(
                 }
 
                 code_block = true;
-                code_language =
-                    (!language.is_empty()).then(|| language.into_string());
+                code_language = (!language.is_empty()).then(|| language.into_string());
 
                 if spans.is_empty() {
                     None
@@ -834,12 +810,7 @@ fn parse_with<'a>(
                     return None;
                 };
 
-                produce(
-                    state.borrow_mut(),
-                    &mut stack,
-                    Item::Quote(quote),
-                    source,
-                )
+                produce(state.borrow_mut(), &mut stack, Item::Quote(quote), source)
             }
             pulldown_cmark::TagEnd::Image if !metadata => {
                 let (url, title) = image.take()?;
@@ -848,12 +819,7 @@ fn parse_with<'a>(
                 let state = state.borrow_mut();
                 let _ = state.images.insert(url.clone());
 
-                produce(
-                    state,
-                    &mut stack,
-                    Item::Image { url, title, alt },
-                    source,
-                )
+                produce(state, &mut stack, Item::Image { url, title, alt }, source)
             }
             pulldown_cmark::TagEnd::CodeBlock if !metadata => {
                 code_block = false;
@@ -939,9 +905,7 @@ fn parse_with<'a>(
                 #[cfg(feature = "highlighter")]
                 if let Some(highlighter) = &mut highlighter {
                     for line in text.lines() {
-                        code_lines.push(Text::new(
-                            highlighter.highlight_line(line).to_vec(),
-                        ));
+                        code_lines.push(Text::new(highlighter.highlight_line(line).to_vec()));
                     }
                 }
 
@@ -1008,9 +972,7 @@ fn parse_with<'a>(
             });
             None
         }
-        pulldown_cmark::Event::InlineHtml(h)
-            if !metadata && h.eq_ignore_ascii_case("<br>") =>
-        {
+        pulldown_cmark::Event::InlineHtml(h) if !metadata && h.eq_ignore_ascii_case("<br>") => {
             spans.push(Span::Standard {
                 text: String::from("\n"),
                 strikethrough,
@@ -1021,9 +983,7 @@ fn parse_with<'a>(
             });
             None
         }
-        pulldown_cmark::Event::Rule => {
-            produce(state.borrow_mut(), &mut stack, Item::Rule, source)
-        }
+        pulldown_cmark::Event::Rule => produce(state.borrow_mut(), &mut stack, Item::Rule, source),
         pulldown_cmark::Event::TaskListMarker(done) => {
             if let Some(Scope::List(list)) = stack.last_mut()
                 && let Some(item) = list.bullets.last_mut()
@@ -1077,10 +1037,7 @@ impl Settings {
     /// Heading levels will be adjusted automatically. Specifically,
     /// the first level will be twice the base size, and then every level
     /// after that will be 25% smaller.
-    pub fn with_text_size(
-        text_size: impl Into<Pixels>,
-        style: impl Into<Style>,
-    ) -> Self {
+    pub fn with_text_size(text_size: impl Into<Pixels>, style: impl Into<Style>) -> Self {
         let text_size = text_size.into();
 
         Self {
@@ -1256,12 +1213,8 @@ where
     Renderer: core::text::Renderer<Font = Font> + 'a,
 {
     match item {
-        Item::Image { url, title, alt } => {
-            viewer.image(settings, url, title, alt)
-        }
-        Item::Heading(level, text) => {
-            viewer.heading(settings, level, text, index)
-        }
+        Item::Image { url, title, alt } => viewer.image(settings, url, title, alt),
+        Item::Heading(level, text) => viewer.heading(settings, level, text, index),
         Item::Paragraph(text) => viewer.paragraph(settings, text),
         Item::CodeBlock {
             language,
@@ -1364,10 +1317,7 @@ where
                 Bullet::Task { done, .. } => {
                     Element::from(
                         container(checkbox(*done).size(settings.text_size))
-                            .center_y(
-                                text::LineHeight::default()
-                                    .to_absolute(settings.text_size),
-                            ),
+                            .center_y(text::LineHeight::default().to_absolute(settings.text_size)),
                     )
                 }
             },
@@ -1488,8 +1438,7 @@ where
 }
 
 /// Displays a rule using the default look.
-pub fn rule<'a, Message, Theme, Renderer>()
--> Element<'a, Message, Theme, Renderer>
+pub fn rule<'a, Message, Theme, Renderer>() -> Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
     Theme: Catalog + 'a,
@@ -1514,27 +1463,19 @@ where
 
     let table = table(
         columns.iter().enumerate().map(move |(i, column)| {
-            table::column(
-                items(viewer, settings, &column.header),
-                move |row: &Row| {
-                    if let Some(cells) = row.cells.get(i) {
-                        items(viewer, settings, cells)
-                    } else {
-                        text("").into()
-                    }
-                },
-            )
+            table::column(items(viewer, settings, &column.header), move |row: &Row| {
+                if let Some(cells) = row.cells.get(i) {
+                    items(viewer, settings, cells)
+                } else {
+                    text("").into()
+                }
+            })
             .align_x(match column.alignment {
-                pulldown_cmark::Alignment::None
-                | pulldown_cmark::Alignment::Left => {
+                pulldown_cmark::Alignment::None | pulldown_cmark::Alignment::Left => {
                     alignment::Horizontal::Left
                 }
-                pulldown_cmark::Alignment::Center => {
-                    alignment::Horizontal::Center
-                }
-                pulldown_cmark::Alignment::Right => {
-                    alignment::Horizontal::Right
-                }
+                pulldown_cmark::Alignment::Center => alignment::Horizontal::Center,
+                pulldown_cmark::Alignment::Right => alignment::Horizontal::Right,
             })
         }),
         rows,
@@ -1596,13 +1537,10 @@ where
         let _url = url;
         let _title = title;
 
-        container(
-            rich_text(alt.spans(settings.style))
-                .on_link_click(Self::on_link_click),
-        )
-        .padding(settings.spacing.0)
-        .class(Theme::code_block())
-        .into()
+        container(rich_text(alt.spans(settings.style)).on_link_click(Self::on_link_click))
+            .padding(settings.spacing.0)
+            .class(Theme::code_block())
+            .into()
     }
 
     /// Displays a heading.
@@ -1621,11 +1559,7 @@ where
     /// Displays a paragraph.
     ///
     /// By default, it calls [`paragraph`].
-    fn paragraph(
-        &self,
-        settings: Settings,
-        text: &Text,
-    ) -> Element<'a, Message, Theme, Renderer> {
+    fn paragraph(&self, settings: Settings, text: &Text) -> Element<'a, Message, Theme, Renderer> {
         paragraph(settings, text, Self::on_link_click)
     }
 
@@ -1682,10 +1616,7 @@ where
     /// Displays a rule.
     ///
     /// By default, it calls [`rule`](self::rule()).
-    fn rule(
-        &self,
-        _settings: Settings,
-    ) -> Element<'a, Message, Theme, Renderer> {
+    fn rule(&self, _settings: Settings) -> Element<'a, Message, Theme, Renderer> {
         rule()
     }
 

--- a/widget/src/mouse_area.rs
+++ b/widget/src/mouse_area.rs
@@ -10,17 +10,11 @@ use crate::core::renderer;
 use crate::core::touch;
 use crate::core::widget::{Operation, Tree, tree};
 use crate::core::{
-    Clipboard, Element, Event, Layout, Length, Point, Rectangle, Shell, Size,
-    Vector, Widget,
+    Clipboard, Element, Event, Layout, Length, Point, Rectangle, Shell, Size, Vector, Widget,
 };
 
 /// Emit messages on mouse events.
-pub struct MouseArea<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> {
+pub struct MouseArea<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     content: Element<'a, Message, Theme, Renderer>,
     on_drag: Option<Message>,
     on_press: Option<Message>,
@@ -112,10 +106,7 @@ impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
 
     /// The message to emit when scroll wheel is used
     #[must_use]
-    pub fn on_scroll(
-        mut self,
-        on_scroll: impl Fn(mouse::ScrollDelta) -> Message + 'a,
-    ) -> Self {
+    pub fn on_scroll(mut self, on_scroll: impl Fn(mouse::ScrollDelta) -> Message + 'a) -> Self {
         self.on_scroll = Some(Box::new(on_scroll));
         self
     }
@@ -176,9 +167,7 @@ impl Default for State {
 
 impl<'a, Message, Theme, Renderer> MouseArea<'a, Message, Theme, Renderer> {
     /// Creates a [`MouseArea`] with the given content.
-    pub fn new(
-        content: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn new(content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         MouseArea {
             content: content.into(),
             on_drag: None,
@@ -231,11 +220,9 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        self.content.as_widget_mut().layout(
-            &mut tree.children[0],
-            renderer,
-            limits,
-        )
+        self.content
+            .as_widget_mut()
+            .layout(&mut tree.children[0], renderer, limits)
     }
 
     fn operate(
@@ -245,12 +232,9 @@ where
         renderer: &Renderer,
         operation: &mut dyn Operation,
     ) {
-        self.content.as_widget_mut().operate(
-            &mut tree.children[0],
-            layout,
-            renderer,
-            operation,
-        );
+        self.content
+            .as_widget_mut()
+            .operate(&mut tree.children[0], layout, renderer, operation);
     }
 
     fn update(
@@ -299,9 +283,7 @@ where
         );
 
         match (self.interaction, content_interaction) {
-            (Some(interaction), mouse::Interaction::None)
-                if cursor.is_over(layout.bounds()) =>
-            {
+            (Some(interaction), mouse::Interaction::None) if cursor.is_over(layout.bounds()) => {
                 interaction
             }
             _ => content_interaction,
@@ -352,12 +334,9 @@ where
         dnd_rectangles: &mut crate::core::clipboard::DndDestinationRectangles,
     ) {
         if let Some(state) = state.children.first() {
-            self.content.as_widget().drag_destinations(
-                state,
-                layout,
-                renderer,
-                dnd_rectangles,
-            );
+            self.content
+                .as_widget()
+                .drag_destinations(state, layout, renderer, dnd_rectangles);
         }
     }
 
@@ -370,11 +349,10 @@ where
     ) -> iced_accessibility::A11yTree {
         let c_state = state.children.get(0);
 
-        let ret = self.content.as_widget().a11y_nodes(
-            layout,
-            c_state.unwrap_or(&Tree::empty()),
-            cursor,
-        );
+        let ret =
+            self.content
+                .as_widget()
+                .a11y_nodes(layout, c_state.unwrap_or(&Tree::empty()), cursor);
         return ret;
     }
 }
@@ -467,11 +445,7 @@ fn update<Message: Clone, Theme, Renderer>(
     | Event::Touch(touch::Event::FingerPressed { .. }) = event
     {
         if let Some(position) = cursor_position {
-            let new_click = mouse::Click::new(
-                position,
-                mouse::Button::Left,
-                state.last_press,
-            );
+            let new_click = mouse::Click::new(position, mouse::Button::Left, state.last_press);
             if new_click.kind() == mouse::click::Kind::Double
                 && let Some(double_press) = widget.on_double_press.as_ref()
             {
@@ -497,11 +471,7 @@ fn update<Message: Clone, Theme, Renderer>(
     {
         state.drag_initiated = None;
         if let Some(position) = cursor_position {
-            let new_click = mouse::Click::new(
-                position,
-                mouse::Button::Left,
-                state.previous_click,
-            );
+            let new_click = mouse::Click::new(position, mouse::Button::Left, state.previous_click);
             if new_click.kind() == mouse::click::Kind::Double
                 && let Some(double_press) = widget.on_double_click.as_ref()
             {
@@ -561,8 +531,7 @@ fn update<Message: Clone, Theme, Renderer>(
         }
     }
 
-    if let Some(message) = widget.on_enter.as_ref().or(widget.on_exit.as_ref())
-    {
+    if let Some(message) = widget.on_enter.as_ref().or(widget.on_exit.as_ref()) {
         if let Event::Mouse(mouse::Event::CursorMoved { .. }) = event {
             if state.is_out_of_bounds {
                 state.is_out_of_bounds = false;
@@ -582,9 +551,7 @@ fn update<Message: Clone, Theme, Renderer>(
         {
             state.drag_initiated = cursor.position();
         }
-    } else if let Some((message, drag_source)) =
-        widget.on_drag.as_ref().zip(state.drag_initiated)
-    {
+    } else if let Some((message, drag_source)) = widget.on_drag.as_ref().zip(state.drag_initiated) {
         if let Some(position) = cursor.position() {
             if position.distance(drag_source) > 1.0 {
                 state.drag_initiated = None;

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -10,21 +10,15 @@ use crate::core::touch;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    Background, Clipboard, Color, Event, Length, Padding, Pixels, Point,
-    Rectangle, Shadow, Size, Theme, Vector,
+    Background, Clipboard, Color, Event, Length, Padding, Pixels, Point, Rectangle, Shadow, Size,
+    Theme, Vector,
 };
 use crate::core::{Element, Shell, Widget};
 use crate::scrollable::{self, Scrollable};
 
 /// A list of selectable options.
-pub struct Menu<
-    'a,
-    'b,
-    T,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct Menu<'a, 'b, T, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Theme: Catalog,
     Renderer: text::Renderer,
     'b: 'a,
@@ -44,8 +38,7 @@ pub struct Menu<
     class: &'a <Theme as Catalog>::Class<'b>,
 }
 
-impl<'a, 'b, T, Message, Theme, Renderer>
-    Menu<'a, 'b, T, Message, Theme, Renderer>
+impl<'a, 'b, T, Message, Theme, Renderer> Menu<'a, 'b, T, Message, Theme, Renderer>
 where
     T: ToString + Clone,
     Message: 'a,
@@ -99,10 +92,7 @@ where
     }
 
     /// Sets the text [`text::LineHeight`] of the [`Menu`].
-    pub fn text_line_height(
-        mut self,
-        line_height: impl Into<text::LineHeight>,
-    ) -> Self {
+    pub fn text_line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
         self.text_line_height = line_height.into();
         self
     }
@@ -252,8 +242,7 @@ where
     Renderer: text::Renderer,
 {
     fn layout(&mut self, renderer: &Renderer, bounds: Size) -> layout::Node {
-        let space_below =
-            bounds.height - (self.position.y + self.target_height);
+        let space_below = bounds.height - (self.position.y + self.target_height);
         let space_above = self.position.y;
 
         let limits = layout::Limits::new(
@@ -291,8 +280,7 @@ where
         let bounds = layout.bounds();
 
         self.list.update(
-            self.tree, event, layout, cursor, renderer, clipboard, shell,
-            &bounds,
+            self.tree, event, layout, cursor, renderer, clipboard, shell, &bounds,
         );
     }
 
@@ -302,13 +290,8 @@ where
         cursor: mouse::Cursor,
         renderer: &Renderer,
     ) -> mouse::Interaction {
-        self.list.mouse_interaction(
-            self.tree,
-            layout,
-            cursor,
-            &self.viewport,
-            renderer,
-        )
+        self.list
+            .mouse_interaction(self.tree, layout, cursor, &self.viewport, renderer)
     }
 
     fn draw(
@@ -391,16 +374,14 @@ where
     ) -> layout::Node {
         use std::f32;
 
-        let text_size =
-            self.text_size.unwrap_or_else(|| renderer.default_size());
+        let text_size = self.text_size.unwrap_or_else(|| renderer.default_size());
 
         let text_line_height = self.text_line_height.to_absolute(text_size);
 
         let size = {
             let intrinsic = Size::new(
                 0.0,
-                (f32::from(text_line_height) + self.padding.y())
-                    * self.options.len() as f32,
+                (f32::from(text_line_height) + self.padding.y()) * self.options.len() as f32,
             );
 
             limits.resolve(Length::Fill, Length::Shrink, intrinsic)
@@ -431,26 +412,18 @@ where
                 }
             }
             Event::Mouse(mouse::Event::CursorMoved { .. }) => {
-                if let Some(cursor_position) =
-                    cursor.position_in(layout.bounds())
-                {
-                    let text_size = self
-                        .text_size
-                        .unwrap_or_else(|| renderer.default_size());
+                if let Some(cursor_position) = cursor.position_in(layout.bounds()) {
+                    let text_size = self.text_size.unwrap_or_else(|| renderer.default_size());
 
                     let option_height =
-                        f32::from(self.text_line_height.to_absolute(text_size))
-                            + self.padding.y();
+                        f32::from(self.text_line_height.to_absolute(text_size)) + self.padding.y();
 
-                    let new_hovered_option =
-                        (cursor_position.y / option_height) as usize;
+                    let new_hovered_option = (cursor_position.y / option_height) as usize;
 
                     if *self.hovered_option != Some(new_hovered_option)
-                        && let Some(option) =
-                            self.options.get(new_hovered_option)
+                        && let Some(option) = self.options.get(new_hovered_option)
                     {
-                        if let Some(on_option_hovered) = self.on_option_hovered
-                        {
+                        if let Some(on_option_hovered) = self.on_option_hovered {
                             shell.publish(on_option_hovered(option.clone()));
                         }
 
@@ -461,19 +434,13 @@ where
                 }
             }
             Event::Touch(touch::Event::FingerPressed { .. }) => {
-                if let Some(cursor_position) =
-                    cursor.position_in(layout.bounds())
-                {
-                    let text_size = self
-                        .text_size
-                        .unwrap_or_else(|| renderer.default_size());
+                if let Some(cursor_position) = cursor.position_in(layout.bounds()) {
+                    let text_size = self.text_size.unwrap_or_else(|| renderer.default_size());
 
                     let option_height =
-                        f32::from(self.text_line_height.to_absolute(text_size))
-                            + self.padding.y();
+                        f32::from(self.text_line_height.to_absolute(text_size)) + self.padding.y();
 
-                    *self.hovered_option =
-                        Some((cursor_position.y / option_height) as usize);
+                    *self.hovered_option = Some((cursor_position.y / option_height) as usize);
 
                     if let Some(index) = *self.hovered_option
                         && let Some(option) = self.options.get(index)
@@ -490,9 +457,10 @@ where
 
         if let Event::Window(window::Event::RedrawRequested(_now)) = event {
             state.is_hovered = Some(cursor.is_over(layout.bounds()));
-        } else if state.is_hovered.is_some_and(|is_hovered| {
-            is_hovered != cursor.is_over(layout.bounds())
-        }) {
+        } else if state
+            .is_hovered
+            .is_some_and(|is_hovered| is_hovered != cursor.is_over(layout.bounds()))
+        {
             shell.request_redraw();
         }
     }
@@ -527,11 +495,9 @@ where
         let style = Catalog::style(theme, self.class);
         let bounds = layout.bounds();
 
-        let text_size =
-            self.text_size.unwrap_or_else(|| renderer.default_size());
+        let text_size = self.text_size.unwrap_or_else(|| renderer.default_size());
         let option_height =
-            f32::from(self.text_line_height.to_absolute(text_size))
-                + self.padding.y();
+            f32::from(self.text_line_height.to_absolute(text_size)) + self.padding.y();
 
         let offset = viewport.y - bounds.y;
         let start = (offset / option_height) as usize;
@@ -590,8 +556,7 @@ where
     }
 }
 
-impl<'a, 'b, T, Message, Theme, Renderer>
-    From<List<'a, 'b, T, Message, Theme, Renderer>>
+impl<'a, 'b, T, Message, Theme, Renderer> From<List<'a, 'b, T, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
     T: ToString + Clone,

--- a/widget/src/pane_grid.rs
+++ b/widget/src/pane_grid.rs
@@ -87,8 +87,8 @@ use crate::core::touch;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    self, Background, Border, Clipboard, Color, Element, Event, Layout, Length,
-    Pixels, Point, Rectangle, Shell, Size, Theme, Vector, Widget,
+    self, Background, Border, Clipboard, Color, Element, Event, Layout, Length, Pixels, Point,
+    Rectangle, Shell, Size, Theme, Vector, Widget,
 };
 use log::trace;
 
@@ -147,12 +147,8 @@ const THICKNESS_RATIO: f32 = 25.0;
 ///     .into()
 /// }
 /// ```
-pub struct PaneGrid<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct PaneGrid<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Theme: Catalog,
     Renderer: core::Renderer,
 {
@@ -288,10 +284,7 @@ where
     /// Sets the style class of the [`PaneGrid`].
     #[cfg(feature = "advanced")]
     #[must_use]
-    pub fn class(
-        mut self,
-        class: impl Into<<Theme as Catalog>::Class<'a>>,
-    ) -> Self {
+    pub fn class(mut self, class: impl Into<<Theme as Catalog>::Class<'a>>) -> Self {
         self.class = class.into();
         self
     }
@@ -317,31 +310,20 @@ where
         let resize_leeway = self.on_resize.as_ref().map(|(leeway, _)| *leeway);
         let node = self.internal.layout();
 
-        let resize_axis =
-            action.picked_split().map(|(_, axis)| axis).or_else(|| {
-                resize_leeway.and_then(|leeway| {
-                    let cursor_position = cursor.position()?;
-                    let bounds = layout.bounds();
+        let resize_axis = action.picked_split().map(|(_, axis)| axis).or_else(|| {
+            resize_leeway.and_then(|leeway| {
+                let cursor_position = cursor.position()?;
+                let bounds = layout.bounds();
 
-                    let splits = node.split_regions(
-                        self.spacing,
-                        self.min_size,
-                        bounds.size(),
-                    );
+                let splits = node.split_regions(self.spacing, self.min_size, bounds.size());
 
-                    let relative_cursor = Point::new(
-                        cursor_position.x - bounds.x,
-                        cursor_position.y - bounds.y,
-                    );
+                let relative_cursor =
+                    Point::new(cursor_position.x - bounds.x, cursor_position.y - bounds.y);
 
-                    hovered_split(
-                        splits.iter(),
-                        self.spacing + leeway,
-                        relative_cursor,
-                    )
+                hovered_split(splits.iter(), self.spacing + leeway, relative_cursor)
                     .map(|(_, axis, _)| axis)
-                })
-            });
+            })
+        });
 
         if let Some(resize_axis) = resize_axis {
             return Some(match resize_axis {
@@ -426,11 +408,10 @@ where
         limits: &layout::Limits,
     ) -> layout::Node {
         let bounds = limits.resolve(self.width, self.height, Size::ZERO);
-        let regions = self.internal.layout().pane_regions(
-            self.spacing,
-            self.min_size,
-            bounds,
-        );
+        let regions = self
+            .internal
+            .layout()
+            .pane_regions(self.spacing, self.min_size, bounds);
 
         let children = self
             .panes
@@ -449,11 +430,7 @@ where
                 let region = regions.get(pane)?;
                 let size = Size::new(region.width, region.height);
 
-                let node = content.layout(
-                    tree,
-                    renderer,
-                    &layout::Limits::new(size, size),
-                );
+                let node = content.layout(tree, renderer, &layout::Limits::new(size, size));
 
                 Some(node.move_to(Point::new(region.x, region.y)))
             })
@@ -530,8 +507,7 @@ where
             let is_picked = picked_pane == Some(pane);
 
             content.update(
-                tree, event, layout, cursor, renderer, clipboard, shell,
-                viewport, is_picked,
+                tree, event, layout, cursor, renderer, clipboard, shell, viewport, is_picked,
             );
         }
 
@@ -550,11 +526,8 @@ where
                                 cursor_position.y - bounds.y,
                             );
 
-                            let splits = node.split_regions(
-                                self.spacing,
-                                self.min_size,
-                                bounds.size(),
-                            );
+                            let splits =
+                                node.split_regions(self.spacing, self.min_size, bounds.size());
 
                             let clicked_split = hovered_split(
                                 splits.iter(),
@@ -564,8 +537,7 @@ where
 
                             if let Some((split, axis, _)) = clicked_split {
                                 if action.picked_pane().is_none() {
-                                    *action =
-                                        state::Action::Resizing { split, axis };
+                                    *action = state::Action::Resizing { split, axis };
                                 }
                             } else {
                                 click_pane(
@@ -573,10 +545,7 @@ where
                                     layout,
                                     cursor_position,
                                     shell,
-                                    self.panes
-                                        .iter()
-                                        .copied()
-                                        .zip(&self.contents),
+                                    self.panes.iter().copied().zip(&self.contents),
                                     &self.on_click,
                                     on_drag,
                                 );
@@ -603,11 +572,8 @@ where
                     && let Some(on_drag) = on_drag
                     && let Some(cursor_position) = cursor.position()
                 {
-                    if cursor_position.distance(origin) > DRAG_DEADBAND_DISTANCE
-                    {
-                        let event = if let Some(edge) =
-                            in_edge(layout, cursor_position)
-                        {
+                    if cursor_position.distance(origin) > DRAG_DEADBAND_DISTANCE {
+                        let event = if let Some(edge) = in_edge(layout, cursor_position) {
                             DragEvent::Dropped {
                                 pane,
                                 target: Target::Edge(edge),
@@ -625,9 +591,7 @@ where
                                 });
 
                             match dropped_region {
-                                Some(((target, _), region))
-                                    if pane != target =>
-                                {
+                                Some(((target, _), region)) if pane != target => {
                                     DragEvent::Dropped {
                                         pane,
                                         target: Target::Pane(target, region),
@@ -651,37 +615,25 @@ where
                     if let Some((split, _)) = action.picked_split() {
                         let bounds = layout.bounds();
 
-                        let splits = node.split_regions(
-                            self.spacing,
-                            self.min_size,
-                            bounds.size(),
-                        );
+                        let splits = node.split_regions(self.spacing, self.min_size, bounds.size());
 
                         if let Some((axis, rectangle, _)) = splits.get(&split)
                             && let Some(cursor_position) = cursor.position()
                         {
                             let ratio = match axis {
                                 Axis::Horizontal => {
-                                    let position = cursor_position.y
-                                        - bounds.y
-                                        - rectangle.y;
+                                    let position = cursor_position.y - bounds.y - rectangle.y;
 
-                                    (position / rectangle.height)
-                                        .clamp(0.0, 1.0)
+                                    (position / rectangle.height).clamp(0.0, 1.0)
                                 }
                                 Axis::Vertical => {
-                                    let position = cursor_position.x
-                                        - bounds.x
-                                        - rectangle.x;
+                                    let position = cursor_position.x - bounds.x - rectangle.x;
 
                                     (position / rectangle.width).clamp(0.0, 1.0)
                                 }
                             };
 
-                            shell.publish(on_resize(ResizeEvent {
-                                split,
-                                ratio,
-                            }));
+                            shell.publish(on_resize(ResizeEvent { split, ratio }));
 
                             shell.capture_event();
                         }
@@ -708,9 +660,7 @@ where
                         })
                         .find_map(|((_pane, content), c_layout)| {
                             content.grid_interaction(
-                                c_layout.with_virtual_offset(
-                                    layout.virtual_offset(),
-                                ),
+                                c_layout.with_virtual_offset(layout.virtual_offset()),
                                 cursor,
                                 on_drag.is_some(),
                             )
@@ -720,9 +670,10 @@ where
 
             if let Event::Window(window::Event::RedrawRequested(_now)) = event {
                 self.last_mouse_interaction = Some(interaction);
-            } else if self.last_mouse_interaction.is_some_and(
-                |last_mouse_interaction| last_mouse_interaction != interaction,
-            ) {
+            } else if self
+                .last_mouse_interaction
+                .is_some_and(|last_mouse_interaction| last_mouse_interaction != interaction)
+            {
                 shell.request_redraw();
             }
         }
@@ -738,9 +689,7 @@ where
     ) -> mouse::Interaction {
         let Memory { action, .. } = tree.state.downcast_ref();
 
-        if let Some(grid_interaction) =
-            self.grid_interaction(action, layout, cursor)
-        {
+        if let Some(grid_interaction) = self.grid_interaction(action, layout, cursor) {
             return grid_interaction;
         }
 
@@ -796,16 +745,11 @@ where
             .and_then(|(split, axis)| {
                 let bounds = layout.bounds();
 
-                let splits = node.split_regions(
-                    self.spacing,
-                    self.min_size,
-                    bounds.size(),
-                );
+                let splits = node.split_regions(self.spacing, self.min_size, bounds.size());
 
                 let (_axis, region, ratio) = splits.get(&split)?;
 
-                let region =
-                    axis.split_line_bounds(*region, *ratio, self.spacing);
+                let region = axis.split_line_bounds(*region, *ratio, self.spacing);
 
                 Some((axis, region + Vector::new(bounds.x, bounds.y), true))
             })
@@ -814,28 +758,15 @@ where
                     let cursor_position = cursor.position()?;
                     let bounds = layout.bounds();
 
-                    let relative_cursor = Point::new(
-                        cursor_position.x - bounds.x,
-                        cursor_position.y - bounds.y,
-                    );
+                    let relative_cursor =
+                        Point::new(cursor_position.x - bounds.x, cursor_position.y - bounds.y);
 
-                    let splits = node.split_regions(
-                        self.spacing,
-                        self.min_size,
-                        bounds.size(),
-                    );
+                    let splits = node.split_regions(self.spacing, self.min_size, bounds.size());
 
-                    let (_split, axis, region) = hovered_split(
-                        splits.iter(),
-                        self.spacing + leeway,
-                        relative_cursor,
-                    )?;
+                    let (_split, axis, region) =
+                        hovered_split(splits.iter(), self.spacing + leeway, relative_cursor)?;
 
-                    Some((
-                        axis,
-                        region + Vector::new(bounds.x, bounds.y),
-                        false,
-                    ))
+                    Some((axis, region + Vector::new(bounds.x, bounds.y), false))
                 }
                 None => None,
             });
@@ -873,8 +804,7 @@ where
         {
             match picked_pane {
                 Some((dragging, origin)) if id == dragging => {
-                    render_picked_pane =
-                        Some(((content, tree), origin, pane_layout));
+                    render_picked_pane = Some(((content, tree), origin, pane_layout));
                 }
                 Some((dragging, _)) if id != dragging => {
                     content.draw(
@@ -882,18 +812,16 @@ where
                         renderer,
                         theme,
                         defaults,
-                        pane_layout
-                            .with_virtual_offset(layout.virtual_offset()),
+                        pane_layout.with_virtual_offset(layout.virtual_offset()),
                         pane_cursor,
                         viewport,
                     );
 
                     if picked_pane.is_some()
                         && pane_in_edge.is_none()
-                        && let Some(region) =
-                            cursor.position().and_then(|cursor_position| {
-                                layout_region(pane_layout, cursor_position)
-                            })
+                        && let Some(region) = cursor
+                            .position()
+                            .and_then(|cursor_position| layout_region(pane_layout, cursor_position))
                     {
                         let bounds = layout_region_bounds(pane_layout, region);
 
@@ -913,8 +841,7 @@ where
                         renderer,
                         theme,
                         defaults,
-                        pane_layout
-                            .with_virtual_offset(layout.virtual_offset()),
+                        pane_layout.with_virtual_offset(layout.virtual_offset()),
                         pane_cursor,
                         viewport,
                     );
@@ -972,16 +899,13 @@ where
                     bounds: match axis {
                         Axis::Horizontal => Rectangle {
                             x: split_region.x,
-                            y: (split_region.y
-                                + (split_region.height - highlight.width)
-                                    / 2.0)
+                            y: (split_region.y + (split_region.height - highlight.width) / 2.0)
                                 .round(),
                             width: split_region.width,
                             height: highlight.width,
                         },
                         Axis::Vertical => Rectangle {
-                            x: (split_region.x
-                                + (split_region.width - highlight.width) / 2.0)
+                            x: (split_region.x + (split_region.width - highlight.width) / 2.0)
                                 .round(),
                             y: split_region.y,
                             width: highlight.width,
@@ -1143,14 +1067,11 @@ fn in_edge(layout: Layout<'_>, cursor: Point) -> Option<Edge> {
 
     if cursor.x > bounds.x && cursor.x < bounds.x + thickness {
         Some(Edge::Left)
-    } else if cursor.x > bounds.x + bounds.width - thickness
-        && cursor.x < bounds.x + bounds.width
-    {
+    } else if cursor.x > bounds.x + bounds.width - thickness && cursor.x < bounds.x + bounds.width {
         Some(Edge::Right)
     } else if cursor.y > bounds.y && cursor.y < bounds.y + thickness {
         Some(Edge::Top)
-    } else if cursor.y > bounds.y + bounds.height - thickness
-        && cursor.y < bounds.y + bounds.height
+    } else if cursor.y > bounds.y + bounds.height - thickness && cursor.y < bounds.y + bounds.height
     {
         Some(Edge::Bottom)
     } else {

--- a/widget/src/pane_grid/axis.rs
+++ b/widget/src/pane_grid/axis.rs
@@ -27,8 +27,7 @@ impl Axis {
                     .max(min_size_a)
                     .min(rectangle.height - min_size_b - spacing);
 
-                let height_bottom =
-                    (rectangle.height - height_top - spacing).max(min_size_b);
+                let height_bottom = (rectangle.height - height_top - spacing).max(min_size_b);
 
                 let ratio = (height_top + spacing / 2.0) / rectangle.height;
 
@@ -51,8 +50,7 @@ impl Axis {
                     .max(min_size_a)
                     .min(rectangle.width - min_size_b - spacing);
 
-                let width_right =
-                    (rectangle.width - width_left - spacing).max(min_size_b);
+                let width_right = (rectangle.width - width_left - spacing).max(min_size_b);
 
                 let ratio = (width_left + spacing / 2.0) / rectangle.width;
 
@@ -73,23 +71,16 @@ impl Axis {
     }
 
     /// Calculates the bounds of the split line in a [`Rectangle`] region.
-    pub fn split_line_bounds(
-        &self,
-        rectangle: Rectangle,
-        ratio: f32,
-        spacing: f32,
-    ) -> Rectangle {
+    pub fn split_line_bounds(&self, rectangle: Rectangle, ratio: f32, spacing: f32) -> Rectangle {
         match self {
             Axis::Horizontal => Rectangle {
                 x: rectangle.x,
-                y: (rectangle.y + rectangle.height * ratio - spacing / 2.0)
-                    .round(),
+                y: (rectangle.y + rectangle.height * ratio - spacing / 2.0).round(),
                 width: rectangle.width,
                 height: spacing,
             },
             Axis::Vertical => Rectangle {
-                x: (rectangle.x + rectangle.width * ratio - spacing / 2.0)
-                    .round(),
+                x: (rectangle.x + rectangle.width * ratio - spacing / 2.0).round(),
                 y: rectangle.y,
                 width: spacing,
                 height: rectangle.height,
@@ -203,8 +194,7 @@ mod tests {
                         width: 10.0,
                         height: overall_height,
                     };
-                    let (top, bottom, _ratio) =
-                        a.split(&r, 0.5, spacing, 0.0, 0.0);
+                    let (top, bottom, _ratio) = a.split(&r, 0.5, spacing, 0.0, 0.0);
                     assert_eq!(
                         top,
                         Rectangle {
@@ -235,8 +225,7 @@ mod tests {
                         width: overall_width,
                         height: 10.0,
                     };
-                    let (left, right, _ratio) =
-                        a.split(&r, 0.5, spacing, 0.0, 0.0);
+                    let (left, right, _ratio) = a.split(&r, 0.5, spacing, 0.0, 0.0);
                     assert_eq!(
                         left,
                         Rectangle {

--- a/widget/src/pane_grid/content.rs
+++ b/widget/src/pane_grid/content.rs
@@ -5,20 +5,15 @@ use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::widget::{self, Tree};
 use crate::core::{
-    self, Clipboard, Element, Event, Layout, Point, Rectangle, Shell, Size,
-    Vector, event,
+    self, Clipboard, Element, Event, Layout, Point, Rectangle, Shell, Size, Vector, event,
 };
 use crate::pane_grid::{Draggable, TitleBar};
 
 /// The content of a [`Pane`].
 ///
 /// [`Pane`]: super::Pane
-pub struct Content<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct Content<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Theme: container::Catalog,
     Renderer: core::Renderer,
 {
@@ -42,20 +37,14 @@ where
     }
 
     /// Sets the [`TitleBar`] of the [`Content`].
-    pub fn title_bar(
-        mut self,
-        title_bar: TitleBar<'a, Message, Theme, Renderer>,
-    ) -> Self {
+    pub fn title_bar(mut self, title_bar: TitleBar<'a, Message, Theme, Renderer>) -> Self {
         self.title_bar = Some(title_bar);
         self
     }
 
     /// Sets the style of the [`Content`].
     #[must_use]
-    pub fn style(
-        mut self,
-        style: impl Fn(&Theme) -> container::Style + 'a,
-    ) -> Self
+    pub fn style(mut self, style: impl Fn(&Theme) -> container::Style + 'a) -> Self
     where
         Theme::Class<'a>: From<container::StyleFn<'a, Theme>>,
     {
@@ -185,10 +174,7 @@ where
                 renderer,
                 &layout::Limits::new(
                     Size::ZERO,
-                    Size::new(
-                        max_size.width,
-                        max_size.height - title_bar_size.height,
-                    ),
+                    Size::new(max_size.width, max_size.height - title_bar_size.height),
                 ),
             );
 
@@ -200,11 +186,9 @@ where
                 ],
             )
         } else {
-            self.body.as_widget_mut().layout(
-                &mut tree.children[0],
-                renderer,
-                limits,
-            )
+            self.body
+                .as_widget_mut()
+                .layout(&mut tree.children[0], renderer, limits)
         }
     }
 
@@ -230,12 +214,9 @@ where
             layout
         };
 
-        self.body.as_widget_mut().operate(
-            &mut tree.children[0],
-            body_layout,
-            renderer,
-            operation,
-        );
+        self.body
+            .as_widget_mut()
+            .operate(&mut tree.children[0], body_layout, renderer, operation);
     }
 
     pub(crate) fn update(
@@ -296,9 +277,7 @@ where
 
         let is_over_pick_area = cursor
             .position()
-            .map(|cursor_position| {
-                title_bar.is_over_pick_area(title_bar_layout, cursor_position)
-            })
+            .map(|cursor_position| title_bar.is_over_pick_area(title_bar_layout, cursor_position))
             .unwrap_or_default();
 
         if is_over_pick_area && drag_enabled {
@@ -362,17 +341,14 @@ where
         renderer: &Renderer,
         drag_enabled: bool,
     ) -> mouse::Interaction {
-        let (body_layout, title_bar_interaction) = if let Some(title_bar) =
-            &self.title_bar
-        {
+        let (body_layout, title_bar_interaction) = if let Some(title_bar) = &self.title_bar {
             let mut children = layout.children();
             let title_bar_layout = children.next().unwrap();
 
             let is_over_pick_area = cursor
                 .position()
                 .map(|cursor_position| {
-                    title_bar
-                        .is_over_pick_area(title_bar_layout, cursor_position)
+                    title_bar.is_over_pick_area(title_bar_layout, cursor_position)
                 })
                 .unwrap_or_default();
 
@@ -395,13 +371,7 @@ where
 
         self.body
             .as_widget()
-            .mouse_interaction(
-                &tree.children[0],
-                body_layout,
-                cursor,
-                viewport,
-                renderer,
-            )
+            .mouse_interaction(&tree.children[0], body_layout, cursor, viewport, renderer)
             .max(title_bar_interaction)
     }
 
@@ -449,17 +419,12 @@ where
     }
 }
 
-impl<Message, Theme, Renderer> Draggable
-    for &Content<'_, Message, Theme, Renderer>
+impl<Message, Theme, Renderer> Draggable for &Content<'_, Message, Theme, Renderer>
 where
     Theme: container::Catalog,
     Renderer: core::Renderer,
 {
-    fn can_be_dragged_at(
-        &self,
-        layout: Layout<'_>,
-        cursor_position: Point,
-    ) -> bool {
+    fn can_be_dragged_at(&self, layout: Layout<'_>, cursor_position: Point) -> bool {
         if let Some(title_bar) = &self.title_bar {
             let mut children = layout.children();
             let title_bar_layout = children.next().unwrap();
@@ -471,8 +436,7 @@ where
     }
 }
 
-impl<'a, T, Message, Theme, Renderer> From<T>
-    for Content<'a, Message, Theme, Renderer>
+impl<'a, T, Message, Theme, Renderer> From<T> for Content<'a, Message, Theme, Renderer>
 where
     T: Into<Element<'a, Message, Theme, Renderer>>,
     Theme: container::Catalog + 'a,

--- a/widget/src/pane_grid/controls.rs
+++ b/widget/src/pane_grid/controls.rs
@@ -4,12 +4,8 @@ use crate::core::{self, Element};
 /// The controls of a [`Pane`].
 ///
 /// [`Pane`]: super::Pane
-pub struct Controls<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct Controls<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Theme: container::Catalog,
     Renderer: core::Renderer,
 {
@@ -23,9 +19,7 @@ where
     Renderer: core::Renderer,
 {
     /// Creates a new [`Controls`] with the given content.
-    pub fn new(
-        content: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn new(content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             full: content.into(),
             compact: None,

--- a/widget/src/pane_grid/node.rs
+++ b/widget/src/pane_grid/node.rs
@@ -160,9 +160,7 @@ impl Node {
 
     pub(crate) fn find(&mut self, pane: Pane) -> Option<&mut Node> {
         match self {
-            Node::Split { a, b, .. } => {
-                a.find(pane).or_else(move || b.find(pane))
-            }
+            Node::Split { a, b, .. } => a.find(pane).or_else(move || b.find(pane)),
             Node::Pane(p) => {
                 if *p == pane {
                     Some(self)
@@ -272,9 +270,7 @@ impl Node {
                 },
             ) => {
                 let (a_factor, b_factor) = match axis {
-                    Axis::Horizontal => {
-                        (count_a.horizontal(), count_b.horizontal())
-                    }
+                    Axis::Horizontal => (count_a.horizontal(), count_b.horizontal()),
                     Axis::Vertical => (count_a.vertical(), count_b.vertical()),
                 };
 
@@ -282,18 +278,12 @@ impl Node {
                     current,
                     *ratio,
                     spacing,
-                    min_size * (a_factor + 1) as f32
-                        + spacing * a_factor as f32,
-                    min_size * (b_factor + 1) as f32
-                        + spacing * b_factor as f32,
+                    min_size * (a_factor + 1) as f32 + spacing * a_factor as f32,
+                    min_size * (b_factor + 1) as f32 + spacing * b_factor as f32,
                 );
 
-                a.compute_regions(
-                    spacing, min_size, &region_a, count_a, regions,
-                );
-                b.compute_regions(
-                    spacing, min_size, &region_b, count_b, regions,
-                );
+                a.compute_regions(spacing, min_size, &region_a, count_a, regions);
+                b.compute_regions(spacing, min_size, &region_b, count_b, regions);
             }
             (Node::Pane(pane), Count::Pane) => {
                 let _ = regions.insert(*pane, *current);
@@ -328,9 +318,7 @@ impl Node {
                 },
             ) => {
                 let (a_factor, b_factor) = match axis {
-                    Axis::Horizontal => {
-                        (count_a.horizontal(), count_b.horizontal())
-                    }
+                    Axis::Horizontal => (count_a.horizontal(), count_b.horizontal()),
                     Axis::Vertical => (count_a.vertical(), count_b.vertical()),
                 };
 
@@ -338,10 +326,8 @@ impl Node {
                     current,
                     *ratio,
                     spacing,
-                    min_size * (a_factor + 1) as f32
-                        + spacing * a_factor as f32,
-                    min_size * (b_factor + 1) as f32
-                        + spacing * b_factor as f32,
+                    min_size * (a_factor + 1) as f32 + spacing * a_factor as f32,
+                    min_size * (b_factor + 1) as f32 + spacing * b_factor as f32,
                 );
 
                 let _ = splits.insert(*id, (*axis, *current, ratio));

--- a/widget/src/pane_grid/state.rs
+++ b/widget/src/pane_grid/state.rs
@@ -2,9 +2,7 @@
 //!
 //! [`PaneGrid`]: super::PaneGrid
 use crate::core::{Point, Size};
-use crate::pane_grid::{
-    Axis, Configuration, Direction, Edge, Node, Pane, Region, Split, Target,
-};
+use crate::pane_grid::{Axis, Configuration, Direction, Edge, Node, Pane, Region, Split, Target};
 
 use std::borrow::Cow;
 use std::collections::BTreeMap;
@@ -50,8 +48,7 @@ impl<T> State<T> {
     pub fn with_configuration(config: impl Into<Configuration<T>>) -> Self {
         let mut panes = BTreeMap::default();
 
-        let internal =
-            Internal::from_configuration(&mut panes, config.into(), 0);
+        let internal = Internal::from_configuration(&mut panes, config.into(), 0);
 
         State { panes, internal }
     }
@@ -97,33 +94,27 @@ impl<T> State<T> {
     /// Returns the adjacent [`Pane`] of another [`Pane`] in the given
     /// direction, if there is one.
     pub fn adjacent(&self, pane: Pane, direction: Direction) -> Option<Pane> {
-        let regions = self.internal.layout.pane_regions(
-            0.0,
-            0.0,
-            Size::new(4096.0, 4096.0),
-        );
+        let regions = self
+            .internal
+            .layout
+            .pane_regions(0.0, 0.0, Size::new(4096.0, 4096.0));
 
         let current_region = regions.get(&pane)?;
 
         let target = match direction {
-            Direction::Left => {
-                Point::new(current_region.x - 1.0, current_region.y + 1.0)
-            }
+            Direction::Left => Point::new(current_region.x - 1.0, current_region.y + 1.0),
             Direction::Right => Point::new(
                 current_region.x + current_region.width + 1.0,
                 current_region.y + 1.0,
             ),
-            Direction::Up => {
-                Point::new(current_region.x + 1.0, current_region.y - 1.0)
-            }
+            Direction::Up => Point::new(current_region.x + 1.0, current_region.y - 1.0),
             Direction::Down => Point::new(
                 current_region.x + 1.0,
                 current_region.y + current_region.height + 1.0,
             ),
         };
 
-        let mut colliding_regions =
-            regions.iter().filter(|(_, region)| region.contains(target));
+        let mut colliding_regions = regions.iter().filter(|(_, region)| region.contains(target));
 
         let (pane, _) = colliding_regions.next()?;
 
@@ -132,12 +123,7 @@ impl<T> State<T> {
 
     /// Splits the given [`Pane`] into two in the given [`Axis`] and
     /// initializing the new [`Pane`] with the provided internal state.
-    pub fn split(
-        &mut self,
-        axis: Axis,
-        pane: Pane,
-        state: T,
-    ) -> Option<(Pane, Split)> {
+    pub fn split(&mut self, axis: Axis, pane: Pane, state: T) -> Option<(Pane, Split)> {
         self.split_node(axis, Some(pane), state, false)
     }
 
@@ -212,13 +198,7 @@ impl<T> State<T> {
         Some((new_pane, new_split))
     }
 
-    fn split_and_swap(
-        &mut self,
-        axis: Axis,
-        target: Pane,
-        pane: Pane,
-        swap: bool,
-    ) {
+    fn split_and_swap(&mut self, axis: Axis, target: Pane, pane: Pane, swap: bool) {
         if let Some((state, _)) = self.close(pane)
             && let Some((new_pane, _)) = self.split(axis, target, state)
         {
@@ -251,15 +231,9 @@ impl<T> State<T> {
         }
     }
 
-    fn split_major_node_and_swap(
-        &mut self,
-        axis: Axis,
-        pane: Pane,
-        inverse: bool,
-    ) {
+    fn split_major_node_and_swap(&mut self, axis: Axis, pane: Pane, inverse: bool) {
         if let Some((state, _)) = self.close(pane)
-            && let Some((new_pane, _)) =
-                self.split_node(axis, None, state, inverse)
+            && let Some((new_pane, _)) = self.split_node(axis, None, state, inverse)
         {
             // Ensure new node corresponds to original closed `Pane` for state continuity
             self.relabel(new_pane, pane);

--- a/widget/src/pane_grid/title_bar.rs
+++ b/widget/src/pane_grid/title_bar.rs
@@ -5,20 +5,15 @@ use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::widget::Tree;
 use crate::core::{
-    self, Clipboard, Element, Event, Layout, Padding, Point, Rectangle, Shell,
-    Size, Vector,
+    self, Clipboard, Element, Event, Layout, Padding, Point, Rectangle, Shell, Size, Vector,
 };
 use crate::pane_grid::controls::Controls;
 
 /// The title bar of a [`Pane`].
 ///
 /// [`Pane`]: super::Pane
-pub struct TitleBar<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct TitleBar<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Theme: container::Catalog,
     Renderer: core::Renderer,
 {
@@ -35,9 +30,7 @@ where
     Renderer: core::Renderer,
 {
     /// Creates a new [`TitleBar`] with the given content.
-    pub fn new(
-        content: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn new(content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             content: content.into(),
             controls: None,
@@ -48,10 +41,7 @@ where
     }
 
     /// Sets the controls of the [`TitleBar`].
-    pub fn controls(
-        mut self,
-        controls: impl Into<Controls<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn controls(mut self, controls: impl Into<Controls<'a, Message, Theme, Renderer>>) -> Self {
         self.controls = Some(controls.into());
         self
     }
@@ -77,10 +67,7 @@ where
 
     /// Sets the style of the [`TitleBar`].
     #[must_use]
-    pub fn style(
-        mut self,
-        style: impl Fn(&Theme) -> container::Style + 'a,
-    ) -> Self
+    pub fn style(mut self, style: impl Fn(&Theme) -> container::Style + 'a) -> Self
     where
         Theme::Class<'a>: From<container::StyleFn<'a, Theme>>,
     {
@@ -179,8 +166,7 @@ where
             && (show_controls || self.always_show_controls)
         {
             let controls_layout = children.next().unwrap();
-            if title_layout.bounds().width + controls_layout.bounds().width
-                > padded.bounds().width
+            if title_layout.bounds().width + controls_layout.bounds().width > padded.bounds().width
             {
                 if let Some(compact) = controls.compact.as_ref() {
                     let compact_layout = children.next().unwrap();
@@ -190,8 +176,7 @@ where
                         renderer,
                         theme,
                         &inherited_style,
-                        compact_layout
-                            .with_virtual_offset(layout.virtual_offset()),
+                        compact_layout.with_virtual_offset(layout.virtual_offset()),
                         cursor,
                         viewport,
                     );
@@ -203,8 +188,7 @@ where
                         renderer,
                         theme,
                         &inherited_style,
-                        controls_layout
-                            .with_virtual_offset(layout.virtual_offset()),
+                        controls_layout.with_virtual_offset(layout.virtual_offset()),
                         cursor,
                         viewport,
                     );
@@ -215,8 +199,7 @@ where
                     renderer,
                     theme,
                     &inherited_style,
-                    controls_layout
-                        .with_virtual_offset(layout.virtual_offset()),
+                    controls_layout.with_virtual_offset(layout.virtual_offset()),
                     cursor,
                     viewport,
                 );
@@ -240,11 +223,7 @@ where
     /// [`TitleBar`] or not.
     ///
     /// The whole [`TitleBar`] is a pick area, except its controls.
-    pub fn is_over_pick_area(
-        &self,
-        layout: Layout<'_>,
-        cursor_position: Point,
-    ) -> bool {
+    pub fn is_over_pick_area(&self, layout: Layout<'_>, cursor_position: Point) -> bool {
         if layout.bounds().contains(cursor_position) {
             let mut children = layout.children();
             let padded = children.next().unwrap();
@@ -301,9 +280,7 @@ where
                 &layout::Limits::new(Size::ZERO, max_size),
             );
 
-            if title_layout.bounds().width + controls_layout.bounds().width
-                > max_size.width
-            {
+            if title_layout.bounds().width + controls_layout.bounds().width > max_size.width {
                 if let Some(compact) = controls.compact.as_mut() {
                     let compact_layout = compact.as_widget_mut().layout(
                         &mut tree.children[2],
@@ -312,8 +289,7 @@ where
                     );
 
                     let compact_size = compact_layout.size();
-                    let space_before_controls =
-                        max_size.width - compact_size.width;
+                    let space_before_controls = max_size.width - compact_size.width;
 
                     let height = title_size.height.max(compact_size.height);
 
@@ -322,16 +298,12 @@ where
                         vec![
                             title_layout,
                             controls_layout,
-                            compact_layout.move_to(Point::new(
-                                space_before_controls,
-                                0.0,
-                            )),
+                            compact_layout.move_to(Point::new(space_before_controls, 0.0)),
                         ],
                     )
                 } else {
                     let controls_size = controls_layout.size();
-                    let space_before_controls =
-                        max_size.width - controls_size.width;
+                    let space_before_controls = max_size.width - controls_size.width;
 
                     let height = title_size.height.max(controls_size.height);
 
@@ -339,17 +311,13 @@ where
                         Size::new(max_size.width, height),
                         vec![
                             title_layout,
-                            controls_layout.move_to(Point::new(
-                                space_before_controls,
-                                0.0,
-                            )),
+                            controls_layout.move_to(Point::new(space_before_controls, 0.0)),
                         ],
                     )
                 }
             } else {
                 let controls_size = controls_layout.size();
-                let space_before_controls =
-                    max_size.width - controls_size.width;
+                let space_before_controls = max_size.width - controls_size.width;
 
                 let height = title_size.height.max(controls_size.height);
 
@@ -357,8 +325,7 @@ where
                     Size::new(max_size.width, height),
                     vec![
                         title_layout,
-                        controls_layout
-                            .move_to(Point::new(space_before_controls, 0.0)),
+                        controls_layout.move_to(Point::new(space_before_controls, 0.0)),
                     ],
                 )
             }
@@ -389,16 +356,14 @@ where
         if let Some(controls) = &mut self.controls {
             let controls_layout = children.next().unwrap();
 
-            if title_layout.bounds().width + controls_layout.bounds().width
-                > padded.bounds().width
+            if title_layout.bounds().width + controls_layout.bounds().width > padded.bounds().width
             {
                 if let Some(compact) = controls.compact.as_mut() {
                     let compact_layout = children.next().unwrap();
 
                     compact.as_widget_mut().operate(
                         &mut tree.children[2],
-                        compact_layout
-                            .with_virtual_offset(layout.virtual_offset()),
+                        compact_layout.with_virtual_offset(layout.virtual_offset()),
                         renderer,
                         operation,
                     );
@@ -407,8 +372,7 @@ where
 
                     controls.full.as_widget_mut().operate(
                         &mut tree.children[1],
-                        controls_layout
-                            .with_virtual_offset(layout.virtual_offset()),
+                        controls_layout.with_virtual_offset(layout.virtual_offset()),
                         renderer,
                         operation,
                     );
@@ -416,8 +380,7 @@ where
             } else {
                 controls.full.as_widget_mut().operate(
                     &mut tree.children[1],
-                    controls_layout
-                        .with_virtual_offset(layout.virtual_offset()),
+                    controls_layout.with_virtual_offset(layout.virtual_offset()),
                     renderer,
                     operation,
                 );
@@ -455,8 +418,7 @@ where
         if let Some(controls) = &mut self.controls {
             let controls_layout = children.next().unwrap();
 
-            if title_layout.bounds().width + controls_layout.bounds().width
-                > padded.bounds().width
+            if title_layout.bounds().width + controls_layout.bounds().width > padded.bounds().width
             {
                 if let Some(compact) = controls.compact.as_mut() {
                     let compact_layout = children.next().unwrap();
@@ -464,8 +426,7 @@ where
                     compact.as_widget_mut().update(
                         &mut tree.children[2],
                         event,
-                        compact_layout
-                            .with_virtual_offset(layout.virtual_offset()),
+                        compact_layout.with_virtual_offset(layout.virtual_offset()),
                         cursor,
                         renderer,
                         clipboard,
@@ -478,8 +439,7 @@ where
                     controls.full.as_widget_mut().update(
                         &mut tree.children[1],
                         event,
-                        controls_layout
-                            .with_virtual_offset(layout.virtual_offset()),
+                        controls_layout.with_virtual_offset(layout.virtual_offset()),
                         cursor,
                         renderer,
                         clipboard,
@@ -491,8 +451,7 @@ where
                 controls.full.as_widget_mut().update(
                     &mut tree.children[1],
                     event,
-                    controls_layout
-                        .with_virtual_offset(layout.virtual_offset()),
+                    controls_layout.with_virtual_offset(layout.virtual_offset()),
                     cursor,
                     renderer,
                     clipboard,
@@ -540,30 +499,25 @@ where
 
         if let Some(controls) = &self.controls {
             let controls_layout = children.next().unwrap();
-            let controls_interaction =
-                controls.full.as_widget().mouse_interaction(
-                    &tree.children[1],
-                    controls_layout
-                        .with_virtual_offset(layout.virtual_offset()),
-                    cursor,
-                    viewport,
-                    renderer,
-                );
+            let controls_interaction = controls.full.as_widget().mouse_interaction(
+                &tree.children[1],
+                controls_layout.with_virtual_offset(layout.virtual_offset()),
+                cursor,
+                viewport,
+                renderer,
+            );
 
-            if title_layout.bounds().width + controls_layout.bounds().width
-                > padded.bounds().width
+            if title_layout.bounds().width + controls_layout.bounds().width > padded.bounds().width
             {
                 if let Some(compact) = controls.compact.as_ref() {
                     let compact_layout = children.next().unwrap();
-                    let compact_interaction =
-                        compact.as_widget().mouse_interaction(
-                            &tree.children[2],
-                            compact_layout
-                                .with_virtual_offset(layout.virtual_offset()),
-                            cursor,
-                            viewport,
-                            renderer,
-                        );
+                    let compact_interaction = compact.as_widget().mouse_interaction(
+                        &tree.children[2],
+                        compact_layout.with_virtual_offset(layout.virtual_offset()),
+                        cursor,
+                        viewport,
+                        renderer,
+                    );
 
                     compact_interaction.max(title_interaction)
                 } else {
@@ -606,8 +560,7 @@ where
                 controls.as_mut().and_then(|controls| {
                     let controls_layout = children.next()?;
 
-                    if title_layout.bounds().width
-                        + controls_layout.bounds().width
+                    if title_layout.bounds().width + controls_layout.bounds().width
                         > padded.bounds().width
                     {
                         if let Some(compact) = controls.compact.as_mut() {
@@ -616,9 +569,7 @@ where
 
                             compact.as_widget_mut().overlay(
                                 compact_state,
-                                compact_layout.with_virtual_offset(
-                                    layout.virtual_offset(),
-                                ),
+                                compact_layout.with_virtual_offset(layout.virtual_offset()),
                                 renderer,
                                 viewport,
                                 translation,
@@ -626,9 +577,7 @@ where
                         } else {
                             controls.full.as_widget_mut().overlay(
                                 controls_state,
-                                controls_layout.with_virtual_offset(
-                                    layout.virtual_offset(),
-                                ),
+                                controls_layout.with_virtual_offset(layout.virtual_offset()),
                                 renderer,
                                 viewport,
                                 translation,
@@ -637,8 +586,7 @@ where
                     } else {
                         controls.full.as_widget_mut().overlay(
                             controls_state,
-                            controls_layout
-                                .with_virtual_offset(layout.virtual_offset()),
+                            controls_layout.with_virtual_offset(layout.virtual_offset()),
                             renderer,
                             viewport,
                             translation,

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -74,8 +74,8 @@ use crate::core::touch;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    Background, Border, Clipboard, Color, Element, Event, Layout, Length,
-    Padding, Pixels, Point, Rectangle, Shell, Size, Theme, Vector, Widget,
+    Background, Border, Clipboard, Color, Element, Event, Layout, Length, Padding, Pixels, Point,
+    Rectangle, Shell, Size, Theme, Vector, Widget,
 };
 use crate::overlay::menu::{self, Menu};
 
@@ -144,15 +144,8 @@ use std::f32;
 ///     }
 /// }
 /// ```
-pub struct PickList<
-    'a,
-    T,
-    L,
-    V,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct PickList<'a, T, L, V, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     T: ToString + PartialEq + Clone,
     L: Borrow<[T]> + 'a,
     V: Borrow<T> + 'a,
@@ -180,8 +173,7 @@ pub struct PickList<
     menu_height: Length,
 }
 
-impl<'a, T, L, V, Message, Theme, Renderer>
-    PickList<'a, T, L, V, Message, Theme, Renderer>
+impl<'a, T, L, V, Message, Theme, Renderer> PickList<'a, T, L, V, Message, Theme, Renderer>
 where
     T: ToString + PartialEq + Clone,
     L: Borrow<[T]> + 'a,
@@ -192,11 +184,7 @@ where
 {
     /// Creates a new [`PickList`] with the given list of options, the current
     /// selected value, and the message to produce when an option is selected.
-    pub fn new(
-        options: L,
-        selected: Option<V>,
-        on_select: impl Fn(T) -> Message + 'a,
-    ) -> Self {
+    pub fn new(options: L, selected: Option<V>, on_select: impl Fn(T) -> Message + 'a) -> Self {
         Self {
             on_select: Box::new(on_select),
             on_open: None,
@@ -251,10 +239,7 @@ where
     }
 
     /// Sets the text [`text::LineHeight`] of the [`PickList`].
-    pub fn text_line_height(
-        mut self,
-        line_height: impl Into<text::LineHeight>,
-    ) -> Self {
+    pub fn text_line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
         self.text_line_height = line_height.into();
         self
     }
@@ -307,10 +292,7 @@ where
 
     /// Sets the style of the [`Menu`].
     #[must_use]
-    pub fn menu_style(
-        mut self,
-        style: impl Fn(&Theme) -> menu::Style + 'a,
-    ) -> Self
+    pub fn menu_style(mut self, style: impl Fn(&Theme) -> menu::Style + 'a) -> Self
     where
         <Theme as menu::Catalog>::Class<'a>: From<menu::StyleFn<'a, Theme>>,
     {
@@ -321,10 +303,7 @@ where
     /// Sets the style class of the [`PickList`].
     #[cfg(feature = "advanced")]
     #[must_use]
-    pub fn class(
-        mut self,
-        class: impl Into<<Theme as Catalog>::Class<'a>>,
-    ) -> Self {
+    pub fn class(mut self, class: impl Into<<Theme as Catalog>::Class<'a>>) -> Self {
         self.class = class.into();
         self
     }
@@ -332,10 +311,7 @@ where
     /// Sets the style class of the [`Menu`].
     #[cfg(feature = "advanced")]
     #[must_use]
-    pub fn menu_class(
-        mut self,
-        class: impl Into<<Theme as menu::Catalog>::Class<'a>>,
-    ) -> Self {
+    pub fn menu_class(mut self, class: impl Into<<Theme as menu::Catalog>::Class<'a>>) -> Self {
         self.menu_class = class.into();
         self
     }
@@ -375,8 +351,7 @@ where
         let state = tree.state.downcast_mut::<State<Renderer::Paragraph>>();
 
         let font = self.font.unwrap_or_else(|| renderer.default_font());
-        let text_size =
-            self.text_size.unwrap_or_else(|| renderer.default_size());
+        let text_size = self.text_size.unwrap_or_else(|| renderer.default_size());
         let options = self.options.borrow();
 
         state.options.resize_with(options.len(), Default::default);
@@ -397,8 +372,7 @@ where
             ellipsize: self.text_ellipsize,
         };
 
-        for (option, paragraph) in options.iter().zip(state.options.iter_mut())
-        {
+        for (option, paragraph) in options.iter().zip(state.options.iter_mut()) {
             let label = option.to_string();
 
             let _ = paragraph.update(Text {
@@ -416,10 +390,9 @@ where
 
         let max_width = match self.width {
             Length::Shrink => {
-                let labels_width =
-                    state.options.iter().fold(0.0, |width, paragraph| {
-                        f32::max(width, paragraph.min_width())
-                    });
+                let labels_width = state.options.iter().fold(0.0, |width, paragraph| {
+                    f32::max(width, paragraph.min_width())
+                });
 
                 labels_width.max(
                     self.placeholder
@@ -662,16 +635,7 @@ where
             Handle::None => None,
         };
 
-        if let Some((
-            font,
-            code_point,
-            size,
-            line_height,
-            shaping,
-            wrap,
-            ellipsize,
-        )) = handle
-        {
+        if let Some((font, code_point, size, line_height, shaping, wrap, ellipsize)) = handle {
             let size = size.unwrap_or_else(|| renderer.default_size());
 
             renderer.fill_text(
@@ -680,10 +644,7 @@ where
                     size,
                     line_height,
                     font,
-                    bounds: Size::new(
-                        bounds.width,
-                        f32::from(line_height.to_absolute(size)),
-                    ),
+                    bounds: Size::new(bounds.width, f32::from(line_height.to_absolute(size))),
                     align_x: text::Alignment::Right,
                     align_y: alignment::Vertical::Center,
                     shaping,
@@ -702,8 +663,7 @@ where
         let label = selected.map(ToString::to_string);
 
         if let Some(label) = label.or_else(|| self.placeholder.clone()) {
-            let text_size =
-                self.text_size.unwrap_or_else(|| renderer.default_size());
+            let text_size = self.text_size.unwrap_or_else(|| renderer.default_size());
 
             renderer.fill_text(
                 Text {
@@ -781,8 +741,7 @@ where
     }
 }
 
-impl<'a, T, L, V, Message, Theme, Renderer>
-    From<PickList<'a, T, L, V, Message, Theme, Renderer>>
+impl<'a, T, L, V, Message, Theme, Renderer> From<PickList<'a, T, L, V, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
     T: Clone + ToString + PartialEq + 'a,
@@ -792,9 +751,7 @@ where
     Theme: Catalog + 'a,
     Renderer: text::Renderer + 'a,
 {
-    fn from(
-        pick_list: PickList<'a, T, L, V, Message, Theme, Renderer>,
-    ) -> Self {
+    fn from(pick_list: PickList<'a, T, L, V, Message, Theme, Renderer>) -> Self {
         Self::new(pick_list)
     }
 }
@@ -920,11 +877,7 @@ pub trait Catalog: menu::Catalog {
     }
 
     /// The [`Style`] of a class with the given status.
-    fn style(
-        &self,
-        class: &<Self as Catalog>::Class<'_>,
-        status: Status,
-    ) -> Style;
+    fn style(&self, class: &<Self as Catalog>::Class<'_>, status: Status) -> Style;
 }
 
 /// A styling function for a [`PickList`].

--- a/widget/src/pin.rs
+++ b/widget/src/pin.rs
@@ -25,8 +25,8 @@ use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::widget;
 use crate::core::{
-    self, Clipboard, Element, Event, Layout, Length, Pixels, Point, Rectangle,
-    Shell, Size, Vector, Widget,
+    self, Clipboard, Element, Event, Layout, Length, Pixels, Point, Rectangle, Shell, Size, Vector,
+    Widget,
 };
 
 /// A widget that positions its contents at some fixed coordinates inside of its boundaries.
@@ -67,9 +67,7 @@ where
     Renderer: core::Renderer,
 {
     /// Creates a [`Pin`] widget with the given content.
-    pub fn new(
-        content: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn new(content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             content: content.into(),
             width: Length::Fill,
@@ -145,8 +143,7 @@ where
     ) -> layout::Node {
         let limits = limits.width(self.width).height(self.height);
 
-        let available =
-            limits.max() - Size::new(self.position.x, self.position.y);
+        let available = limits.max() - Size::new(self.position.x, self.position.y);
 
         let node = self
             .content
@@ -263,9 +260,7 @@ where
     Theme: 'a,
     Renderer: core::Renderer + 'a,
 {
-    fn from(
-        pin: Pin<'a, Message, Theme, Renderer>,
-    ) -> Element<'a, Message, Theme, Renderer> {
+    fn from(pin: Pin<'a, Message, Theme, Renderer>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(pin)
     }
 }

--- a/widget/src/progress_bar.rs
+++ b/widget/src/progress_bar.rs
@@ -25,8 +25,7 @@ use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::widget::Tree;
 use crate::core::{
-    self, Background, Color, Element, Layout, Length, Rectangle, Size, Theme,
-    Widget,
+    self, Background, Color, Element, Layout, Length, Rectangle, Size, Theme, Widget,
 };
 
 use std::ops::RangeInclusive;
@@ -142,8 +141,7 @@ where
     }
 }
 
-impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for ProgressBar<'_, Theme>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for ProgressBar<'_, Theme>
 where
     Theme: Catalog,
     Renderer: core::Renderer,
@@ -236,9 +234,7 @@ where
     Theme: 'a + Catalog,
     Renderer: 'a + core::Renderer,
 {
-    fn from(
-        progress_bar: ProgressBar<'a, Theme>,
-    ) -> Element<'a, Message, Theme, Renderer> {
+    fn from(progress_bar: ProgressBar<'a, Theme>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(progress_bar)
     }
 }
@@ -321,10 +317,7 @@ pub fn danger(theme: &Theme) -> Style {
     styled(palette.background.strong.color, palette.danger.base.color)
 }
 
-fn styled(
-    background: impl Into<Background>,
-    bar: impl Into<Background>,
-) -> Style {
+fn styled(background: impl Into<Background>, bar: impl Into<Background>) -> Style {
     Style {
         background: background.into(),
         bar: bar.into(),

--- a/widget/src/qr_code.rs
+++ b/widget/src/qr_code.rs
@@ -27,8 +27,7 @@ use crate::core::mouse;
 use crate::core::renderer::{self, Renderer as _};
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
-    Color, Element, Layout, Length, Pixels, Point, Rectangle, Size, Theme,
-    Vector, Widget,
+    Color, Element, Layout, Length, Pixels, Point, Rectangle, Size, Theme, Vector, Widget,
 };
 
 use std::cell::RefCell;
@@ -90,8 +89,7 @@ where
 
     /// Sets the size of the entire [`QRCode`].
     pub fn total_size(mut self, total_size: impl Into<Pixels>) -> Self {
-        self.cell_size =
-            total_size.into().0 / (self.data.width + 2 * QUIET_ZONE) as f32;
+        self.cell_size = total_size.into().0 / (self.data.width + 2 * QUIET_ZONE) as f32;
 
         self
     }
@@ -140,8 +138,7 @@ where
         _renderer: &Renderer,
         _limits: &layout::Limits,
     ) -> layout::Node {
-        let side_length =
-            (self.data.width + 2 * QUIET_ZONE) as f32 * self.cell_size;
+        let side_length = (self.data.width + 2 * QUIET_ZONE) as f32 * self.cell_size;
 
         layout::Node::new(Size::new(side_length, side_length))
     }
@@ -203,19 +200,15 @@ where
                 });
         });
 
-        renderer.with_translation(
-            bounds.position() - Point::ORIGIN,
-            |renderer| {
-                use crate::graphics::geometry::Renderer as _;
+        renderer.with_translation(bounds.position() - Point::ORIGIN, |renderer| {
+            use crate::graphics::geometry::Renderer as _;
 
-                renderer.draw_geometry(geometry);
-            },
-        );
+            renderer.draw_geometry(geometry);
+        });
     }
 }
 
-impl<'a, Message, Theme> From<QRCode<'a, Theme>>
-    for Element<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme> From<QRCode<'a, Theme>> for Element<'a, Message, Theme, Renderer>
 where
     Theme: Catalog + 'a,
 {
@@ -250,10 +243,7 @@ impl Data {
         data: impl AsRef<[u8]>,
         error_correction: ErrorCorrection,
     ) -> Result<Self, Error> {
-        let encoded = qrcode::QrCode::with_error_correction_level(
-            data,
-            error_correction.into(),
-        )?;
+        let encoded = qrcode::QrCode::with_error_correction_level(data, error_correction.into())?;
 
         Ok(Self::build(encoded))
     }
@@ -265,11 +255,7 @@ impl Data {
         version: Version,
         error_correction: ErrorCorrection,
     ) -> Result<Self, Error> {
-        let encoded = qrcode::QrCode::with_version(
-            data,
-            version.into(),
-            error_correction.into(),
-        )?;
+        let encoded = qrcode::QrCode::with_version(data, version.into(), error_correction.into())?;
 
         Ok(Self::build(encoded))
     }
@@ -341,15 +327,11 @@ impl From<ErrorCorrection> for qrcode::EcLevel {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum Error {
     /// The data is too long to encode in a QR code for the chosen [`Version`].
-    #[error(
-        "The data is too long to encode in a QR code for the chosen version"
-    )]
+    #[error("The data is too long to encode in a QR code for the chosen version")]
     DataTooLong,
 
     /// The chosen [`Version`] and [`ErrorCorrection`] combination is invalid.
-    #[error(
-        "The chosen version and error correction level combination is invalid."
-    )]
+    #[error("The chosen version and error correction level combination is invalid.")]
     InvalidVersion,
 
     /// One or more characters in the provided data are not supported by the

--- a/widget/src/radio.rs
+++ b/widget/src/radio.rs
@@ -67,8 +67,8 @@ use crate::core::widget;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    Background, Clipboard, Color, Element, Event, Layout, Length, Pixels,
-    Rectangle, Shell, Size, Theme, Widget,
+    Background, Clipboard, Color, Element, Event, Layout, Length, Pixels, Rectangle, Shell, Size,
+    Theme, Widget,
 };
 
 /// A circular button representing a choice.
@@ -170,12 +170,7 @@ where
     ///   * the current selected value
     ///   * a function that will be called when the [`Radio`] is selected. It
     ///     receives the value of the radio and must produce a `Message`.
-    pub fn new<F, V>(
-        label: impl Into<String>,
-        value: V,
-        selected: Option<V>,
-        f: F,
-    ) -> Self
+    pub fn new<F, V>(label: impl Into<String>, value: V, selected: Option<V>, f: F) -> Self
     where
         V: Eq + Copy,
         F: FnOnce(V) -> Message,
@@ -223,10 +218,7 @@ where
     }
 
     /// Sets the text [`text::LineHeight`] of the [`Radio`] button.
-    pub fn text_line_height(
-        mut self,
-        line_height: impl Into<text::LineHeight>,
-    ) -> Self {
+    pub fn text_line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
         self.text_line_height = line_height.into();
         self
     }
@@ -449,8 +441,7 @@ where
 
         {
             let label_layout = children.next().unwrap();
-            let state: &widget::text::State<Renderer::Paragraph> =
-                tree.state.downcast_ref();
+            let state: &widget::text::State<Renderer::Paragraph> = tree.state.downcast_ref();
 
             crate::text::draw(
                 renderer,
@@ -473,9 +464,7 @@ where
     Theme: 'a + Catalog,
     Renderer: 'a + text::Renderer,
 {
-    fn from(
-        radio: Radio<'a, Message, Theme, Renderer>,
-    ) -> Element<'a, Message, Theme, Renderer> {
+    fn from(radio: Radio<'a, Message, Theme, Renderer>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(radio)
     }
 }

--- a/widget/src/responsive.rs
+++ b/widget/src/responsive.rs
@@ -5,8 +5,7 @@ use crate::core::renderer;
 use crate::core::widget;
 use crate::core::widget::Tree;
 use crate::core::{
-    self, Clipboard, Element, Event, Length, Rectangle, Shell, Size, Vector,
-    Widget,
+    self, Clipboard, Element, Event, Length, Rectangle, Shell, Size, Vector, Widget,
 };
 use crate::space;
 
@@ -14,12 +13,7 @@ use crate::space;
 ///
 /// A [`Responsive`] widget will always try to fill all the available space of
 /// its parent.
-pub struct Responsive<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> {
+pub struct Responsive<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     view: Box<dyn Fn(Size) -> Element<'a, Message, Theme, Renderer> + 'a>,
     width: Length,
     height: Length,
@@ -36,9 +30,7 @@ where
     /// The `view` closure will receive the maximum available space for
     /// the [`Responsive`] during layout. You can use this [`Size`] to
     /// conditionally build the contents.
-    pub fn new(
-        view: impl Fn(Size) -> Element<'a, Message, Theme, Renderer> + 'a,
-    ) -> Self {
+    pub fn new(view: impl Fn(Size) -> Element<'a, Message, Theme, Renderer> + 'a) -> Self {
         Self {
             view: Box::new(view),
             width: Length::Fill,
@@ -88,11 +80,10 @@ where
         self.content = (self.view)(size);
         tree.diff_children(std::slice::from_mut(&mut self.content));
 
-        let node = self.content.as_widget_mut().layout(
-            &mut tree.children[0],
-            renderer,
-            &limits.loose(),
-        );
+        let node =
+            self.content
+                .as_widget_mut()
+                .layout(&mut tree.children[0], renderer, &limits.loose());
 
         let size = limits.resolve(self.width, self.height, node.size());
 
@@ -230,8 +221,7 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer>
-    From<Responsive<'a, Message, Theme, Renderer>>
+impl<'a, Message, Theme, Renderer> From<Responsive<'a, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,

--- a/widget/src/row.rs
+++ b/widget/src/row.rs
@@ -6,8 +6,7 @@ use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::widget::{Operation, Tree};
 use crate::core::{
-    Clipboard, Element, Event, Length, Padding, Pixels, Rectangle, Shell, Size,
-    Vector, Widget,
+    Clipboard, Element, Event, Length, Padding, Pixels, Rectangle, Shell, Size, Vector, Widget,
 };
 
 /// A container that distributes its contents horizontally.
@@ -72,9 +71,7 @@ where
     ///
     /// If any of the children have a [`Length::Fill`] strategy, you will need to
     /// call [`Row::width`] or [`Row::height`] accordingly.
-    pub fn from_vec(
-        children: Vec<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn from_vec(children: Vec<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             spacing: 0.0,
             padding: Padding::ZERO,
@@ -128,10 +125,7 @@ where
     }
 
     /// Adds an [`Element`] to the [`Row`].
-    pub fn push(
-        mut self,
-        child: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn push(mut self, child: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         let child = child.into();
         let child_size = child.as_widget().size_hint();
 
@@ -186,14 +180,9 @@ where
 }
 
 impl<'a, Message, Theme, Renderer: crate::core::Renderer>
-    FromIterator<Element<'a, Message, Theme, Renderer>>
-    for Row<'a, Message, Theme, Renderer>
+    FromIterator<Element<'a, Message, Theme, Renderer>> for Row<'a, Message, Theme, Renderer>
 {
-    fn from_iter<
-        T: IntoIterator<Item = Element<'a, Message, Theme, Renderer>>,
-    >(
-        iter: T,
-    ) -> Self {
+    fn from_iter<T: IntoIterator<Item = Element<'a, Message, Theme, Renderer>>>(iter: T) -> Self {
         Self::with_children(iter)
     }
 }
@@ -437,12 +426,7 @@ where
 /// obtain a [`Row`] that wraps its contents.
 ///
 /// The original alignment of the [`Row`] is preserved per row wrapped.
-pub struct Wrapping<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> {
+pub struct Wrapping<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     row: Row<'a, Message, Theme, Renderer>,
     vertical_spacing: Option<f32>,
     align_x: alignment::Horizontal,
@@ -456,10 +440,7 @@ impl<Message, Theme, Renderer> Wrapping<'_, Message, Theme, Renderer> {
     }
 
     /// Sets the horizontal alignment of the wrapping [`Row`].
-    pub fn align_x(
-        mut self,
-        align_x: impl Into<alignment::Horizontal>,
-    ) -> Self {
+    pub fn align_x(mut self, align_x: impl Into<alignment::Horizontal>) -> Self {
         self.align_x = align_x.into();
         self
     }
@@ -518,20 +499,15 @@ where
                 for node in &mut children[row_start] {
                     let height = node.size().height;
 
-                    node.translate_mut(Vector::new(
-                        0.0,
-                        (row_height - height) / align_factor,
-                    ));
+                    node.translate_mut(Vector::new(0.0, (row_height - height) / align_factor));
                 }
             }
         };
 
         for (i, child) in self.row.children.iter_mut().enumerate() {
-            let node = child.as_widget_mut().layout(
-                &mut tree.children[i],
-                renderer,
-                &child_limits,
-            );
+            let node = child
+                .as_widget_mut()
+                .layout(&mut tree.children[i], renderer, &child_limits);
 
             let child_size = node.size();
 
@@ -548,10 +524,7 @@ where
 
             row_height = row_height.max(child_size.height);
 
-            children.push(node.move_to((
-                x + self.row.padding.left,
-                y + self.row.padding.top,
-            )));
+            children.push(node.move_to((x + self.row.padding.left, y + self.row.padding.top)));
 
             x += child_size.width + spacing;
         }
@@ -584,10 +557,7 @@ where
                     .unwrap_or_default();
 
                 if next_x == 0.0 {
-                    let translation = Vector::new(
-                        (total_width - row_width) / align_factor,
-                        0.0,
-                    );
+                    let translation = Vector::new((total_width - row_width) / align_factor, 0.0);
 
                     for node in &mut children[row_start..=i] {
                         node.translate_mut(translation);
@@ -598,8 +568,7 @@ where
             }
         }
 
-        let size =
-            limits.resolve(self.row.width, self.row.height, intrinsic_size);
+        let size = limits.resolve(self.row.width, self.row.height, intrinsic_size);
 
         layout::Node::with_children(size.expand(self.row.padding), children)
     }

--- a/widget/src/rule.rs
+++ b/widget/src/rule.rs
@@ -22,9 +22,7 @@ use crate::core::layout;
 use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::widget::Tree;
-use crate::core::{
-    Color, Element, Layout, Length, Pixels, Rectangle, Size, Theme, Widget,
-};
+use crate::core::{Color, Element, Layout, Length, Pixels, Rectangle, Size, Theme, Widget};
 
 /// Creates a new horizontal [`Rule`] with the given height.
 pub fn horizontal<'a, Theme>(height: impl Into<Pixels>) -> Rule<'a, Theme>
@@ -135,8 +133,7 @@ where
     }
 }
 
-impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for Rule<'_, Theme>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Rule<'_, Theme>
 where
     Renderer: core::Renderer,
     Theme: Catalog,
@@ -210,8 +207,7 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer> From<Rule<'a, Theme>>
-    for Element<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme, Renderer> From<Rule<'a, Theme>> for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
     Theme: 'a + Catalog,

--- a/widget/src/scrollable.rs
+++ b/widget/src/scrollable.rs
@@ -40,9 +40,8 @@ use crate::core::widget::operation::{self, Operation};
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    self, Background, Clipboard, Color, Element, Event, InputMethod, Layout,
-    Length, Padding, Pixels, Point, Rectangle, Shadow, Shell, Size, Theme,
-    Vector, Widget, id::Internal,
+    self, Background, Clipboard, Color, Element, Event, InputMethod, Layout, Length, Padding,
+    Pixels, Point, Rectangle, Shadow, Shell, Size, Theme, Vector, Widget, id::Internal,
 };
 
 use iced_runtime::{Action, Task, task};
@@ -69,12 +68,8 @@ pub use operation::scrollable::{AbsoluteOffset, RelativeOffset};
 ///     ]).into()
 /// }
 /// ```
-pub struct Scrollable<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct Scrollable<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Theme: Catalog,
     Renderer: text::Renderer,
 {
@@ -102,9 +97,7 @@ where
     Renderer: text::Renderer,
 {
     /// Creates a new vertical [`Scrollable`].
-    pub fn new(
-        content: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn new(content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self::with_direction(content, Direction::default())
     }
 
@@ -208,8 +201,7 @@ where
     /// Sets the [`Anchor`] of the horizontal direction of the [`Scrollable`], if applicable.
     pub fn anchor_x(mut self, alignment: Anchor) -> Self {
         match &mut self.direction {
-            Direction::Horizontal(horizontal)
-            | Direction::Both { horizontal, .. } => {
+            Direction::Horizontal(horizontal) | Direction::Both { horizontal, .. } => {
                 horizontal.alignment = alignment;
             }
             Direction::Vertical { .. } => {}
@@ -221,8 +213,7 @@ where
     /// Sets the [`Anchor`] of the vertical direction of the [`Scrollable`], if applicable.
     pub fn anchor_y(mut self, alignment: Anchor) -> Self {
         match &mut self.direction {
-            Direction::Vertical(vertical)
-            | Direction::Both { vertical, .. } => {
+            Direction::Vertical(vertical) | Direction::Both { vertical, .. } => {
                 vertical.alignment = alignment;
             }
             Direction::Horizontal { .. } => {}
@@ -238,8 +229,7 @@ where
     /// of the [`Scrollable`].
     pub fn spacing(mut self, new_spacing: impl Into<Pixels>) -> Self {
         match &mut self.direction {
-            Direction::Horizontal(scrollbar)
-            | Direction::Vertical(scrollbar) => {
+            Direction::Horizontal(scrollbar) | Direction::Vertical(scrollbar) => {
                 scrollbar.spacing = Some(new_spacing.into().0);
             }
             Direction::Both { .. } => {}
@@ -262,8 +252,7 @@ where
         let width = width.into().0.max(0.0);
 
         match &mut self.direction {
-            Direction::Horizontal(scrollbar)
-            | Direction::Vertical(scrollbar) => {
+            Direction::Horizontal(scrollbar) | Direction::Vertical(scrollbar) => {
                 scrollbar.width = width;
             }
             Direction::Both {
@@ -283,8 +272,7 @@ where
         let width = width.into().0.max(0.0);
 
         match &mut self.direction {
-            Direction::Horizontal(scrollbar)
-            | Direction::Vertical(scrollbar) => {
+            Direction::Horizontal(scrollbar) | Direction::Vertical(scrollbar) => {
                 scrollbar.scroller_width = width;
             }
             Direction::Both {
@@ -304,8 +292,7 @@ where
         let padding = padding.into().0.max(0.0);
 
         match &mut self.direction {
-            Direction::Horizontal(scrollbar)
-            | Direction::Vertical(scrollbar) => {
+            Direction::Horizontal(scrollbar) | Direction::Vertical(scrollbar) => {
                 scrollbar.padding = padding;
             }
             Direction::Both {
@@ -347,10 +334,7 @@ where
 
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Scrollable`].
-    pub fn description_widget(
-        mut self,
-        description: &impl iced_accessibility::Describes,
-    ) -> Self {
+    pub fn description_widget(mut self, description: &impl iced_accessibility::Describes) -> Self {
         self.description = Some(iced_accessibility::Description::Id(
             description.description(),
         ));
@@ -360,16 +344,14 @@ where
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Scrollable`].
     pub fn description(mut self, description: impl Into<Cow<'a, str>>) -> Self {
-        self.description =
-            Some(iced_accessibility::Description::Text(description.into()));
+        self.description = Some(iced_accessibility::Description::Text(description.into()));
         self
     }
 
     #[cfg(feature = "a11y")]
     /// Sets the label of the [`Scrollable`].
     pub fn label(mut self, label: &dyn iced_accessibility::Labels) -> Self {
-        self.label =
-            Some(label.label().into_iter().map(|l| l.into()).collect());
+        self.label = Some(label.label().into_iter().map(|l| l.into()).collect());
         self
     }
 }
@@ -410,11 +392,9 @@ impl Direction {
     }
 
     fn align(&self, delta: Vector) -> Vector {
-        let horizontal_alignment =
-            self.horizontal().map(|p| p.alignment).unwrap_or_default();
+        let horizontal_alignment = self.horizontal().map(|p| p.alignment).unwrap_or_default();
 
-        let vertical_alignment =
-            self.vertical().map(|p| p.alignment).unwrap_or_default();
+        let vertical_alignment = self.vertical().map(|p| p.alignment).unwrap_or_default();
 
         let align = |alignment: Anchor, delta: f32| match alignment {
             Anchor::Start => delta,
@@ -610,8 +590,7 @@ where
                 spacing: Some(spacing),
                 ..
             }) => {
-                let is_vertical =
-                    matches!(self.direction, Direction::Vertical(_));
+                let is_vertical = matches!(self.direction, Direction::Vertical(_));
 
                 let padding = width + margin * 2.0 + spacing;
                 let state = tree.state.downcast_mut::<State>();
@@ -630,11 +609,9 @@ where
                 );
 
                 let is_scrollbar_visible = if is_vertical {
-                    status_quo.children()[0].size().height
-                        > status_quo.size().height
+                    status_quo.children()[0].size().height > status_quo.size().height
                 } else {
-                    status_quo.children()[0].size().width
-                        > status_quo.size().width
+                    status_quo.children()[0].size().width > status_quo.size().width
                 };
 
                 if state.is_scrollbar_visible == is_scrollbar_visible {
@@ -673,16 +650,9 @@ where
         let bounds = layout.bounds();
         let content_layout = layout.children().next().unwrap();
         let content_bounds = content_layout.bounds();
-        let translation =
-            state.translation(self.direction, bounds, content_bounds);
+        let translation = state.translation(self.direction, bounds, content_bounds);
 
-        operation.scrollable(
-            Some(&self.id),
-            bounds,
-            content_bounds,
-            translation,
-            state,
-        );
+        operation.scrollable(Some(&self.id), bounds, content_bounds, translation, state);
 
         operation.traverse(&mut |operation| {
             self.content.as_widget_mut().operate(
@@ -719,11 +689,9 @@ where
         let content = layout.children().next().unwrap();
         let content_bounds = content.bounds();
 
-        let scrollbars =
-            Scrollbars::new(state, self.direction, bounds, content_bounds);
+        let scrollbars = Scrollbars::new(state, self.direction, bounds, content_bounds);
 
-        let (mouse_over_y_scrollbar, mouse_over_x_scrollbar) =
-            scrollbars.is_mouse_over(cursor);
+        let (mouse_over_y_scrollbar, mouse_over_x_scrollbar) = scrollbars.is_mouse_over(cursor);
 
         let last_offsets = (state.offset_x, state.offset_y);
 
@@ -751,17 +719,12 @@ where
                     Event::Mouse(mouse::Event::CursorMoved { .. })
                     | Event::Touch(touch::Event::FingerMoved { .. }) => {
                         if let Some(scrollbar) = scrollbars.y {
-                            let Some(cursor_position) =
-                                cursor.land().position()
-                            else {
+                            let Some(cursor_position) = cursor.land().position() else {
                                 return;
                             };
 
                             state.scroll_y_to(
-                                scrollbar.scroll_percentage_y(
-                                    scroller_grabbed_at,
-                                    cursor_position,
-                                ),
+                                scrollbar.scroll_percentage_y(scroller_grabbed_at, cursor_position),
                                 bounds,
                                 content_bounds,
                             );
@@ -781,30 +744,22 @@ where
                 }
             } else if mouse_over_y_scrollbar {
                 match event {
-                    Event::Mouse(mouse::Event::ButtonPressed(
-                        mouse::Button::Left,
-                    ))
+                    Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
                     | Event::Touch(touch::Event::FingerPressed { .. }) => {
                         let Some(cursor_position) = cursor.position() else {
                             return;
                         };
 
-                        if let (Some(scroller_grabbed_at), Some(scrollbar)) = (
-                            scrollbars.grab_y_scroller(cursor_position),
-                            scrollbars.y,
-                        ) {
+                        if let (Some(scroller_grabbed_at), Some(scrollbar)) =
+                            (scrollbars.grab_y_scroller(cursor_position), scrollbars.y)
+                        {
                             state.scroll_y_to(
-                                scrollbar.scroll_percentage_y(
-                                    scroller_grabbed_at,
-                                    cursor_position,
-                                ),
+                                scrollbar.scroll_percentage_y(scroller_grabbed_at, cursor_position),
                                 bounds,
                                 content_bounds,
                             );
 
-                            state.interaction = Interaction::YScrollerGrabbed(
-                                scroller_grabbed_at,
-                            );
+                            state.interaction = Interaction::YScrollerGrabbed(scroller_grabbed_at);
 
                             let _ = notify_scroll(
                                 state,
@@ -825,17 +780,13 @@ where
                 match event {
                     Event::Mouse(mouse::Event::CursorMoved { .. })
                     | Event::Touch(touch::Event::FingerMoved { .. }) => {
-                        let Some(cursor_position) = cursor.land().position()
-                        else {
+                        let Some(cursor_position) = cursor.land().position() else {
                             return;
                         };
 
                         if let Some(scrollbar) = scrollbars.x {
                             state.scroll_x_to(
-                                scrollbar.scroll_percentage_x(
-                                    scroller_grabbed_at,
-                                    cursor_position,
-                                ),
+                                scrollbar.scroll_percentage_x(scroller_grabbed_at, cursor_position),
                                 bounds,
                                 content_bounds,
                             );
@@ -855,30 +806,22 @@ where
                 }
             } else if mouse_over_x_scrollbar {
                 match event {
-                    Event::Mouse(mouse::Event::ButtonPressed(
-                        mouse::Button::Left,
-                    ))
+                    Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
                     | Event::Touch(touch::Event::FingerPressed { .. }) => {
                         let Some(cursor_position) = cursor.position() else {
                             return;
                         };
 
-                        if let (Some(scroller_grabbed_at), Some(scrollbar)) = (
-                            scrollbars.grab_x_scroller(cursor_position),
-                            scrollbars.x,
-                        ) {
+                        if let (Some(scroller_grabbed_at), Some(scrollbar)) =
+                            (scrollbars.grab_x_scroller(cursor_position), scrollbars.x)
+                        {
                             state.scroll_x_to(
-                                scrollbar.scroll_percentage_x(
-                                    scroller_grabbed_at,
-                                    cursor_position,
-                                ),
+                                scrollbar.scroll_percentage_x(scroller_grabbed_at, cursor_position),
                                 bounds,
                                 content_bounds,
                             );
 
-                            state.interaction = Interaction::XScrollerGrabbed(
-                                scroller_grabbed_at,
-                            );
+                            state.interaction = Interaction::XScrollerGrabbed(scroller_grabbed_at);
 
                             let _ = notify_scroll(
                                 state,
@@ -899,8 +842,7 @@ where
                 && matches!(
                     event,
                     Event::Mouse(
-                        mouse::Event::ButtonPressed(_)
-                            | mouse::Event::WheelScrolled { .. }
+                        mouse::Event::ButtonPressed(_) | mouse::Event::WheelScrolled { .. }
                     ) | Event::Touch(_)
                         | Event::Keyboard(_)
                 )
@@ -913,18 +855,13 @@ where
             }
 
             if state.last_scrolled.is_none()
-                || !matches!(
-                    event,
-                    Event::Mouse(mouse::Event::WheelScrolled { .. })
-                )
+                || !matches!(event, Event::Mouse(mouse::Event::WheelScrolled { .. }))
             {
-                let translation =
-                    state.translation(self.direction, bounds, content_bounds);
+                let translation = state.translation(self.direction, bounds, content_bounds);
 
                 let cursor = match cursor_over_scrollable {
                     Some(cursor_position)
-                        if !(mouse_over_x_scrollbar
-                            || mouse_over_y_scrollbar) =>
+                        if !(mouse_over_x_scrollbar || mouse_over_y_scrollbar) =>
                     {
                         mouse::Cursor::Available(cursor_position + translation)
                     }
@@ -951,24 +888,21 @@ where
                             surface: surface.clone(),
                         },
                     )),
-                    Event::Dnd(dnd::DndEvent::Offer(
-                        id,
-                        dnd::OfferEvent::Motion { x, y },
-                    )) => Event::Dnd(dnd::DndEvent::Offer(
-                        id.clone(),
-                        dnd::OfferEvent::Motion {
-                            x: x + translation.x as f64,
-                            y: y + translation.y as f64,
-                        },
-                    )),
+                    Event::Dnd(dnd::DndEvent::Offer(id, dnd::OfferEvent::Motion { x, y })) => {
+                        Event::Dnd(dnd::DndEvent::Offer(
+                            id.clone(),
+                            dnd::OfferEvent::Motion {
+                                x: x + translation.x as f64,
+                                y: y + translation.y as f64,
+                            },
+                        ))
+                    }
                     e => e,
                 };
                 self.content.as_widget_mut().update(
                     &mut tree.children[0],
                     &c_event,
-                    content.with_virtual_offset(
-                        translation + layout.virtual_offset(),
-                    ),
+                    content.with_virtual_offset(translation + layout.virtual_offset()),
                     cursor,
                     renderer,
                     clipboard,
@@ -981,8 +915,7 @@ where
                 );
 
                 if !had_input_method
-                    && let InputMethod::Enabled { cursor, .. } =
-                        shell.input_method_mut()
+                    && let InputMethod::Enabled { cursor, .. } = shell.input_method_mut()
                 {
                     *cursor = *cursor - translation;
                 }
@@ -992,8 +925,7 @@ where
                 event,
                 Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
                     | Event::Touch(
-                        touch::Event::FingerLifted { .. }
-                            | touch::Event::FingerLost { .. }
+                        touch::Event::FingerLifted { .. } | touch::Event::FingerLost { .. }
                     )
             ) {
                 state.interaction = Interaction::None;
@@ -1012,13 +944,10 @@ where
 
                     let delta = match *delta {
                         mouse::ScrollDelta::Lines { x, y } => {
-                            let is_shift_pressed =
-                                state.keyboard_modifiers.shift();
+                            let is_shift_pressed = state.keyboard_modifiers.shift();
 
                             // macOS automatically inverts the axes when Shift is pressed
-                            let (x, y) = if cfg!(target_os = "macos")
-                                && is_shift_pressed
-                            {
+                            let (x, y) = if cfg!(target_os = "macos") && is_shift_pressed {
                                 (y, x)
                             } else {
                                 (x, y)
@@ -1033,23 +962,12 @@ where
                             // TODO: Configurable speed/friction (?)
                             -movement * 60.0
                         }
-                        mouse::ScrollDelta::Pixels { x, y } => {
-                            -Vector::new(x, y)
-                        }
+                        mouse::ScrollDelta::Pixels { x, y } => -Vector::new(x, y),
                     };
-                    state.scroll(
-                        self.direction.align(delta),
-                        bounds,
-                        content_bounds,
-                    );
+                    state.scroll(self.direction.align(delta), bounds, content_bounds);
 
-                    let has_scrolled = notify_scroll(
-                        state,
-                        &self.on_scroll,
-                        bounds,
-                        content_bounds,
-                        shell,
-                    );
+                    let has_scrolled =
+                        notify_scroll(state, &self.on_scroll, bounds, content_bounds, shell);
 
                     let in_transaction = state.last_scrolled.is_some();
 
@@ -1057,10 +975,8 @@ where
                         shell.capture_event();
                     }
                 }
-                Event::Mouse(mouse::Event::ButtonPressed(
-                    mouse::Button::Middle,
-                )) if self.auto_scroll
-                    && matches!(state.interaction, Interaction::None) =>
+                Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Middle))
+                    if self.auto_scroll && matches!(state.interaction, Interaction::None) =>
                 {
                     let Some(origin) = cursor_over_scrollable else {
                         return;
@@ -1077,11 +993,8 @@ where
                     shell.request_redraw();
                 }
                 Event::Touch(event)
-                    if matches!(
-                        state.interaction,
-                        Interaction::TouchScrolling(_)
-                    ) || (!mouse_over_y_scrollbar
-                        && !mouse_over_x_scrollbar) =>
+                    if matches!(state.interaction, Interaction::TouchScrolling(_))
+                        || (!mouse_over_y_scrollbar && !mouse_over_x_scrollbar) =>
                 {
                     match event {
                         touch::Event::FingerPressed { .. } => {
@@ -1089,19 +1002,16 @@ where
                                 return;
                             };
 
-                            state.interaction =
-                                Interaction::TouchScrolling(position);
+                            state.interaction = Interaction::TouchScrolling(position);
                         }
                         touch::Event::FingerMoved { .. } => {
-                            let Interaction::TouchScrolling(
-                                scroll_box_touched_at,
-                            ) = state.interaction
+                            let Interaction::TouchScrolling(scroll_box_touched_at) =
+                                state.interaction
                             else {
                                 return;
                             };
 
-                            let Some(cursor_position) = cursor.position()
-                            else {
+                            let Some(cursor_position) = cursor.position() else {
                                 return;
                             };
 
@@ -1110,14 +1020,9 @@ where
                                 scroll_box_touched_at.y - cursor_position.y,
                             );
 
-                            state.scroll(
-                                self.direction.align(delta),
-                                bounds,
-                                content_bounds,
-                            );
+                            state.scroll(self.direction.align(delta), bounds, content_bounds);
 
-                            state.interaction =
-                                Interaction::TouchScrolling(cursor_position);
+                            state.interaction = Interaction::TouchScrolling(cursor_position);
 
                             // TODO: bubble up touch movements if not consumed.
                             let _ = notify_scroll(
@@ -1135,9 +1040,7 @@ where
                 }
                 Event::Mouse(mouse::Event::CursorMoved { position }) => {
                     if let Interaction::AutoScrolling {
-                        origin,
-                        last_frame,
-                        ..
+                        origin, last_frame, ..
                     } = state.interaction
                     {
                         let delta = *position - origin;
@@ -1156,9 +1059,7 @@ where
                         }
                     }
                 }
-                Event::Keyboard(keyboard::Event::ModifiersChanged(
-                    modifiers,
-                )) => {
+                Event::Keyboard(keyboard::Event::ModifiersChanged(modifiers)) => {
                     state.keyboard_modifiers = *modifiers;
                 }
                 Event::Window(window::Event::RedrawRequested(now)) => {
@@ -1189,27 +1090,20 @@ where
                             delta.y = 0.0;
                         }
                         if delta.x != 0.0 || delta.y != 0.0 {
-                            let time_delta =
-                                if let Some(last_frame) = last_frame {
-                                    *now - last_frame
-                                } else {
-                                    Duration::ZERO
-                                };
+                            let time_delta = if let Some(last_frame) = last_frame {
+                                *now - last_frame
+                            } else {
+                                Duration::ZERO
+                            };
 
                             let scroll_factor = time_delta.as_secs_f32();
                             state.scroll(
                                 self.direction.align(Vector::new(
                                     delta.x.signum()
-                                        * delta
-                                            .x
-                                            .abs()
-                                            .powf(AUTOSCROLL_SMOOTHNESS)
+                                        * delta.x.abs().powf(AUTOSCROLL_SMOOTHNESS)
                                         * scroll_factor,
                                     delta.y.signum()
-                                        * delta
-                                            .y
-                                            .abs()
-                                            .powf(AUTOSCROLL_SMOOTHNESS)
+                                        * delta.y.abs().powf(AUTOSCROLL_SMOOTHNESS)
                                         * scroll_factor,
                                 )),
                                 bounds,
@@ -1225,12 +1119,11 @@ where
                             );
 
                             if has_scrolled || time_delta.is_zero() {
-                                state.interaction =
-                                    Interaction::AutoScrolling {
-                                        origin,
-                                        current,
-                                        last_frame: Some(*now),
-                                    };
+                                state.interaction = Interaction::AutoScrolling {
+                                    origin,
+                                    current,
+                                    last_frame: Some(*now),
+                                };
 
                                 shell.request_redraw();
                             }
@@ -1239,13 +1132,7 @@ where
                         }
                     }
 
-                    let _ = notify_viewport(
-                        state,
-                        &self.on_scroll,
-                        bounds,
-                        content_bounds,
-                        shell,
-                    );
+                    let _ = notify_viewport(state, &self.on_scroll, bounds, content_bounds, shell);
                 }
                 _ => {}
             }
@@ -1255,12 +1142,8 @@ where
 
         let status = if state.scrollers_grabbed() {
             Status::Dragged {
-                is_horizontal_scrollbar_dragged: state
-                    .x_scroller_grabbed_at()
-                    .is_some(),
-                is_vertical_scrollbar_dragged: state
-                    .y_scroller_grabbed_at()
-                    .is_some(),
+                is_horizontal_scrollbar_dragged: state.x_scroller_grabbed_at().is_some(),
+                is_vertical_scrollbar_dragged: state.y_scroller_grabbed_at().is_some(),
                 is_horizontal_scrollbar_disabled: scrollbars.is_x_disabled(),
                 is_vertical_scrollbar_disabled: scrollbars.is_y_disabled(),
             }
@@ -1311,20 +1194,15 @@ where
             return;
         };
 
-        let scrollbars =
-            Scrollbars::new(state, self.direction, bounds, content_bounds);
+        let scrollbars = Scrollbars::new(state, self.direction, bounds, content_bounds);
 
         let cursor_over_scrollable = cursor.position_over(bounds);
-        let (mouse_over_y_scrollbar, mouse_over_x_scrollbar) =
-            scrollbars.is_mouse_over(cursor);
+        let (mouse_over_y_scrollbar, mouse_over_x_scrollbar) = scrollbars.is_mouse_over(cursor);
 
-        let translation =
-            state.translation(self.direction, bounds, content_bounds);
+        let translation = state.translation(self.direction, bounds, content_bounds);
 
         let cursor = match cursor_over_scrollable {
-            Some(cursor_position)
-                if !(mouse_over_x_scrollbar || mouse_over_y_scrollbar) =>
-            {
+            Some(cursor_position) if !(mouse_over_x_scrollbar || mouse_over_y_scrollbar) => {
                 mouse::Cursor::Available(cursor_position + translation)
             }
             _ => mouse::Cursor::Unavailable,
@@ -1351,9 +1229,8 @@ where
                             renderer,
                             theme,
                             defaults,
-                            content_layout.with_virtual_offset(
-                                translation + layout.virtual_offset(),
-                            ),
+                            content_layout
+                                .with_virtual_offset(translation + layout.virtual_offset()),
                             cursor,
                             &Rectangle {
                                 y: visible_bounds.y + translation.y,
@@ -1366,9 +1243,7 @@ where
             });
 
             let draw_scrollbar =
-                |renderer: &mut Renderer,
-                 style: Rail,
-                 scrollbar: &internals::Scrollbar| {
+                |renderer: &mut Renderer, style: Rail, scrollbar: &internals::Scrollbar| {
                     if scrollbar.bounds.width > 0.0
                         && scrollbar.bounds.height > 0.0
                         && (style.background.is_some()
@@ -1381,19 +1256,17 @@ where
                                 border: style.border,
                                 ..renderer::Quad::default()
                             },
-                            style.background.unwrap_or(Background::Color(
-                                Color::TRANSPARENT,
-                            )),
+                            style
+                                .background
+                                .unwrap_or(Background::Color(Color::TRANSPARENT)),
                         );
                     }
 
                     if let Some(scroller) = scrollbar.scroller
                         && scroller.bounds.width > 0.0
                         && scroller.bounds.height > 0.0
-                        && (style.scroller.background
-                            != Background::Color(Color::TRANSPARENT)
-                            || (style.scroller.border.color
-                                != Color::TRANSPARENT
+                        && (style.scroller.background != Background::Color(Color::TRANSPARENT)
+                            || (style.scroller.border.color != Color::TRANSPARENT
                                 && style.scroller.border.width > 0.0))
                     {
                         renderer.fill_quad(
@@ -1415,24 +1288,15 @@ where
                 },
                 |renderer| {
                     if let Some(scrollbar) = scrollbars.y {
-                        draw_scrollbar(
-                            renderer,
-                            style.vertical_rail,
-                            &scrollbar,
-                        );
+                        draw_scrollbar(renderer, style.vertical_rail, &scrollbar);
                     }
 
                     if let Some(scrollbar) = scrollbars.x {
-                        draw_scrollbar(
-                            renderer,
-                            style.horizontal_rail,
-                            &scrollbar,
-                        );
+                        draw_scrollbar(renderer, style.horizontal_rail, &scrollbar);
                     }
 
                     if let (Some(x), Some(y)) = (scrollbars.x, scrollbars.y) {
-                        let background =
-                            style.gap.or(style.container.background);
+                        let background = style.gap.or(style.container.background);
 
                         if let Some(background) = background {
                             renderer.fill_quad(
@@ -1483,23 +1347,18 @@ where
         let content_layout = layout.children().next().unwrap();
         let content_bounds = content_layout.bounds();
 
-        let scrollbars =
-            Scrollbars::new(state, self.direction, bounds, content_bounds);
+        let scrollbars = Scrollbars::new(state, self.direction, bounds, content_bounds);
 
-        let (mouse_over_y_scrollbar, mouse_over_x_scrollbar) =
-            scrollbars.is_mouse_over(cursor);
+        let (mouse_over_y_scrollbar, mouse_over_x_scrollbar) = scrollbars.is_mouse_over(cursor);
 
         if state.scrollers_grabbed() {
             return mouse::Interaction::None;
         }
 
-        let translation =
-            state.translation(self.direction, bounds, content_bounds);
+        let translation = state.translation(self.direction, bounds, content_bounds);
 
         let cursor = match cursor_over_scrollable {
-            Some(cursor_position)
-                if !(mouse_over_x_scrollbar || mouse_over_y_scrollbar) =>
-            {
+            Some(cursor_position) if !(mouse_over_x_scrollbar || mouse_over_y_scrollbar) => {
                 mouse::Cursor::Available(cursor_position + translation)
             }
             _ => cursor.levitate() + translation,
@@ -1545,11 +1404,8 @@ where
             translation - offset,
         );
 
-        let icon = if let Interaction::AutoScrolling { origin, .. } =
-            state.interaction
-        {
-            let scrollbars =
-                Scrollbars::new(state, self.direction, bounds, content_bounds);
+        let icon = if let Interaction::AutoScrolling { origin, .. } = state.interaction {
+            let scrollbars = Scrollbars::new(state, self.direction, bounds, content_bounds);
 
             Some(overlay::Element::new(Box::new(AutoScrollIcon {
                 origin,
@@ -1565,9 +1421,9 @@ where
             (None, None) => None,
             (None, Some(icon)) => Some(icon),
             (Some(overlay), None) => Some(overlay),
-            (Some(overlay), Some(icon)) => Some(overlay::Element::new(
-                Box::new(overlay::Group::with_children(vec![overlay, icon])),
-            )),
+            (Some(overlay), Some(icon)) => Some(overlay::Element::new(Box::new(
+                overlay::Group::with_children(vec![overlay, icon]),
+            ))),
         }
     }
 
@@ -1598,26 +1454,16 @@ where
         let content = layout.children().next().unwrap();
         let content_bounds = content.bounds();
 
-        let translation = my_state.translation(
-            self.direction,
-            layout.bounds(),
-            content_bounds,
-        );
+        let translation = my_state.translation(self.direction, layout.bounds(), content_bounds);
 
         let child_layout = layout.children().next().unwrap();
         let child_tree = &state.children[0];
         let child_tree = self.content.as_widget().a11y_nodes(
-            child_layout
-                .with_virtual_offset(translation + layout.virtual_offset()),
+            child_layout.with_virtual_offset(translation + layout.virtual_offset()),
             &child_tree,
             cursor,
         );
-        let bounds = Rect::new(
-            x as f64,
-            y as f64,
-            (x + width) as f64,
-            (y + height) as f64,
-        );
+        let bounds = Rect::new(x as f64, y as f64, (x + width) as f64, (y + height) as f64);
         let mut node = Node::new(Role::ScrollView);
         node.set_bounds(bounds);
         if let Some(name) = self.name.as_ref() {
@@ -1653,21 +1499,17 @@ where
         let mut scrollbar_node = Node::new(Role::ScrollBar);
         if matches!(state.state, tree::State::Some(_)) {
             let state = state.state.downcast_ref::<State>();
-            let scrollbars = Scrollbars::new(
-                state,
-                self.direction,
-                content_bounds,
-                content_bounds,
-            );
+            let scrollbars = Scrollbars::new(state, self.direction, content_bounds, content_bounds);
             for (window, content, offset, scrollbar) in scrollbars
                 .x
                 .iter()
-                .map(|s| {
-                    (window.width, content_bounds.width, state.offset_x, s)
-                })
-                .chain(scrollbars.y.iter().map(|s| {
-                    (window.height, content_bounds.height, state.offset_y, s)
-                }))
+                .map(|s| (window.width, content_bounds.width, state.offset_x, s))
+                .chain(
+                    scrollbars
+                        .y
+                        .iter()
+                        .map(|s| (window.height, content_bounds.height, state.offset_y, s)),
+                )
             {
                 let scrollbar_bounds = scrollbar.total_bounds;
                 let is_hovered = cursor.is_over(scrollbar_bounds);
@@ -1677,19 +1519,13 @@ where
                     width,
                     height,
                 } = scrollbar_bounds;
-                let bounds = Rect::new(
-                    x as f64,
-                    y as f64,
-                    (x + width) as f64,
-                    (y + height) as f64,
-                );
+                let bounds = Rect::new(x as f64, y as f64, (x + width) as f64, (y + height) as f64);
                 scrollbar_node.set_bounds(bounds);
                 // TODO: hover
                 // if is_hovered {
                 //     scrollbar_node.set_hovered();
                 // }
-                scrollbar_node
-                    .set_controls(vec![A11yId::Widget(self.id.clone()).into()]);
+                scrollbar_node.set_controls(vec![A11yId::Widget(self.id.clone()).into()]);
                 scrollbar_node.set_numeric_value(
                     100.0 * offset.absolute(window, content) as f64
                         / scrollbar_bounds.height as f64,
@@ -1704,10 +1540,7 @@ where
             ]
             .into_iter(),
         );
-        A11yTree::node_with_child_tree(
-            A11yNode::new(node, self.id.clone()),
-            child_tree,
-        )
+        A11yTree::node_with_child_tree(A11yNode::new(node, self.id.clone()), child_tree)
     }
 
     fn id(&self) -> Option<Id> {
@@ -1734,19 +1567,13 @@ where
         dnd_rectangles: &mut crate::core::clipboard::DndDestinationRectangles,
     ) {
         let my_state = tree.state.downcast_ref::<State>();
-        if let Some((c_layout, c_state)) =
-            layout.children().zip(tree.children.iter()).next()
-        {
+        if let Some((c_layout, c_state)) = layout.children().zip(tree.children.iter()).next() {
             let mut my_dnd_rectangles = DndDestinationRectangles::new();
-            let translation = my_state.translation(
-                self.direction,
-                layout.bounds(),
-                c_layout.bounds(),
-            );
+            let translation =
+                my_state.translation(self.direction, layout.bounds(), c_layout.bounds());
             self.content.as_widget().drag_destinations(
                 c_state,
-                c_layout
-                    .with_virtual_offset(translation + layout.virtual_offset()),
+                c_layout.with_virtual_offset(translation + layout.virtual_offset()),
                 renderer,
                 &mut my_dnd_rectangles,
             );
@@ -1755,11 +1582,7 @@ where
             let bounds = layout.bounds();
             let content_bounds = c_layout.bounds();
             for r in &mut my_dnd_rectangles {
-                let translation = my_state.translation(
-                    self.direction,
-                    bounds,
-                    content_bounds,
-                );
+                let translation = my_state.translation(self.direction, bounds, content_bounds);
                 r.rectangle.x -= translation.x as f64;
                 r.rectangle.y -= translation.y as f64;
             }
@@ -1825,8 +1648,7 @@ where
             renderer.fill_quad(
                 renderer::Quad {
                     bounds: Rectangle::new(
-                        bounds.center()
-                            - Vector::new(Self::DOT, Self::DOT) / 2.0,
+                        bounds.center() - Vector::new(Self::DOT, Self::DOT) / 2.0,
                         Size::new(Self::DOT, Self::DOT),
                     ),
                     border: border::rounded(bounds.width),
@@ -1883,10 +1705,7 @@ where
                         align_x: text::Alignment::Left,
                         ..arrow
                     },
-                    Point::new(
-                        bounds.x + Self::PADDING + 1.0,
-                        bounds.center_y() + 1.0,
-                    ),
+                    Point::new(bounds.x + Self::PADDING + 1.0, bounds.center_y() + 1.0),
                     style.icon,
                     bounds,
                 );
@@ -1913,8 +1732,7 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer>
-    From<Scrollable<'a, Message, Theme, Renderer>>
+impl<'a, Message, Theme, Renderer> From<Scrollable<'a, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
@@ -1969,9 +1787,7 @@ fn notify_viewport<Message>(
     content_bounds: Rectangle,
     shell: &mut Shell<'_, Message>,
 ) -> bool {
-    if content_bounds.width <= bounds.width
-        && content_bounds.height <= bounds.height
-    {
+    if content_bounds.width <= bounds.width && content_bounds.height <= bounds.height {
         return false;
     }
 
@@ -1990,9 +1806,8 @@ fn notify_viewport<Message>(
         let last_absolute_offset = last_notified.absolute_offset();
         let current_absolute_offset = viewport.absolute_offset();
 
-        let unchanged = |a: f32, b: f32| {
-            (a - b).abs() <= f32::EPSILON || (a.is_nan() && b.is_nan())
-        };
+        let unchanged =
+            |a: f32, b: f32| (a - b).abs() <= f32::EPSILON || (a.is_nan() && b.is_nan());
 
         if last_notified.bounds == bounds
             && last_notified.content_bounds == content_bounds
@@ -2060,12 +1875,7 @@ impl operation::Scrollable for State {
         State::scroll_to(self, offset);
     }
 
-    fn scroll_by(
-        &mut self,
-        offset: AbsoluteOffset,
-        bounds: Rectangle,
-        content_bounds: Rectangle,
-    ) {
+    fn scroll_by(&mut self, offset: AbsoluteOffset, bounds: Rectangle, content_bounds: Rectangle) {
         State::scroll_by(self, offset, bounds, content_bounds);
     }
 }
@@ -2079,21 +1889,12 @@ enum Offset {
 impl Offset {
     fn absolute(self, viewport: f32, content: f32) -> f32 {
         match self {
-            Offset::Absolute(absolute) => {
-                absolute.min((content - viewport).max(0.0))
-            }
-            Offset::Relative(percentage) => {
-                ((content - viewport) * percentage).max(0.0)
-            }
+            Offset::Absolute(absolute) => absolute.min((content - viewport).max(0.0)),
+            Offset::Relative(percentage) => ((content - viewport) * percentage).max(0.0),
         }
     }
 
-    fn translation(
-        self,
-        viewport: f32,
-        content: f32,
-        alignment: Anchor,
-    ) -> f32 {
+    fn translation(self, viewport: f32, content: f32, alignment: Anchor) -> f32 {
         let offset = self.absolute(viewport, content);
 
         match alignment {
@@ -2165,45 +1966,28 @@ impl State {
         State::default()
     }
 
-    fn scroll(
-        &mut self,
-        delta: Vector<f32>,
-        bounds: Rectangle,
-        content_bounds: Rectangle,
-    ) {
+    fn scroll(&mut self, delta: Vector<f32>, bounds: Rectangle, content_bounds: Rectangle) {
         if bounds.height < content_bounds.height {
             self.offset_y = Offset::Absolute(
-                (self.offset_y.absolute(bounds.height, content_bounds.height)
-                    + delta.y)
+                (self.offset_y.absolute(bounds.height, content_bounds.height) + delta.y)
                     .clamp(0.0, content_bounds.height - bounds.height),
             );
         }
 
         if bounds.width < content_bounds.width {
             self.offset_x = Offset::Absolute(
-                (self.offset_x.absolute(bounds.width, content_bounds.width)
-                    + delta.x)
+                (self.offset_x.absolute(bounds.width, content_bounds.width) + delta.x)
                     .clamp(0.0, content_bounds.width - bounds.width),
             );
         }
     }
 
-    fn scroll_y_to(
-        &mut self,
-        percentage: f32,
-        bounds: Rectangle,
-        content_bounds: Rectangle,
-    ) {
+    fn scroll_y_to(&mut self, percentage: f32, bounds: Rectangle, content_bounds: Rectangle) {
         self.offset_y = Offset::Relative(percentage.clamp(0.0, 1.0));
         self.unsnap(bounds, content_bounds);
     }
 
-    fn scroll_x_to(
-        &mut self,
-        percentage: f32,
-        bounds: Rectangle,
-        content_bounds: Rectangle,
-    ) {
+    fn scroll_x_to(&mut self, percentage: f32, bounds: Rectangle, content_bounds: Rectangle) {
         self.offset_x = Offset::Relative(percentage.clamp(0.0, 1.0));
         self.unsnap(bounds, content_bounds);
     }
@@ -2229,24 +2013,17 @@ impl State {
     }
 
     /// Scroll by the provided [`AbsoluteOffset`].
-    fn scroll_by(
-        &mut self,
-        offset: AbsoluteOffset,
-        bounds: Rectangle,
-        content_bounds: Rectangle,
-    ) {
+    fn scroll_by(&mut self, offset: AbsoluteOffset, bounds: Rectangle, content_bounds: Rectangle) {
         self.scroll(Vector::new(offset.x, offset.y), bounds, content_bounds);
     }
 
     /// Unsnaps the current scroll position, if snapped, given the bounds of the
     /// [`Scrollable`] and its contents.
     fn unsnap(&mut self, bounds: Rectangle, content_bounds: Rectangle) {
-        self.offset_x = Offset::Absolute(
-            self.offset_x.absolute(bounds.width, content_bounds.width),
-        );
-        self.offset_y = Offset::Absolute(
-            self.offset_y.absolute(bounds.height, content_bounds.height),
-        );
+        self.offset_x =
+            Offset::Absolute(self.offset_x.absolute(bounds.width, content_bounds.width));
+        self.offset_y =
+            Offset::Absolute(self.offset_y.absolute(bounds.height, content_bounds.height));
     }
 
     /// Returns the scrolling translation of the [`State`], given a [`Direction`],
@@ -2260,22 +2037,14 @@ impl State {
         Vector::new(
             if let Some(horizontal) = direction.horizontal() {
                 self.offset_x
-                    .translation(
-                        bounds.width,
-                        content_bounds.width,
-                        horizontal.alignment,
-                    )
+                    .translation(bounds.width, content_bounds.width, horizontal.alignment)
                     .round()
             } else {
                 0.0
             },
             if let Some(vertical) = direction.vertical() {
                 self.offset_y
-                    .translation(
-                        bounds.height,
-                        content_bounds.height,
-                        vertical.alignment,
-                    )
+                    .translation(bounds.height, content_bounds.height, vertical.alignment)
                     .round()
             } else {
                 0.0
@@ -2343,30 +2112,25 @@ impl Scrollbars {
 
             // Adjust the height of the vertical scrollbar if the horizontal scrollbar
             // is present
-            let x_scrollbar_height = show_scrollbar_x
-                .map_or(0.0, |h| h.width.max(h.scroller_width) + h.margin);
+            let x_scrollbar_height =
+                show_scrollbar_x.map_or(0.0, |h| h.width.max(h.scroller_width) + h.margin);
 
-            let total_scrollbar_width =
-                width.max(scroller_width) + 2.0 * margin;
+            let total_scrollbar_width = width.max(scroller_width) + 2.0 * margin;
 
             // Total bounds of the scrollbar + margin + scroller width
             let total_scrollbar_bounds = Rectangle {
                 x: bounds.x + bounds.width - total_scrollbar_width,
                 y: bounds.y + padding,
                 width: total_scrollbar_width,
-                height: (bounds.height - x_scrollbar_height - 2.0 * padding)
-                    .max(0.0),
+                height: (bounds.height - x_scrollbar_height - 2.0 * padding).max(0.0),
             };
 
             // Bounds of just the scrollbar
             let scrollbar_bounds = Rectangle {
-                x: bounds.x + bounds.width
-                    - total_scrollbar_width / 2.0
-                    - width / 2.0,
+                x: bounds.x + bounds.width - total_scrollbar_width / 2.0 - width / 2.0,
                 y: bounds.y + padding,
                 width,
-                height: (bounds.height - x_scrollbar_height - 2.0 * padding)
-                    .max(0.0),
+                height: (bounds.height - x_scrollbar_height - 2.0 * padding).max(0.0),
             };
 
             let ratio = bounds.height / content_bounds.height;
@@ -2375,16 +2139,12 @@ impl Scrollbars {
                 None
             } else {
                 // min height for easier grabbing with super tall content
-                let scroller_height =
-                    (scrollbar_bounds.height * ratio).max(2.0);
+                let scroller_height = (scrollbar_bounds.height * ratio).max(2.0);
                 let scroller_offset =
-                    translation.y * ratio * scrollbar_bounds.height
-                        / bounds.height;
+                    translation.y * ratio * scrollbar_bounds.height / bounds.height;
 
                 let scroller_bounds = Rectangle {
-                    x: bounds.x + bounds.width
-                        - total_scrollbar_width / 2.0
-                        - scroller_width / 2.0,
+                    x: bounds.x + bounds.width - total_scrollbar_width / 2.0 - scroller_width / 2.0,
                     y: (scrollbar_bounds.y + scroller_offset).max(0.0),
                     width: scroller_width,
                     height: scroller_height,
@@ -2417,29 +2177,24 @@ impl Scrollbars {
 
             // Need to adjust the width of the horizontal scrollbar if the vertical scrollbar
             // is present
-            let scrollbar_y_width = y_scrollbar
-                .map_or(0.0, |scrollbar| scrollbar.total_bounds.width);
+            let scrollbar_y_width =
+                y_scrollbar.map_or(0.0, |scrollbar| scrollbar.total_bounds.width);
 
-            let total_scrollbar_height =
-                width.max(scroller_width) + 2.0 * margin;
+            let total_scrollbar_height = width.max(scroller_width) + 2.0 * margin;
 
             // Total bounds of the scrollbar + margin + scroller width
             let total_scrollbar_bounds = Rectangle {
                 x: bounds.x + padding,
                 y: bounds.y + bounds.height - total_scrollbar_height,
-                width: (bounds.width - scrollbar_y_width - 2.0 * padding)
-                    .max(0.0),
+                width: (bounds.width - scrollbar_y_width - 2.0 * padding).max(0.0),
                 height: total_scrollbar_height,
             };
 
             // Bounds of just the scrollbar
             let scrollbar_bounds = Rectangle {
                 x: bounds.x + padding,
-                y: bounds.y + bounds.height
-                    - total_scrollbar_height / 2.0
-                    - width / 2.0,
-                width: (bounds.width - scrollbar_y_width - 2.0 * padding)
-                    .max(0.0),
+                y: bounds.y + bounds.height - total_scrollbar_height / 2.0 - width / 2.0,
+                width: (bounds.width - scrollbar_y_width - 2.0 * padding).max(0.0),
                 height: width,
             };
 
@@ -2450,9 +2205,7 @@ impl Scrollbars {
             } else {
                 // min width for easier grabbing with extra wide content
                 let scroller_length = (scrollbar_bounds.width * ratio).max(2.0);
-                let scroller_offset =
-                    translation.x * ratio * scrollbar_bounds.width
-                        / bounds.width;
+                let scroller_offset = translation.x * ratio * scrollbar_bounds.width / bounds.width;
 
                 let scroller_bounds = Rectangle {
                     x: (scrollbar_bounds.x + scroller_offset).max(0.0),
@@ -2566,16 +2319,11 @@ pub(super) mod internals {
         }
 
         /// Returns the y-axis scrolled percentage from the cursor position.
-        pub fn scroll_percentage_y(
-            &self,
-            grabbed_at: f32,
-            cursor_position: Point,
-        ) -> f32 {
+        pub fn scroll_percentage_y(&self, grabbed_at: f32, cursor_position: Point) -> f32 {
             if let Some(scroller) = self.scroller {
-                let percentage = (cursor_position.y
-                    - self.bounds.y
-                    - scroller.bounds.height * grabbed_at)
-                    / (self.bounds.height - scroller.bounds.height);
+                let percentage =
+                    (cursor_position.y - self.bounds.y - scroller.bounds.height * grabbed_at)
+                        / (self.bounds.height - scroller.bounds.height);
 
                 match self.alignment {
                     Anchor::Start => percentage,
@@ -2587,16 +2335,11 @@ pub(super) mod internals {
         }
 
         /// Returns the x-axis scrolled percentage from the cursor position.
-        pub fn scroll_percentage_x(
-            &self,
-            grabbed_at: f32,
-            cursor_position: Point,
-        ) -> f32 {
+        pub fn scroll_percentage_x(&self, grabbed_at: f32, cursor_position: Point) -> f32 {
             if let Some(scroller) = self.scroller {
-                let percentage = (cursor_position.x
-                    - self.bounds.x
-                    - scroller.bounds.width * grabbed_at)
-                    / (self.bounds.width - scroller.bounds.width);
+                let percentage =
+                    (cursor_position.x - self.bounds.x - scroller.bounds.width * grabbed_at)
+                        / (self.bounds.width - scroller.bounds.width);
 
                 match self.alignment {
                     Anchor::Start => percentage,

--- a/widget/src/sensor.rs
+++ b/widget/src/sensor.rs
@@ -8,20 +8,13 @@ use crate::core::widget;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    self, Clipboard, Element, Event, Layout, Length, Pixels, Rectangle, Shell,
-    Size, Vector, Widget,
+    self, Clipboard, Element, Event, Layout, Length, Pixels, Rectangle, Shell, Size, Vector, Widget,
 };
 
 /// A widget that can generate messages when its content pops in and out of view.
 ///
 /// It can even notify you with anticipation at a given distance!
-pub struct Sensor<
-    'a,
-    Key,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> {
+pub struct Sensor<'a, Key, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     content: Element<'a, Message, Theme, Renderer>,
     key: Key,
     on_show: Option<Box<dyn Fn(Size) -> Message + 'a>>,
@@ -36,9 +29,7 @@ where
     Renderer: core::Renderer,
 {
     /// Creates a new [`Sensor`] widget with the given content.
-    pub fn new(
-        content: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn new(content: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             content: content.into(),
             key: (),
@@ -51,8 +42,7 @@ where
     }
 }
 
-impl<'a, Key, Message, Theme, Renderer>
-    Sensor<'a, Key, Message, Theme, Renderer>
+impl<'a, Key, Message, Theme, Renderer> Sensor<'a, Key, Message, Theme, Renderer>
 where
     Key: self::Key,
     Renderer: core::Renderer,
@@ -68,10 +58,7 @@ where
     /// Sets the message to be produced when the content changes [`Size`] once its in view.
     ///
     /// The closure will receive the new [`Size`] of the content.
-    pub fn on_resize(
-        mut self,
-        on_resize: impl Fn(Size) -> Message + 'a,
-    ) -> Self {
+    pub fn on_resize(mut self, on_resize: impl Fn(Size) -> Message + 'a) -> Self {
         self.on_resize = Some(Box::new(on_resize));
         self
     }
@@ -85,10 +72,7 @@ where
     /// Sets the key of the [`Sensor`] widget, for continuity.
     ///
     /// If the key changes, the [`Sensor`] widget will trigger again.
-    pub fn key<K>(
-        self,
-        key: K,
-    ) -> Sensor<'a, impl self::Key, Message, Theme, Renderer>
+    pub fn key<K>(self, key: K) -> Sensor<'a, impl self::Key, Message, Theme, Renderer>
     where
         K: Clone + PartialEq + 'static,
     {
@@ -106,10 +90,7 @@ where
     /// Sets the key of the [`Sensor`], for continuity; using a reference.
     ///
     /// If the key changes, the [`Sensor`] will trigger again.
-    pub fn key_ref<K>(
-        self,
-        key: &'a K,
-    ) -> Sensor<'a, &'a K, Message, Theme, Renderer>
+    pub fn key_ref<K>(self, key: &'a K) -> Sensor<'a, &'a K, Message, Theme, Renderer>
     where
         K: ToOwned + PartialEq<K::Owned> + ?Sized,
         K::Owned: 'static,
@@ -207,8 +188,8 @@ where
             let bounds = layout.bounds();
             let top_left_distance = viewport.distance(bounds.position());
 
-            let bottom_right_distance = viewport
-                .distance(bounds.position() + Vector::from(bounds.size()));
+            let bottom_right_distance =
+                viewport.distance(bounds.position() + Vector::from(bounds.size()));
 
             let distance = top_left_distance.min(bottom_right_distance);
 
@@ -288,11 +269,9 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        self.content.as_widget_mut().layout(
-            &mut tree.children[0],
-            renderer,
-            limits,
-        )
+        self.content
+            .as_widget_mut()
+            .layout(&mut tree.children[0], renderer, limits)
     }
 
     fn draw(
@@ -323,12 +302,9 @@ where
         renderer: &Renderer,
         operation: &mut dyn widget::Operation,
     ) {
-        self.content.as_widget_mut().operate(
-            &mut tree.children[0],
-            layout,
-            renderer,
-            operation,
-        );
+        self.content
+            .as_widget_mut()
+            .operate(&mut tree.children[0], layout, renderer, operation);
     }
 
     fn mouse_interaction(
@@ -366,8 +342,7 @@ where
     }
 }
 
-impl<'a, Key, Message, Theme, Renderer>
-    From<Sensor<'a, Key, Message, Theme, Renderer>>
+impl<'a, Key, Message, Theme, Renderer> From<Sensor<'a, Key, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,

--- a/widget/src/shader.rs
+++ b/widget/src/shader.rs
@@ -53,8 +53,7 @@ impl<Message, P: Program<Message>> Shader<Message, P> {
     }
 }
 
-impl<P, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for Shader<Message, P>
+impl<P, Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Shader<Message, P>
 where
     P: Program<Message>,
     Renderer: primitive::Renderer,
@@ -99,8 +98,7 @@ where
 
         let state = tree.state.downcast_mut::<P::State>();
 
-        if let Some(action) = self.program.update(state, event, bounds, cursor)
-        {
+        if let Some(action) = self.program.update(state, event, bounds, cursor) {
             let (message, redraw_request, event_status) = action.into_inner();
 
             shell.request_redraw_at(redraw_request);
@@ -142,10 +140,7 @@ where
         let bounds = layout.bounds();
         let state = tree.state.downcast_ref::<P::State>();
 
-        renderer.draw_primitive(
-            bounds,
-            self.program.draw(state, cursor_position, bounds),
-        );
+        renderer.draw_primitive(bounds, self.program.draw(state, cursor_position, bounds));
     }
 }
 
@@ -156,9 +151,7 @@ where
     Renderer: primitive::Renderer,
     P: Program<Message> + 'a,
 {
-    fn from(
-        custom: Shader<Message, P>,
-    ) -> Element<'a, Message, Theme, Renderer> {
+    fn from(custom: Shader<Message, P>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(custom)
     }
 }

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -39,8 +39,8 @@ use crate::core::widget::Id;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    self, Background, Clipboard, Color, Element, Event, Layout, Length, Pixels,
-    Point, Rectangle, Shell, Size, Theme, Widget,
+    self, Background, Clipboard, Color, Element, Event, Layout, Length, Pixels, Point, Rectangle,
+    Shell, Size, Theme, Widget,
 };
 
 use std::ops::RangeInclusive;
@@ -248,10 +248,7 @@ where
 
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Slider`].
-    pub fn description_widget(
-        mut self,
-        description: &impl iced_accessibility::Describes,
-    ) -> Self {
+    pub fn description_widget(mut self, description: &impl iced_accessibility::Describes) -> Self {
         self.description = Some(iced_accessibility::Description::Id(
             description.description(),
         ));
@@ -261,22 +258,19 @@ where
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Slider`].
     pub fn description(mut self, description: impl Into<Cow<'a, str>>) -> Self {
-        self.description =
-            Some(iced_accessibility::Description::Text(description.into()));
+        self.description = Some(iced_accessibility::Description::Text(description.into()));
         self
     }
 
     #[cfg(feature = "a11y")]
     /// Sets the label of the [`Slider`].
     pub fn label(mut self, label: &dyn iced_accessibility::Labels) -> Self {
-        self.label =
-            Some(label.label().into_iter().map(|l| l.into()).collect());
+        self.label = Some(label.label().into_iter().map(|l| l.into()).collect());
         self
     }
 }
 
-impl<T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for Slider<'_, T, Message, Theme>
+impl<T, Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Slider<'_, T, Message, Theme>
 where
     T: Copy + Into<f64> + num_traits::FromPrimitive,
     Message: Clone,
@@ -341,8 +335,7 @@ where
                     let start = (*self.range.start()).into();
                     let end = (*self.range.end()).into();
 
-                    let percent = f64::from(cursor_position.x - bounds.x)
-                        / f64::from(bounds.width);
+                    let percent = f64::from(cursor_position.x - bounds.x) / f64::from(bounds.width);
 
                     let steps = (percent * (end - start) / step).round();
                     let value = steps * step + start;
@@ -396,13 +389,9 @@ where
             };
 
             match &event {
-                Event::Mouse(mouse::Event::ButtonPressed(
-                    mouse::Button::Left,
-                ))
+                Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
                 | Event::Touch(touch::Event::FingerPressed { .. }) => {
-                    if let Some(cursor_position) =
-                        cursor.position_over(layout.bounds())
-                    {
+                    if let Some(cursor_position) = cursor.position_over(layout.bounds()) {
                         if state.keyboard_modifiers.command() {
                             let _ = self.default.map(change);
                             state.is_dragging = false;
@@ -414,9 +403,7 @@ where
                         shell.capture_event();
                     }
                 }
-                Event::Mouse(mouse::Event::ButtonReleased(
-                    mouse::Button::Left,
-                ))
+                Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
                 | Event::Touch(touch::Event::FingerLifted { .. })
                 | Event::Touch(touch::Event::FingerLost { .. }) => {
                     if state.is_dragging {
@@ -429,11 +416,7 @@ where
                 Event::Mouse(mouse::Event::CursorMoved { .. })
                 | Event::Touch(touch::Event::FingerMoved { .. }) => {
                     if state.is_dragging {
-                        let _ = cursor
-                            .land()
-                            .position()
-                            .and_then(locate)
-                            .map(change);
+                        let _ = cursor.land().position().and_then(locate).map(change);
 
                         shell.capture_event();
                     }
@@ -456,9 +439,7 @@ where
                         shell.capture_event();
                     }
                 }
-                Event::Keyboard(keyboard::Event::KeyPressed {
-                    key, ..
-                }) => {
+                Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) => {
                     if cursor.is_over(layout.bounds()) {
                         match key {
                             Key::Named(key::Named::ArrowUp) => {
@@ -473,9 +454,7 @@ where
                         }
                     }
                 }
-                Event::Keyboard(keyboard::Event::ModifiersChanged(
-                    modifiers,
-                )) => {
+                Event::Keyboard(keyboard::Event::ModifiersChanged(modifiers)) => {
                     state.keyboard_modifiers = *modifiers;
                 }
                 _ => {}
@@ -511,8 +490,7 @@ where
     ) {
         let bounds = layout.bounds();
 
-        let style =
-            theme.style(&self.class, self.status.unwrap_or(Status::Active));
+        let style = theme.style(&self.class, self.status.unwrap_or(Status::Active));
 
         let border_width = style
             .handle
@@ -520,42 +498,41 @@ where
             .min(bounds.height / 2.0)
             .min(bounds.width / 2.0);
 
-        let (handle_width, handle_height, handle_border_radius) =
-            match style.handle.shape {
-                HandleShape::Circle { radius } => {
-                    let radius = (radius)
-                        .max(2.0 * border_width)
-                        .min(bounds.height / 2.0)
-                        .min(bounds.width / 2.0 + 2.0 * border_width);
-                    (radius * 2.0, radius * 2.0, Radius::from(radius))
+        let (handle_width, handle_height, handle_border_radius) = match style.handle.shape {
+            HandleShape::Circle { radius } => {
+                let radius = (radius)
+                    .max(2.0 * border_width)
+                    .min(bounds.height / 2.0)
+                    .min(bounds.width / 2.0 + 2.0 * border_width);
+                (radius * 2.0, radius * 2.0, Radius::from(radius))
+            }
+            HandleShape::Rectangle {
+                height,
+                width,
+                border_radius,
+            } => {
+                let width = (f32::from(width)).max(2.0 * border_width);
+                let height = (f32::from(height)).max(2.0 * border_width);
+                let mut border_radius: [f32; 4] = border_radius.into();
+                for r in &mut border_radius {
+                    *r = (*r)
+                        .min(height / 2.0)
+                        .min(width / 2.0)
+                        .max(*r * (width + border_width * 2.0) / width);
                 }
-                HandleShape::Rectangle {
-                    height,
-                    width,
-                    border_radius,
-                } => {
-                    let width = (f32::from(width)).max(2.0 * border_width);
-                    let height = (f32::from(height)).max(2.0 * border_width);
-                    let mut border_radius: [f32; 4] = border_radius.into();
-                    for r in &mut border_radius {
-                        *r = (*r)
-                            .min(height / 2.0)
-                            .min(width / 2.0)
-                            .max(*r * (width + border_width * 2.0) / width);
-                    }
 
-                    (
-                        width,
-                        height,
-                        Radius {
-                            top_left: border_radius[0],
-                            top_right: border_radius[1],
-                            bottom_right: border_radius[2],
-                            bottom_left: border_radius[3],
-                        },
-                    )
-                }
-            };
+                (
+                    width,
+                    height,
+                    Radius {
+                        top_left: border_radius[0],
+                        top_right: border_radius[1],
+                        bottom_right: border_radius[2],
+                        bottom_left: border_radius[3],
+                    },
+                )
+            }
+        };
 
         let value = self.value.into() as f32;
         let (range_start, range_end) = {
@@ -567,8 +544,7 @@ where
         let offset = if range_start >= range_end {
             0.0
         } else {
-            (bounds.width - handle_width) * (value - range_start)
-                / (range_end - range_start)
+            (bounds.width - handle_width) * (value - range_start) / (range_end - range_start)
         };
 
         let rail_y = bounds.y + bounds.height / 2.0;
@@ -702,12 +678,7 @@ where
             width,
             height,
         } = bounds;
-        let bounds = Rect::new(
-            x as f64,
-            y as f64,
-            (x + width) as f64,
-            (y + height) as f64,
-        );
+        let bounds = Rect::new(x as f64, y as f64, (x + width) as f64, (y + height) as f64);
         let mut node = Node::new(Role::Slider);
         node.set_bounds(bounds);
         if let Some(name) = self.name.as_ref() {
@@ -768,9 +739,7 @@ where
     Theme: Catalog + 'a,
     Renderer: core::Renderer + 'a,
 {
-    fn from(
-        slider: Slider<'a, T, Message, Theme>,
-    ) -> Element<'a, Message, Theme, Renderer> {
+    fn from(slider: Slider<'a, T, Message, Theme>) -> Element<'a, Message, Theme, Renderer> {
         Element::new(slider)
     }
 }

--- a/widget/src/space.rs
+++ b/widget/src/space.rs
@@ -92,8 +92,7 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer> From<Space>
-    for Element<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme, Renderer> From<Space> for Element<'a, Message, Theme, Renderer>
 where
     Renderer: core::Renderer,
     Message: 'a,

--- a/widget/src/stack.rs
+++ b/widget/src/stack.rs
@@ -7,8 +7,7 @@ use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::widget::{Operation, Tree};
 use crate::core::{
-    Clipboard, Element, Event, Layout, Length, Rectangle, Shell, Size, Vector,
-    Widget,
+    Clipboard, Element, Event, Layout, Length, Rectangle, Shell, Size, Vector, Widget,
 };
 
 /// A container that displays children on top of each other.
@@ -22,8 +21,7 @@ use crate::core::{
 ///
 /// Keep in mind that too much layering will normally produce bad UX as well as
 /// introduce certain rendering overhead. Use this widget sparingly!
-pub struct Stack<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
-{
+pub struct Stack<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     width: Length,
     height: Length,
     children: Vec<Element<'a, Message, Theme, Renderer>>,
@@ -61,9 +59,7 @@ where
     ///
     /// If any of the children have a [`Length::Fill`] strategy, you will need to
     /// call [`Stack::width`] or [`Stack::height`] accordingly.
-    pub fn from_vec(
-        children: Vec<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn from_vec(children: Vec<Element<'a, Message, Theme, Renderer>>) -> Self {
         Self {
             width: Length::Shrink,
             height: Length::Shrink,
@@ -86,10 +82,7 @@ where
     }
 
     /// Adds an element on top of the [`Stack`].
-    pub fn push(
-        mut self,
-        child: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn push(mut self, child: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         let child = child.into();
         let child_size = child.as_widget().size_hint();
 
@@ -106,10 +99,7 @@ where
     }
 
     /// Adds an element under the [`Stack`].
-    pub fn push_under(
-        mut self,
-        child: impl Into<Element<'a, Message, Theme, Renderer>>,
-    ) -> Self {
+    pub fn push_under(mut self, child: impl Into<Element<'a, Message, Theme, Renderer>>) -> Self {
         self.children.insert(0, child.into());
         self.base_layer += 1;
         self
@@ -172,11 +162,7 @@ where
         let limits = limits.width(self.width).height(self.height);
 
         if self.children.len() <= self.base_layer {
-            return layout::Node::new(limits.resolve(
-                self.width,
-                self.height,
-                Size::ZERO,
-            ));
+            return layout::Node::new(limits.resolve(self.width, self.height, Size::ZERO));
         }
 
         let base = self.children[self.base_layer].as_widget_mut().layout(
@@ -189,21 +175,19 @@ where
         let limits = layout::Limits::new(Size::ZERO, size);
 
         let (under, above) = self.children.split_at_mut(self.base_layer);
-        let (tree_under, tree_above) =
-            tree.children.split_at_mut(self.base_layer);
+        let (tree_under, tree_above) = tree.children.split_at_mut(self.base_layer);
 
         let nodes = under
             .iter_mut()
             .zip(tree_under)
-            .map(|(layer, tree)| {
-                layer.as_widget_mut().layout(tree, renderer, &limits)
-            })
+            .map(|(layer, tree)| layer.as_widget_mut().layout(tree, renderer, &limits))
             .chain(std::iter::once(base))
-            .chain(above[1..].iter_mut().zip(&mut tree_above[1..]).map(
-                |(layer, tree)| {
-                    layer.as_widget_mut().layout(tree, renderer, &limits)
-                },
-            ))
+            .chain(
+                above[1..]
+                    .iter_mut()
+                    .zip(&mut tree_above[1..])
+                    .map(|(layer, tree)| layer.as_widget_mut().layout(tree, renderer, &limits)),
+            )
             .collect();
 
         layout::Node::with_children(size, nodes)
@@ -257,8 +241,7 @@ where
             .enumerate()
         {
             child.as_widget_mut().update(
-                tree, event, layout, cursor, renderer, clipboard, shell,
-                viewport,
+                tree, event, layout, cursor, renderer, clipboard, shell, viewport,
             );
 
             if shell.is_event_captured() {
@@ -266,9 +249,9 @@ where
             }
 
             if i < end && is_over && !cursor.is_levitating() {
-                let interaction = child.as_widget().mouse_interaction(
-                    tree, layout, cursor, viewport, renderer,
-                );
+                let interaction = child
+                    .as_widget()
+                    .mouse_interaction(tree, layout, cursor, viewport, renderer);
 
                 if interaction != mouse::Interaction::None {
                     cursor = cursor.levitate();
@@ -323,9 +306,9 @@ where
                     .zip(tree.children.iter().rev())
                     .zip(layout.children().rev())
                     .position(|((layer, tree), layout)| {
-                        let interaction = layer.as_widget().mouse_interaction(
-                            tree, layout, cursor, viewport, renderer,
-                        );
+                        let interaction = layer
+                            .as_widget()
+                            .mouse_interaction(tree, layout, cursor, viewport, renderer);
 
                         interaction != mouse::Interaction::None
                     })
@@ -345,23 +328,17 @@ where
             let layers = layers.by_ref();
 
             let mut draw_layer =
-                |i,
-                 layer: &Element<'a, Message, Theme, Renderer>,
-                 tree,
-                 layout,
-                 cursor| {
+                |i, layer: &Element<'a, Message, Theme, Renderer>, tree, layout, cursor| {
                     if i > 0 {
                         renderer.with_layer(*viewport, |renderer| {
-                            layer.as_widget().draw(
-                                tree, renderer, theme, style, layout, cursor,
-                                viewport,
-                            );
+                            layer
+                                .as_widget()
+                                .draw(tree, renderer, theme, style, layout, cursor, viewport);
                         });
                     } else {
-                        layer.as_widget().draw(
-                            tree, renderer, theme, style, layout, cursor,
-                            viewport,
-                        );
+                        layer
+                            .as_widget()
+                            .draw(tree, renderer, theme, style, layout, cursor, viewport);
                     }
                 };
 

--- a/widget/src/svg.rs
+++ b/widget/src/svg.rs
@@ -25,8 +25,8 @@ use crate::core::svg;
 use crate::core::widget::Tree;
 use crate::core::window;
 use crate::core::{
-    Clipboard, Color, ContentFit, Element, Event, Layout, Length, Point,
-    Rectangle, Rotation, Shell, Size, Theme, Vector, Widget,
+    Clipboard, Color, ContentFit, Element, Event, Layout, Length, Point, Rectangle, Rotation,
+    Shell, Size, Theme, Vector, Widget,
 };
 
 #[cfg(feature = "a11y")]
@@ -187,10 +187,7 @@ where
 
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Svg`].
-    pub fn description_widget<T: iced_accessibility::Describes>(
-        mut self,
-        description: &T,
-    ) -> Self {
+    pub fn description_widget<T: iced_accessibility::Describes>(mut self, description: &T) -> Self {
         self.description = Some(iced_accessibility::Description::Id(
             description.description(),
         ));
@@ -200,22 +197,19 @@ where
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Svg`].
     pub fn description(mut self, description: impl Into<Cow<'a, str>>) -> Self {
-        self.description =
-            Some(iced_accessibility::Description::Text(description.into()));
+        self.description = Some(iced_accessibility::Description::Text(description.into()));
         self
     }
 
     #[cfg(feature = "a11y")]
     /// Sets the label of the [`Svg`].
     pub fn label(mut self, label: &dyn iced_accessibility::Labels) -> Self {
-        self.label =
-            Some(label.label().into_iter().map(|l| l.into()).collect());
+        self.label = Some(label.label().into_iter().map(|l| l.into()).collect());
         self
     }
 }
 
-impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer>
-    for Svg<'_, Theme>
+impl<Message, Theme, Renderer> Widget<Message, Theme, Renderer> for Svg<'_, Theme>
 where
     Renderer: svg::Renderer,
     Theme: Catalog,
@@ -348,9 +342,7 @@ where
             );
         };
 
-        if adjusted_fit.width > bounds.width
-            || adjusted_fit.height > bounds.height
-        {
+        if adjusted_fit.width > bounds.width || adjusted_fit.height > bounds.height {
             renderer.with_layer(bounds, render);
         } else {
             render(renderer);
@@ -376,12 +368,7 @@ where
             width,
             height,
         } = bounds;
-        let bounds = Rect::new(
-            x as f64,
-            y as f64,
-            (x + width) as f64,
-            (y + height) as f64,
-        );
+        let bounds = Rect::new(x as f64, y as f64, (x + width) as f64, (y + height) as f64);
         let mut node = Node::new(Role::Image);
         node.set_bounds(bounds);
         if let Some(name) = self.name.as_ref() {
@@ -418,8 +405,7 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer> From<Svg<'a, Theme>>
-    for Element<'a, Message, Theme, Renderer>
+impl<'a, Message, Theme, Renderer> From<Svg<'a, Theme>> for Element<'a, Message, Theme, Renderer>
 where
     Theme: Catalog + 'a,
     Renderer: svg::Renderer + 'a,

--- a/widget/src/table.rs
+++ b/widget/src/table.rs
@@ -7,8 +7,7 @@ use crate::core::overlay;
 use crate::core::renderer;
 use crate::core::widget;
 use crate::core::{
-    Alignment, Background, Element, Layout, Length, Pixels, Rectangle, Size,
-    Widget,
+    Alignment, Background, Element, Layout, Length, Pixels, Rectangle, Size, Widget,
 };
 
 /// Creates a new [`Table`] with the given columns and rows.
@@ -80,9 +79,7 @@ where
     /// Columns can be created using the [`column()`] function, while rows can be any
     /// iterator over some data type `T`.
     pub fn new<'b, T>(
-        columns: impl IntoIterator<
-            Item = Column<'a, 'b, T, Message, Theme, Renderer>,
-        >,
+        columns: impl IntoIterator<Item = Column<'a, 'b, T, Message, Theme, Renderer>>,
         rows: impl IntoIterator<Item = T>,
     ) -> Self
     where
@@ -94,9 +91,7 @@ where
         let mut width = Length::Shrink;
         let mut height = Length::Shrink;
 
-        let mut cells = Vec::with_capacity(
-            columns.size_hint().0 * (1 + rows.size_hint().0),
-        );
+        let mut cells = Vec::with_capacity(columns.size_hint().0 * (1 + rows.size_hint().0));
 
         let (mut columns, views): (Vec<_>, Vec<_>) = columns
             .map(|column| {
@@ -263,9 +258,7 @@ where
         let mut x = self.padding_x;
         let mut y = self.padding_y;
 
-        for (i, (cell, state)) in
-            self.cells.iter_mut().zip(&mut tree.children).enumerate()
-        {
+        for (i, (cell, state)) in self.cells.iter_mut().zip(&mut tree.children).enumerate() {
             let row = i / columns;
             let column = i % columns;
 
@@ -291,8 +284,7 @@ where
             let height_factor = size.height.fill_factor();
 
             if width_factor != 0 || height_factor != 0 || size.width.is_fill() {
-                column_factors[column] =
-                    column_factors[column].max(width_factor);
+                column_factors[column] = column_factors[column].max(width_factor);
 
                 row_factor = row_factor.max(height_factor);
 
@@ -334,17 +326,14 @@ where
             - self.padding_x * 2.0)
             / column_factors.iter().sum::<u16>() as f32;
 
-        let height_unit = (left.height
-            - spacing_y * rows.saturating_sub(1) as f32
-            - self.padding_y * 2.0)
-            / total_row_factors as f32;
+        let height_unit =
+            (left.height - spacing_y * rows.saturating_sub(1) as f32 - self.padding_y * 2.0)
+                / total_row_factors as f32;
 
         let mut x = self.padding_x;
         let mut y = self.padding_y;
 
-        for (i, (cell, state)) in
-            self.cells.iter_mut().zip(&mut tree.children).enumerate()
-        {
+        for (i, (cell, state)) in self.cells.iter_mut().zip(&mut tree.children).enumerate() {
             let row = i / columns;
             let column = i % columns;
 
@@ -362,9 +351,7 @@ where
                 }
             }
 
-            if width_factor == 0
-                && size.width.fill_factor() == 0
-                && size.height.fill_factor() == 0
+            if width_factor == 0 && size.width.fill_factor() == 0 && size.height.fill_factor() == 0
             {
                 continue;
             }
@@ -389,11 +376,8 @@ where
                 height_unit * height_factor as f32
             };
 
-            let limits = layout::Limits::new(
-                Size::ZERO,
-                Size::new(max_width, max_height),
-            )
-            .width(width);
+            let limits =
+                layout::Limits::new(Size::ZERO, Size::new(max_width, max_height)).width(width);
 
             let layout = cell.as_widget_mut().layout(state, renderer, &limits);
             let size = limits.resolve(
@@ -479,8 +463,7 @@ where
             .zip(layout.children())
         {
             cell.as_widget_mut().update(
-                tree, event, layout, cursor, renderer, clipboard, shell,
-                viewport,
+                tree, event, layout, cursor, renderer, clipboard, shell, viewport,
             );
         }
     }
@@ -495,8 +478,7 @@ where
         cursor: mouse::Cursor,
         viewport: &Rectangle,
     ) {
-        for ((cell, state), layout) in
-            self.cells.iter().zip(&tree.children).zip(layout.children())
+        for ((cell, state), layout) in self.cells.iter().zip(&tree.children).zip(layout.children())
         {
             cell.as_widget()
                 .draw(state, renderer, theme, style, layout, cursor, viewport);
@@ -509,9 +491,7 @@ where
         if self.separator_x > 0.0 {
             let mut x = self.padding_x;
 
-            for width in
-                &metrics.columns[..metrics.columns.len().saturating_sub(1)]
-            {
+            for width in &metrics.columns[..metrics.columns.len().saturating_sub(1)] {
                 x += width + self.padding_x;
 
                 renderer.fill_quad(
@@ -535,8 +515,7 @@ where
         if self.separator_y > 0.0 {
             let mut y = self.padding_y;
 
-            for height in &metrics.rows[..metrics.rows.len().saturating_sub(1)]
-            {
+            for height in &metrics.rows[..metrics.rows.len().saturating_sub(1)] {
                 y += height + self.padding_y;
 
                 renderer.fill_quad(
@@ -628,14 +607,7 @@ where
 }
 
 /// A vertical visualization of some data with a header.
-pub struct Column<
-    'a,
-    'b,
-    T,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> {
+pub struct Column<'a, 'b, T, Message, Theme = crate::Theme, Renderer = crate::Renderer> {
     header: Element<'a, Message, Theme, Renderer>,
     view: Box<dyn Fn(T) -> Element<'a, Message, Theme, Renderer> + 'b>,
     width: Length,
@@ -643,9 +615,7 @@ pub struct Column<
     align_y: alignment::Vertical,
 }
 
-impl<'a, 'b, T, Message, Theme, Renderer>
-    Column<'a, 'b, T, Message, Theme, Renderer>
-{
+impl<'a, 'b, T, Message, Theme, Renderer> Column<'a, 'b, T, Message, Theme, Renderer> {
     /// Sets the width of the [`Column`].
     pub fn width(mut self, width: impl Into<Length>) -> Self {
         self.width = width.into();
@@ -653,19 +623,13 @@ impl<'a, 'b, T, Message, Theme, Renderer>
     }
 
     /// Sets the alignment for the horizontal axis of the [`Column`].
-    pub fn align_x(
-        mut self,
-        alignment: impl Into<alignment::Horizontal>,
-    ) -> Self {
+    pub fn align_x(mut self, alignment: impl Into<alignment::Horizontal>) -> Self {
         self.align_x = alignment.into();
         self
     }
 
     /// Sets the alignment for the vertical axis of the [`Column`].
-    pub fn align_y(
-        mut self,
-        alignment: impl Into<alignment::Vertical>,
-    ) -> Self {
+    pub fn align_y(mut self, alignment: impl Into<alignment::Vertical>) -> Self {
         self.align_y = alignment.into();
         self
     }

--- a/widget/src/text/rich.rs
+++ b/widget/src/text/rich.rs
@@ -4,23 +4,17 @@ use crate::core::mouse;
 use crate::core::renderer;
 use crate::core::text::{Paragraph, Span};
 use crate::core::widget::text::{
-    self, Alignment, Catalog, Ellipsize, LineHeight, Shaping, Style, StyleFn,
-    Wrapping,
+    self, Alignment, Catalog, Ellipsize, LineHeight, Shaping, Style, StyleFn, Wrapping,
 };
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
-    self, Clipboard, Color, Element, Event, Layout, Length, Pixels, Point,
-    Rectangle, Shell, Size, Vector, Widget,
+    self, Clipboard, Color, Element, Event, Layout, Length, Pixels, Point, Rectangle, Shell, Size,
+    Vector, Widget,
 };
 
 /// A bunch of [`Rich`] text.
-pub struct Rich<
-    'a,
-    Link,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct Rich<'a, Link, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Link: Clone + 'static,
     Theme: Catalog,
     Renderer: core::text::Renderer,
@@ -40,8 +34,7 @@ pub struct Rich<
     on_link_click: Option<Box<dyn Fn(Link) -> Message + 'a>>,
 }
 
-impl<'a, Link, Message, Theme, Renderer>
-    Rich<'a, Link, Message, Theme, Renderer>
+impl<'a, Link, Message, Theme, Renderer> Rich<'a, Link, Message, Theme, Renderer>
 where
     Link: Clone + 'static,
     Theme: Catalog,
@@ -68,9 +61,7 @@ where
     }
 
     /// Creates a new [`Rich`] text with the given text spans.
-    pub fn with_spans(
-        spans: impl AsRef<[Span<'a, Link, Renderer::Font>]> + 'a,
-    ) -> Self {
+    pub fn with_spans(spans: impl AsRef<[Span<'a, Link, Renderer::Font>]> + 'a) -> Self {
         Self {
             spans: Box::new(spans),
             ..Self::new()
@@ -120,10 +111,7 @@ where
     }
 
     /// Sets the [`alignment::Vertical`] of the [`Rich`] text.
-    pub fn align_y(
-        mut self,
-        alignment: impl Into<alignment::Vertical>,
-    ) -> Self {
+    pub fn align_y(mut self, alignment: impl Into<alignment::Vertical>) -> Self {
         self.align_y = alignment.into();
         self
     }
@@ -140,10 +128,7 @@ where
     /// If the spans of the [`Rich`] text contain no links, you may need to call
     /// this method with `on_link_click(never)` in order for the compiler to infer
     /// the proper `Link` generic type.
-    pub fn on_link_click(
-        mut self,
-        on_link_click: impl Fn(Link) -> Message + 'a,
-    ) -> Self {
+    pub fn on_link_click(mut self, on_link_click: impl Fn(Link) -> Message + 'a) -> Self {
         self.on_link_click = Some(Box::new(on_link_click));
         self
     }
@@ -191,8 +176,7 @@ where
     }
 }
 
-impl<'a, Link, Message, Theme, Renderer> Default
-    for Rich<'a, Link, Message, Theme, Renderer>
+impl<'a, Link, Message, Theme, Renderer> Default for Rich<'a, Link, Message, Theme, Renderer>
 where
     Link: Clone + 'a,
     Theme: Catalog,
@@ -281,27 +265,17 @@ where
         let style = theme.style(&self.class);
 
         for (index, span) in self.spans.as_ref().as_ref().iter().enumerate() {
-            let is_hovered_link = self.on_link_click.is_some()
-                && Some(index) == self.hovered_link;
+            let is_hovered_link = self.on_link_click.is_some() && Some(index) == self.hovered_link;
 
-            if span.highlight.is_some()
-                || span.underline
-                || span.strikethrough
-                || is_hovered_link
-            {
+            if span.highlight.is_some() || span.underline || span.strikethrough || is_hovered_link {
                 let translation = layout.position() - Point::ORIGIN;
                 let regions = state.paragraph.span_bounds(index);
 
                 if let Some(highlight) = span.highlight {
                     for bounds in &regions {
                         let bounds = Rectangle::new(
-                            bounds.position()
-                                - Vector::new(
-                                    span.padding.left,
-                                    span.padding.top,
-                                ),
-                            bounds.size()
-                                + Size::new(span.padding.x(), span.padding.y()),
+                            bounds.position() - Vector::new(span.padding.left, span.padding.top),
+                            bounds.size() + Size::new(span.padding.x(), span.padding.y()),
                         );
 
                         renderer.fill_quad(
@@ -316,26 +290,17 @@ where
                 }
 
                 if span.underline || span.strikethrough || is_hovered_link {
-                    let size = span
-                        .size
-                        .or(self.size)
-                        .unwrap_or(renderer.default_size());
+                    let size = span.size.or(self.size).unwrap_or(renderer.default_size());
 
                     let line_height = span
                         .line_height
                         .unwrap_or(self.line_height)
                         .to_absolute(size);
 
-                    let color = span
-                        .color
-                        .or(style.color)
-                        .unwrap_or(defaults.text_color);
+                    let color = span.color.or(style.color).unwrap_or(defaults.text_color);
 
-                    let baseline = translation
-                        + Vector::new(
-                            0.0,
-                            size.0 + (line_height.0 - size.0) / 2.0,
-                        );
+                    let baseline =
+                        translation + Vector::new(0.0, size.0 + (line_height.0 - size.0) / 2.0);
 
                     if span.underline || is_hovered_link {
                         for bounds in &regions {
@@ -404,14 +369,13 @@ where
                 .state
                 .downcast_ref::<State<Link, Renderer::Paragraph>>();
 
-            self.hovered_link =
-                state.paragraph.hit_span(position).and_then(|span| {
-                    if self.spans.as_ref().as_ref().get(span)?.link.is_some() {
-                        Some(span)
-                    } else {
-                        None
-                    }
-                });
+            self.hovered_link = state.paragraph.hit_span(position).and_then(|span| {
+                if self.spans.as_ref().as_ref().get(span)?.link.is_some() {
+                    Some(span)
+                } else {
+                    None
+                }
+            });
         } else {
             self.hovered_link = None;
         }
@@ -512,8 +476,7 @@ where
         };
 
         if state.spans != spans {
-            state.paragraph =
-                Renderer::Paragraph::with_spans(text_with_spans());
+            state.paragraph = Renderer::Paragraph::with_spans(text_with_spans());
             state.spans = spans.iter().cloned().map(Span::to_static).collect();
         } else {
             match state.paragraph.compare(core::Text {
@@ -533,8 +496,7 @@ where
                     state.paragraph.resize(bounds);
                 }
                 core::text::Difference::Shape => {
-                    state.paragraph =
-                        Renderer::Paragraph::with_spans(text_with_spans());
+                    state.paragraph = Renderer::Paragraph::with_spans(text_with_spans());
                 }
             }
         }
@@ -543,8 +505,7 @@ where
     })
 }
 
-impl<'a, Link, Message, Theme, Renderer>
-    FromIterator<Span<'a, Link, Renderer::Font>>
+impl<'a, Link, Message, Theme, Renderer> FromIterator<Span<'a, Link, Renderer::Font>>
     for Rich<'a, Link, Message, Theme, Renderer>
 where
     Link: Clone + 'a,
@@ -552,15 +513,12 @@ where
     Renderer: core::text::Renderer,
     Renderer::Font: 'a,
 {
-    fn from_iter<T: IntoIterator<Item = Span<'a, Link, Renderer::Font>>>(
-        spans: T,
-    ) -> Self {
+    fn from_iter<T: IntoIterator<Item = Span<'a, Link, Renderer::Font>>>(spans: T) -> Self {
         Self::with_spans(spans.into_iter().collect::<Vec<_>>())
     }
 }
 
-impl<'a, Link, Message, Theme, Renderer>
-    From<Rich<'a, Link, Message, Theme, Renderer>>
+impl<'a, Link, Message, Theme, Renderer> From<Rich<'a, Link, Message, Theme, Renderer>>
     for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,

--- a/widget/src/text_editor.rs
+++ b/widget/src/text_editor.rs
@@ -48,8 +48,8 @@ use crate::core::widget::operation;
 use crate::core::widget::{self, Widget};
 use crate::core::window;
 use crate::core::{
-    Background, Border, Color, Element, Event, InputMethod, Length, Padding,
-    Pixels, Point, Rectangle, Shell, Size, SmolStr, Theme, Vector,
+    Background, Border, Color, Element, Event, InputMethod, Length, Padding, Pixels, Point,
+    Rectangle, Shell, Size, SmolStr, Theme, Vector,
 };
 
 use std::borrow::Cow;
@@ -59,9 +59,7 @@ use std::ops;
 use std::ops::DerefMut;
 use std::sync::Arc;
 
-pub use text::editor::{
-    Action, Cursor, Edit, Line, LineEnding, Motion, Position, Selection,
-};
+pub use text::editor::{Action, Cursor, Edit, Line, LineEnding, Motion, Position, Selection};
 
 /// The identifier of a [`TextEditor`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -106,13 +104,8 @@ impl From<widget::Id> for Id {
 ///     }
 /// }
 /// ```
-pub struct TextEditor<
-    'a,
-    Highlighter,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct TextEditor<'a, Highlighter, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Highlighter: text::Highlighter,
     Theme: Catalog,
     Renderer: text::Renderer,
@@ -134,15 +127,11 @@ pub struct TextEditor<
     key_binding: Option<Box<dyn Fn(KeyPress) -> Option<Binding<Message>> + 'a>>,
     on_edit: Option<Box<dyn Fn(Action) -> Message + 'a>>,
     highlighter_settings: Highlighter::Settings,
-    highlighter_format: fn(
-        &Highlighter::Highlight,
-        &Theme,
-    ) -> highlighter::Format<Renderer::Font>,
+    highlighter_format: fn(&Highlighter::Highlight, &Theme) -> highlighter::Format<Renderer::Font>,
     last_status: Option<Status>,
 }
 
-impl<'a, Message, Theme, Renderer>
-    TextEditor<'a, highlighter::PlainText, Message, Theme, Renderer>
+impl<'a, Message, Theme, Renderer> TextEditor<'a, highlighter::PlainText, Message, Theme, Renderer>
 where
     Theme: Catalog,
     Renderer: text::Renderer,
@@ -167,9 +156,7 @@ where
             key_binding: None,
             on_edit: None,
             highlighter_settings: (),
-            highlighter_format: |_highlight, _theme| {
-                highlighter::Format::default()
-            },
+            highlighter_format: |_highlight, _theme| highlighter::Format::default(),
             last_status: None,
         }
     }
@@ -189,10 +176,7 @@ where
     Renderer: text::Renderer,
 {
     /// Sets the placeholder of the [`TextEditor`].
-    pub fn placeholder(
-        mut self,
-        placeholder: impl text::IntoFragment<'a>,
-    ) -> Self {
+    pub fn placeholder(mut self, placeholder: impl text::IntoFragment<'a>) -> Self {
         self.placeholder = Some(placeholder.into_fragment());
         self
     }
@@ -225,10 +209,7 @@ where
     /// the [`TextEditor`].
     ///
     /// If this method is not called, the [`TextEditor`] will be disabled.
-    pub fn on_action(
-        mut self,
-        on_edit: impl Fn(Action) -> Message + 'a,
-    ) -> Self {
+    pub fn on_action(mut self, on_edit: impl Fn(Action) -> Message + 'a) -> Self {
         self.on_edit = Some(Box::new(on_edit));
         self
     }
@@ -248,10 +229,7 @@ where
     }
 
     /// Sets the [`text::LineHeight`] of the [`TextEditor`].
-    pub fn line_height(
-        mut self,
-        line_height: impl Into<text::LineHeight>,
-    ) -> Self {
+    pub fn line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
         self.line_height = line_height.into();
         self
     }
@@ -292,10 +270,7 @@ where
     pub fn highlight_with<H: text::Highlighter>(
         self,
         settings: H::Settings,
-        to_format: fn(
-            &H::Highlight,
-            &Theme,
-        ) -> highlighter::Format<Renderer::Font>,
+        to_format: fn(&H::Highlight, &Theme) -> highlighter::Format<Renderer::Font>,
     ) -> TextEditor<'a, H, Message, Theme, Renderer> {
         TextEditor {
             id: self.id,
@@ -371,22 +346,17 @@ where
 
         let cursor = match internal.editor.selection() {
             Selection::Caret(position) => position,
-            Selection::Range(ranges) => {
-                ranges.first().cloned().unwrap_or_default().position()
-            }
+            Selection::Range(ranges) => ranges.first().cloned().unwrap_or_default().position(),
         };
 
-        let line_height = self.line_height.to_absolute(
-            self.text_size.unwrap_or_else(|| renderer.default_size()),
-        );
+        let line_height = self
+            .line_height
+            .to_absolute(self.text_size.unwrap_or_else(|| renderer.default_size()));
 
         let position = cursor + translation;
 
         InputMethod::Enabled {
-            cursor: Rectangle::new(
-                position,
-                Size::new(1.0, f32::from(line_height)),
-            ),
+            cursor: Rectangle::new(position, Size::new(1.0, f32::from(line_height))),
             purpose: input_method::Purpose::Normal,
             preedit: state.preedit.as_ref().map(input_method::Preedit::as_ref),
         }
@@ -568,8 +538,7 @@ impl Focus {
 
     fn is_cursor_visible(&self) -> bool {
         self.is_window_focused
-            && ((self.now - self.updated_at).as_millis()
-                / Self::CURSOR_BLINK_INTERVAL_MILLIS)
+            && ((self.now - self.updated_at).as_millis() / Self::CURSOR_BLINK_INTERVAL_MILLIS)
                 .is_multiple_of(2)
     }
 }
@@ -581,9 +550,7 @@ impl<Highlighter: text::Highlighter> State<Highlighter> {
     }
 }
 
-impl<Highlighter: text::Highlighter> operation::Focusable
-    for State<Highlighter>
-{
+impl<Highlighter: text::Highlighter> operation::Focusable for State<Highlighter> {
     fn is_focused(&self) -> bool {
         self.focus.is_some()
     }
@@ -616,9 +583,7 @@ where
             drag_click: None,
             partial_scroll: 0.0,
             last_theme: RefCell::default(),
-            highlighter: RefCell::new(Highlighter::new(
-                &self.highlighter_settings,
-            )),
+            highlighter: RefCell::new(Highlighter::new(&self.highlighter_settings)),
             highlighter_settings: self.highlighter_settings.clone(),
             highlighter_format_address: self.highlighter_format as usize,
         })
@@ -640,8 +605,7 @@ where
         let mut internal = self.content.0.borrow_mut();
         let state = tree.state.downcast_mut::<State<Highlighter>>();
 
-        if state.highlighter_format_address != self.highlighter_format as usize
-        {
+        if state.highlighter_format_address != self.highlighter_format as usize {
             state.highlighter.borrow_mut().change_line(0);
 
             state.highlighter_format_address = self.highlighter_format as usize;
@@ -704,10 +668,7 @@ where
         };
 
         let state = tree.state.downcast_mut::<State<Highlighter>>();
-        let is_redraw = matches!(
-            event,
-            Event::Window(window::Event::RedrawRequested(_now)),
-        );
+        let is_redraw = matches!(event, Event::Window(window::Event::RedrawRequested(_now)),);
 
         match event {
             Event::Window(window::Event::Unfocused) => {
@@ -729,14 +690,12 @@ where
                 {
                     focus.now = *now;
 
-                    let millis_until_redraw =
-                        Focus::CURSOR_BLINK_INTERVAL_MILLIS
-                            - (focus.now - focus.updated_at).as_millis()
-                                % Focus::CURSOR_BLINK_INTERVAL_MILLIS;
+                    let millis_until_redraw = Focus::CURSOR_BLINK_INTERVAL_MILLIS
+                        - (focus.now - focus.updated_at).as_millis()
+                            % Focus::CURSOR_BLINK_INTERVAL_MILLIS;
 
                     shell.request_redraw_at(
-                        focus.now
-                            + Duration::from_millis(millis_until_redraw as u64),
+                        focus.now + Duration::from_millis(millis_until_redraw as u64),
                     );
                 }
             }
@@ -754,9 +713,7 @@ where
             match update {
                 Update::Click(click) => {
                     let action = match click.kind() {
-                        mouse::click::Kind::Single => {
-                            Action::Click(click.position())
-                        }
+                        mouse::click::Kind::Single => Action::Click(click.position()),
                         mouse::click::Kind::Double => Action::SelectWord,
                         mouse::click::Kind::Triple => Action::SelectLine,
                     };
@@ -791,8 +748,7 @@ where
                 }
                 Update::InputMethod(update) => match update {
                     Ime::Toggle(is_open) => {
-                        state.preedit =
-                            is_open.then(input_method::Preedit::new);
+                        state.preedit = is_open.then(input_method::Preedit::new);
 
                         shell.request_redraw();
                     }
@@ -806,17 +762,11 @@ where
                         shell.request_redraw();
                     }
                     Ime::Commit(text) => {
-                        shell.publish(on_edit(Action::Edit(Edit::Paste(
-                            Arc::new(text),
-                        ))));
+                        shell.publish(on_edit(Action::Edit(Edit::Paste(Arc::new(text)))));
                     }
                 },
                 Update::Binding(binding) => {
-                    fn apply_binding<
-                        H: text::Highlighter,
-                        R: text::Renderer,
-                        Message,
-                    >(
+                    fn apply_binding<H: text::Highlighter, R: text::Renderer, Message>(
                         binding: Binding<Message>,
                         content: &Content<R>,
                         state: &mut State<H>,
@@ -824,8 +774,7 @@ where
                         clipboard: &mut dyn Clipboard,
                         shell: &mut Shell<'_, Message>,
                     ) {
-                        let mut publish =
-                            |action| shell.publish(on_edit(action));
+                        let mut publish = |action| shell.publish(on_edit(action));
 
                         match binding {
                             Binding::Unfocus => {
@@ -834,29 +783,19 @@ where
                             }
                             Binding::Copy => {
                                 if let Some(selection) = content.selection() {
-                                    clipboard.write(
-                                        clipboard::Kind::Standard,
-                                        selection,
-                                    );
+                                    clipboard.write(clipboard::Kind::Standard, selection);
                                 }
                             }
                             Binding::Cut => {
                                 if let Some(selection) = content.selection() {
-                                    clipboard.write(
-                                        clipboard::Kind::Standard,
-                                        selection,
-                                    );
+                                    clipboard.write(clipboard::Kind::Standard, selection);
 
                                     publish(Action::Edit(Edit::Delete));
                                 }
                             }
                             Binding::Paste => {
-                                if let Some(contents) =
-                                    clipboard.read(clipboard::Kind::Standard)
-                                {
-                                    publish(Action::Edit(Edit::Paste(
-                                        Arc::new(contents),
-                                    )));
+                                if let Some(contents) = clipboard.read(clipboard::Kind::Standard) {
+                                    publish(Action::Edit(Edit::Paste(Arc::new(contents))));
                                 }
                             }
                             Binding::Move(motion) => {
@@ -889,8 +828,7 @@ where
                             Binding::Sequence(sequence) => {
                                 for binding in sequence {
                                     apply_binding(
-                                        binding, content, state, on_edit,
-                                        clipboard, shell,
+                                        binding, content, state, on_edit, clipboard, shell,
                                     );
                                 }
                             }
@@ -904,14 +842,7 @@ where
                         shell.capture_event();
                     }
 
-                    apply_binding(
-                        binding,
-                        self.content,
-                        state,
-                        on_edit,
-                        clipboard,
-                        shell,
-                    );
+                    apply_binding(binding, self.content, state, on_edit, clipboard, shell);
 
                     if let Some(focus) = &mut state.focus {
                         focus.updated_at = Instant::now();
@@ -938,9 +869,7 @@ where
         if is_redraw {
             self.last_status = Some(status);
 
-            shell.request_input_method(
-                &self.input_method(state, renderer, layout),
-            );
+            shell.request_input_method(&self.input_method(state, renderer, layout));
         } else if self
             .last_status
             .is_some_and(|last_status| status != last_status)
@@ -975,8 +904,7 @@ where
             .is_none_or(|last_theme| last_theme != theme_name)
         {
             state.highlighter.borrow_mut().change_line(0);
-            let _ =
-                state.last_theme.borrow_mut().replace(theme_name.to_owned());
+            let _ = state.last_theme.borrow_mut().replace(theme_name.to_owned());
         }
 
         internal.editor.highlight(
@@ -985,8 +913,7 @@ where
             |highlight| (self.highlighter_format)(highlight, theme),
         );
 
-        let style = theme
-            .style(&self.class, self.last_status.unwrap_or(Status::Active));
+        let style = theme.style(&self.class, self.last_status.unwrap_or(Status::Active));
 
         renderer.fill_quad(
             renderer::Quad {
@@ -1005,9 +932,7 @@ where
                     Text {
                         content: placeholder.into_owned(),
                         bounds: text_bounds.size(),
-                        size: self
-                            .text_size
-                            .unwrap_or_else(|| renderer.default_size()),
+                        size: self.text_size.unwrap_or_else(|| renderer.default_size()),
                         line_height: self.line_height,
                         font,
                         align_x: text::Alignment::Default,
@@ -1035,22 +960,19 @@ where
         if let Some(focus) = state.focus.as_ref() {
             match internal.editor.selection() {
                 Selection::Caret(position) if focus.is_cursor_visible() => {
-                    let cursor =
-                        Rectangle::new(
-                            position + translation,
-                            Size::new(
-                                1.0,
-                                self.line_height
-                                    .to_absolute(self.text_size.unwrap_or_else(
-                                        || renderer.default_size(),
-                                    ))
-                                    .into(),
-                            ),
-                        );
+                    let cursor = Rectangle::new(
+                        position + translation,
+                        Size::new(
+                            1.0,
+                            self.line_height
+                                .to_absolute(
+                                    self.text_size.unwrap_or_else(|| renderer.default_size()),
+                                )
+                                .into(),
+                        ),
+                    );
 
-                    if let Some(clipped_cursor) =
-                        text_bounds.intersection(&cursor)
-                    {
+                    if let Some(clipped_cursor) = text_bounds.intersection(&cursor) {
                         renderer.fill_quad(
                             renderer::Quad {
                                 bounds: clipped_cursor,
@@ -1061,9 +983,10 @@ where
                     }
                 }
                 Selection::Range(ranges) => {
-                    for range in ranges.into_iter().filter_map(|range| {
-                        text_bounds.intersection(&(range + translation))
-                    }) {
+                    for range in ranges
+                        .into_iter()
+                        .filter_map(|range| text_bounds.intersection(&(range + translation)))
+                    {
                         renderer.fill_quad(
                             renderer::Quad {
                                 bounds: range,
@@ -1128,9 +1051,7 @@ where
     Theme: Catalog + 'a,
     Renderer: text::Renderer,
 {
-    fn from(
-        text_editor: TextEditor<'a, Highlighter, Message, Theme, Renderer>,
-    ) -> Self {
+    fn from(text_editor: TextEditor<'a, Highlighter, Message, Theme, Renderer>) -> Self {
         Self::new(text_editor)
     }
 }
@@ -1212,9 +1133,7 @@ impl<Message> Binding<Message> {
         let combination = match key.to_latin(physical_key) {
             Some('c') if modifiers.command() => Some(Self::Copy),
             Some('x') if modifiers.command() => Some(Self::Cut),
-            Some('v') if modifiers.command() && !modifiers.alt() => {
-                Some(Self::Paste)
-            }
+            Some('v') if modifiers.command() && !modifiers.alt() => Some(Self::Paste),
             Some('a') if modifiers.command() => Some(Self::SelectAll),
             _ => None,
         };
@@ -1224,14 +1143,11 @@ impl<Message> Binding<Message> {
         }
 
         #[cfg(target_os = "macos")]
-        let modified_key =
-            convert_macos_shortcut(&key, modifiers).unwrap_or(modified_key);
+        let modified_key = convert_macos_shortcut(&key, modifiers).unwrap_or(modified_key);
 
         match modified_key.as_ref() {
             keyboard::Key::Named(key::Named::Enter) => Some(Self::Enter),
-            keyboard::Key::Named(key::Named::Backspace) => {
-                Some(Self::Backspace)
-            }
+            keyboard::Key::Named(key::Named::Backspace) => Some(Self::Backspace),
             keyboard::Key::Named(key::Named::Delete)
                 if text.is_none() || text.as_deref() == Some("\u{7f}") =>
             {
@@ -1308,8 +1224,8 @@ impl<Message> Update<Message> {
             Event::Mouse(event) => match event {
                 mouse::Event::ButtonPressed(mouse::Button::Left) => {
                     if let Some(cursor_position) = cursor.position_in(bounds) {
-                        let cursor_position = cursor_position
-                            - Vector::new(padding.left, padding.top);
+                        let cursor_position =
+                            cursor_position - Vector::new(padding.left, padding.top);
 
                         let click = mouse::Click::new(
                             cursor_position,
@@ -1324,21 +1240,17 @@ impl<Message> Update<Message> {
                         None
                     }
                 }
-                mouse::Event::ButtonReleased(mouse::Button::Left) => {
-                    Some(Update::Release)
-                }
+                mouse::Event::ButtonReleased(mouse::Button::Left) => Some(Update::Release),
                 mouse::Event::CursorMoved { .. } => match state.drag_click {
                     Some(mouse::click::Kind::Single) => {
-                        let cursor_position = cursor.position_in(bounds)?
-                            - Vector::new(padding.left, padding.top);
+                        let cursor_position =
+                            cursor.position_in(bounds)? - Vector::new(padding.left, padding.top);
 
                         Some(Update::Drag(cursor_position))
                     }
                     _ => None,
                 },
-                mouse::Event::WheelScrolled { delta }
-                    if cursor.is_over(bounds) =>
-                {
+                mouse::Event::WheelScrolled { delta } if cursor.is_over(bounds) => {
                     Some(Update::Scroll(match delta {
                         mouse::ScrollDelta::Lines { y, .. } => {
                             if y.abs() > 0.0 {
@@ -1353,23 +1265,16 @@ impl<Message> Update<Message> {
                 _ => None,
             },
             Event::InputMethod(event) => match event {
-                input_method::Event::Opened | input_method::Event::Closed => {
-                    Some(Update::InputMethod(Ime::Toggle(matches!(
-                        event,
-                        input_method::Event::Opened
-                    ))))
-                }
-                input_method::Event::Preedit(content, selection)
-                    if state.focus.is_some() =>
-                {
+                input_method::Event::Opened | input_method::Event::Closed => Some(
+                    Update::InputMethod(Ime::Toggle(matches!(event, input_method::Event::Opened))),
+                ),
+                input_method::Event::Preedit(content, selection) if state.focus.is_some() => {
                     Some(Update::InputMethod(Ime::Preedit {
                         content: content.clone(),
                         selection: selection.clone(),
                     }))
                 }
-                input_method::Event::Commit(content)
-                    if state.focus.is_some() =>
-                {
+                input_method::Event::Commit(content) if state.focus.is_some() => {
                     Some(Update::InputMethod(Ime::Commit(content.clone())))
                 }
                 _ => None,

--- a/widget/src/text_input.rs
+++ b/widget/src/text_input.rs
@@ -57,9 +57,8 @@ use crate::core::widget::operation::{self, Operation};
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    Alignment, Background, Border, Color, Element, Event, InputMethod, Layout,
-    Length, Padding, Pixels, Point, Rectangle, Shell, Size, Theme, Vector,
-    Widget,
+    Alignment, Background, Border, Color, Element, Event, InputMethod, Layout, Length, Padding,
+    Pixels, Point, Rectangle, Shell, Size, Theme, Vector, Widget,
 };
 
 /// A field that can be filled with text.
@@ -94,12 +93,8 @@ use crate::core::{
 ///     }
 /// }
 /// ```
-pub struct TextInput<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct TextInput<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Theme: Catalog,
     Renderer: text::Renderer,
 {
@@ -169,10 +164,7 @@ where
     /// the [`TextInput`].
     ///
     /// If this method is not called, the [`TextInput`] will be disabled.
-    pub fn on_input(
-        mut self,
-        on_input: impl Fn(String) -> Message + 'a,
-    ) -> Self {
+    pub fn on_input(mut self, on_input: impl Fn(String) -> Message + 'a) -> Self {
         self.on_input = Some(Box::new(on_input));
         self
     }
@@ -181,10 +173,7 @@ where
     /// the [`TextInput`], if `Some`.
     ///
     /// If `None`, the [`TextInput`] will be disabled.
-    pub fn on_input_maybe(
-        mut self,
-        on_input: Option<impl Fn(String) -> Message + 'a>,
-    ) -> Self {
+    pub fn on_input_maybe(mut self, on_input: Option<impl Fn(String) -> Message + 'a>) -> Self {
         self.on_input = on_input.map(|f| Box::new(f) as _);
         self
     }
@@ -205,20 +194,14 @@ where
 
     /// Sets the message that should be produced when some text is pasted into
     /// the [`TextInput`].
-    pub fn on_paste(
-        mut self,
-        on_paste: impl Fn(String) -> Message + 'a,
-    ) -> Self {
+    pub fn on_paste(mut self, on_paste: impl Fn(String) -> Message + 'a) -> Self {
         self.on_paste = Some(Box::new(on_paste));
         self
     }
 
     /// Sets the message that should be produced when some text is pasted into
     /// the [`TextInput`], if `Some`.
-    pub fn on_paste_maybe(
-        mut self,
-        on_paste: Option<impl Fn(String) -> Message + 'a>,
-    ) -> Self {
+    pub fn on_paste_maybe(mut self, on_paste: Option<impl Fn(String) -> Message + 'a>) -> Self {
         self.on_paste = on_paste.map(|f| Box::new(f) as _);
         self
     }
@@ -256,19 +239,13 @@ where
     }
 
     /// Sets the [`text::LineHeight`] of the [`TextInput`].
-    pub fn line_height(
-        mut self,
-        line_height: impl Into<text::LineHeight>,
-    ) -> Self {
+    pub fn line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
         self.line_height = line_height.into();
         self
     }
 
     /// Sets the horizontal alignment of the [`TextInput`].
-    pub fn align_x(
-        mut self,
-        alignment: impl Into<alignment::Horizontal>,
-    ) -> Self {
+    pub fn align_x(mut self, alignment: impl Into<alignment::Horizontal>) -> Self {
         self.alignment = Some(alignment.into());
         self
     }
@@ -356,37 +333,26 @@ where
 
             let (text_position, icon_position) = match icon.side {
                 Side::Left => (
-                    Point::new(
-                        padding.left + icon_width + icon.spacing,
-                        padding.top,
-                    ),
+                    Point::new(padding.left + icon_width + icon.spacing, padding.top),
                     Point::new(padding.left, padding.top),
                 ),
                 Side::Right => (
                     Point::new(padding.left, padding.top),
-                    Point::new(
-                        padding.left + text_bounds.width - icon_width,
-                        padding.top,
-                    ),
+                    Point::new(padding.left + text_bounds.width - icon_width, padding.top),
                 ),
             };
 
-            let text_node = layout::Node::new(
-                text_bounds - Size::new(icon_width + icon.spacing, 0.0),
-            )
-            .move_to(text_position);
+            let text_node =
+                layout::Node::new(text_bounds - Size::new(icon_width + icon.spacing, 0.0))
+                    .move_to(text_position);
 
             let icon_node =
-                layout::Node::new(Size::new(icon_width, text_bounds.height))
-                    .move_to(icon_position);
+                layout::Node::new(Size::new(icon_width, text_bounds.height)).move_to(icon_position);
 
-            layout::Node::with_children(
-                text_bounds.expand(padding),
-                vec![text_node, icon_node],
-            )
+            layout::Node::with_children(text_bounds.expand(padding), vec![text_node, icon_node])
         } else {
-            let text = layout::Node::new(text_bounds)
-                .move_to(Point::new(padding.left, padding.top));
+            let text =
+                layout::Node::new(text_bounds).move_to(Point::new(padding.left, padding.top));
 
             layout::Node::with_children(text_bounds.expand(padding), vec![text])
         }
@@ -428,14 +394,10 @@ where
             state.scroll_offset,
         );
 
-        let alignment_offset = alignment_offset(
-            text_bounds.width,
-            text.min_width(),
-            effective_alignment,
-        );
+        let alignment_offset =
+            alignment_offset(text_bounds.width, text.min_width(), effective_alignment);
 
-        let x = (text_bounds.x + cursor_x).floor() - state.scroll_offset
-            + alignment_offset;
+        let x = (text_bounds.x + cursor_x).floor() - state.scroll_offset + alignment_offset;
 
         InputMethod::Enabled {
             cursor: Rectangle::new(
@@ -477,8 +439,7 @@ where
         let mut children_layout = layout.children();
         let text_bounds = children_layout.next().unwrap().bounds();
 
-        let style = theme
-            .style(&self.class, self.last_status.unwrap_or(Status::Disabled));
+        let style = theme.style(&self.class, self.last_status.unwrap_or(Status::Disabled));
 
         renderer.fill_quad(
             renderer::Quad {
@@ -515,15 +476,14 @@ where
         {
             match state.cursor.state(value) {
                 cursor::State::Index(position) => {
-                    let (text_value_width, _) =
-                        measure_cursor_and_scroll_offset(
-                            state.value.raw(),
-                            text_bounds,
-                            position,
-                            value,
-                            state.cursor.affinity(),
-                            state.scroll_offset,
-                        );
+                    let (text_value_width, _) = measure_cursor_and_scroll_offset(
+                        state.value.raw(),
+                        text_bounds,
+                        position,
+                        value,
+                        state.cursor.affinity(),
+                        state.scroll_offset,
+                    );
 
                     let is_cursor_visible = !is_disabled
                         && ((focus.now - focus.updated_at).as_millis()
@@ -534,8 +494,7 @@ where
                         vec![(
                             renderer::Quad {
                                 bounds: Rectangle {
-                                    x: (text_bounds.x + text_value_width)
-                                        .floor(),
+                                    x: (text_bounds.x + text_value_width).floor(),
                                     y: text_bounds.y,
                                     width: 1.0,
                                     height: text_bounds.height,
@@ -588,8 +547,7 @@ where
             let unfocused_offset = {
                 match effective_alignment(self.alignment, state.value.raw()) {
                     alignment::Horizontal::Right => {
-                        (state.value.raw().min_width() - text_bounds.width)
-                            .max(0.0)
+                        (state.value.raw().min_width() - text_bounds.width).max(0.0)
                     }
                     _ => 0.0,
                 }
@@ -631,11 +589,8 @@ where
 
             renderer.fill_paragraph(
                 paragraph,
-                text_bounds.anchor(
-                    paragraph.min_bounds(),
-                    Alignment::Start,
-                    Alignment::Center,
-                ) + Vector::new(alignment_offset - offset, 0.0),
+                text_bounds.anchor(paragraph.min_bounds(), Alignment::Start, Alignment::Center)
+                    + Vector::new(alignment_offset - offset, 0.0),
                 if text.is_empty() {
                     style.placeholder
                 } else {
@@ -758,20 +713,14 @@ where
                         let alignment_offset = alignment_offset(
                             text_bounds.width,
                             state.value.raw().min_width(),
-                            effective_alignment(
-                                self.alignment,
-                                state.value.raw(),
-                            ),
+                            effective_alignment(self.alignment, state.value.raw()),
                         );
 
                         cursor_position.x - text_bounds.x - alignment_offset
                     };
 
-                    let click = mouse::Click::new(
-                        cursor_position,
-                        mouse::Button::Left,
-                        state.last_click,
-                    );
+                    let click =
+                        mouse::Click::new(cursor_position, mouse::Button::Left, state.last_click);
 
                     match click.kind() {
                         click::Kind::Single => {
@@ -781,21 +730,16 @@ where
                                 self.value.clone()
                             };
 
-                            let (position, affinity) = find_cursor_position(
-                                text_layout.bounds(),
-                                &value,
-                                state,
-                                target,
-                            )
-                            .unwrap_or((0, text::Affinity::Before));
+                            let (position, affinity) =
+                                find_cursor_position(text_layout.bounds(), &value, state, target)
+                                    .unwrap_or((0, text::Affinity::Before));
 
                             state.cursor.set_affinity(affinity);
 
                             if state.keyboard_modifiers.shift() {
-                                state.cursor.select_range(
-                                    state.cursor.start(&self.value),
-                                    position,
-                                );
+                                state
+                                    .cursor
+                                    .select_range(state.cursor.start(&self.value), position);
                             } else {
                                 state.cursor.move_to(position);
                             }
@@ -808,14 +752,13 @@ where
 
                                 state.is_dragging = None;
                             } else {
-                                let (position, affinity) =
-                                    find_cursor_position(
-                                        text_layout.bounds(),
-                                        &self.value,
-                                        state,
-                                        target,
-                                    )
-                                    .unwrap_or((0, text::Affinity::Before));
+                                let (position, affinity) = find_cursor_position(
+                                    text_layout.bounds(),
+                                    &self.value,
+                                    state,
+                                    target,
+                                )
+                                .unwrap_or((0, text::Affinity::Before));
 
                                 state.cursor.set_affinity(affinity);
 
@@ -824,9 +767,7 @@ where
                                     self.value.next_end_of_word(position),
                                 );
 
-                                state.is_dragging = Some(Drag::SelectWords {
-                                    anchor: position,
-                                });
+                                state.is_dragging = Some(Drag::SelectWords { anchor: position });
                             }
                         }
                         click::Kind::Triple => {
@@ -862,10 +803,7 @@ where
                         let alignment_offset = alignment_offset(
                             text_bounds.width,
                             state.value.raw().min_width(),
-                            effective_alignment(
-                                self.alignment,
-                                state.value.raw(),
-                            ),
+                            effective_alignment(self.alignment, state.value.raw()),
                         );
 
                         position.x - text_bounds.x - alignment_offset
@@ -877,13 +815,9 @@ where
                         self.value.clone()
                     };
 
-                    let (position, affinity) = find_cursor_position(
-                        text_layout.bounds(),
-                        &value,
-                        state,
-                        target,
-                    )
-                    .unwrap_or((0, text::Affinity::Before));
+                    let (position, affinity) =
+                        find_cursor_position(text_layout.bounds(), &value, state, target)
+                            .unwrap_or((0, text::Affinity::Before));
 
                     state.cursor.set_affinity(affinity);
 
@@ -891,10 +825,9 @@ where
 
                     match is_dragging {
                         Drag::Select => {
-                            state.cursor.select_range(
-                                state.cursor.start(&value),
-                                position,
-                            );
+                            state
+                                .cursor
+                                .select_range(state.cursor.start(&value), position);
                         }
                         Drag::SelectWords { anchor } => {
                             if position < *anchor {
@@ -935,13 +868,8 @@ where
                     let modifiers = state.keyboard_modifiers;
 
                     match key.to_latin(*physical_key) {
-                        Some('c')
-                            if state.keyboard_modifiers.command()
-                                && !self.is_secure =>
-                        {
-                            if let Some((start, end)) =
-                                state.cursor.selection(&self.value)
-                            {
+                        Some('c') if state.keyboard_modifiers.command() && !self.is_secure => {
+                            if let Some((start, end)) = state.cursor.selection(&self.value) {
                                 clipboard.write(
                                     clipboard::Kind::Standard,
                                     self.value.select(start, end).to_string(),
@@ -951,25 +879,19 @@ where
                             shell.capture_event();
                             return;
                         }
-                        Some('x')
-                            if state.keyboard_modifiers.command()
-                                && !self.is_secure =>
-                        {
+                        Some('x') if state.keyboard_modifiers.command() && !self.is_secure => {
                             let Some(on_input) = &self.on_input else {
                                 return;
                             };
 
-                            if let Some((start, end)) =
-                                state.cursor.selection(&self.value)
-                            {
+                            if let Some((start, end)) = state.cursor.selection(&self.value) {
                                 clipboard.write(
                                     clipboard::Kind::Standard,
                                     self.value.select(start, end).to_string(),
                                 );
                             }
 
-                            let mut editor =
-                                Editor::new(&mut self.value, &mut state.cursor);
+                            let mut editor = Editor::new(&mut self.value, &mut state.cursor);
                             editor.delete();
 
                             let message = (on_input)(editor.contents());
@@ -1002,8 +924,7 @@ where
                                 }
                             };
 
-                            let mut editor =
-                                Editor::new(&mut self.value, &mut state.cursor);
+                            let mut editor = Editor::new(&mut self.value, &mut state.cursor);
                             editor.paste(content.clone());
 
                             let message = if let Some(paste) = &self.on_paste {
@@ -1043,11 +964,8 @@ where
 
                         state.is_pasting = None;
 
-                        if let Some(c) =
-                            text.chars().next().filter(|c| !c.is_control())
-                        {
-                            let mut editor =
-                                Editor::new(&mut self.value, &mut state.cursor);
+                        if let Some(c) = text.chars().next().filter(|c| !c.is_control()) {
+                            let mut editor = Editor::new(&mut self.value, &mut state.cursor);
 
                             editor.insert(c);
 
@@ -1062,14 +980,10 @@ where
                     }
 
                     #[cfg(target_os = "macos")]
-                    let macos_shortcut =
-                        crate::text_editor::convert_macos_shortcut(
-                            key, modifiers,
-                        );
+                    let macos_shortcut = crate::text_editor::convert_macos_shortcut(key, modifiers);
 
                     #[cfg(target_os = "macos")]
-                    let modified_key =
-                        macos_shortcut.as_ref().unwrap_or(modified_key);
+                    let modified_key = macos_shortcut.as_ref().unwrap_or(modified_key);
 
                     match modified_key.as_ref() {
                         keyboard::Key::Named(key::Named::Enter) => {
@@ -1084,22 +998,17 @@ where
                             };
 
                             if state.cursor.selection(&self.value).is_none() {
-                                if (self.is_secure && modifiers.jump())
-                                    || modifiers.macos_command()
+                                if (self.is_secure && modifiers.jump()) || modifiers.macos_command()
                                 {
-                                    state.cursor.select_range(
-                                        state.cursor.start(&self.value),
-                                        0,
-                                    );
-                                } else if modifiers.jump() {
                                     state
                                         .cursor
-                                        .select_left_by_words(&self.value);
+                                        .select_range(state.cursor.start(&self.value), 0);
+                                } else if modifiers.jump() {
+                                    state.cursor.select_left_by_words(&self.value);
                                 }
                             }
 
-                            let mut editor =
-                                Editor::new(&mut self.value, &mut state.cursor);
+                            let mut editor = Editor::new(&mut self.value, &mut state.cursor);
                             editor.backspace();
 
                             let message = (on_input)(editor.contents());
@@ -1115,22 +1024,18 @@ where
                             };
 
                             if state.cursor.selection(&self.value).is_none() {
-                                if (self.is_secure && modifiers.jump())
-                                    || modifiers.macos_command()
+                                if (self.is_secure && modifiers.jump()) || modifiers.macos_command()
                                 {
                                     state.cursor.select_range(
                                         state.cursor.start(&self.value),
                                         self.value.len(),
                                     );
                                 } else if modifiers.jump() {
-                                    state
-                                        .cursor
-                                        .select_right_by_words(&self.value);
+                                    state.cursor.select_right_by_words(&self.value);
                                 }
                             }
 
-                            let mut editor =
-                                Editor::new(&mut self.value, &mut state.cursor);
+                            let mut editor = Editor::new(&mut self.value, &mut state.cursor);
                             editor.delete();
 
                             let message = (on_input)(editor.contents());
@@ -1144,10 +1049,9 @@ where
                             let cursor_before = state.cursor;
 
                             if modifiers.shift() {
-                                state.cursor.select_range(
-                                    state.cursor.start(&self.value),
-                                    0,
-                                );
+                                state
+                                    .cursor
+                                    .select_range(state.cursor.start(&self.value), 0);
                             } else {
                                 state.cursor.move_to(0);
                             }
@@ -1182,36 +1086,24 @@ where
                         }
                         keyboard::Key::Named(key::Named::ArrowLeft) => {
                             let cursor_before = state.cursor;
-                            let rtl =
-                                state.value.raw().is_rtl(0).unwrap_or(false);
+                            let rtl = state.value.raw().is_rtl(0).unwrap_or(false);
 
-                            if (self.is_secure && modifiers.jump())
-                                || modifiers.macos_command()
-                            {
+                            if (self.is_secure && modifiers.jump()) || modifiers.macos_command() {
                                 if modifiers.shift() {
-                                    state.cursor.select_range(
-                                        state.cursor.start(&self.value),
-                                        0,
-                                    );
+                                    state
+                                        .cursor
+                                        .select_range(state.cursor.start(&self.value), 0);
                                 } else {
                                     state.cursor.move_to(0);
                                 }
                             } else {
                                 let by_words = modifiers.jump();
                                 if modifiers.shift() {
-                                    state.cursor.select_visual(
-                                        false,
-                                        by_words,
-                                        rtl,
-                                        &self.value,
-                                    );
+                                    state
+                                        .cursor
+                                        .select_visual(false, by_words, rtl, &self.value);
                                 } else {
-                                    state.cursor.move_visual(
-                                        false,
-                                        by_words,
-                                        rtl,
-                                        &self.value,
-                                    );
+                                    state.cursor.move_visual(false, by_words, rtl, &self.value);
                                 }
                             }
 
@@ -1225,12 +1117,9 @@ where
                         }
                         keyboard::Key::Named(key::Named::ArrowRight) => {
                             let cursor_before = state.cursor;
-                            let rtl =
-                                state.value.raw().is_rtl(0).unwrap_or(false);
+                            let rtl = state.value.raw().is_rtl(0).unwrap_or(false);
 
-                            if (self.is_secure && modifiers.jump())
-                                || modifiers.macos_command()
-                            {
+                            if (self.is_secure && modifiers.jump()) || modifiers.macos_command() {
                                 if modifiers.shift() {
                                     state.cursor.select_range(
                                         state.cursor.start(&self.value),
@@ -1242,19 +1131,9 @@ where
                             } else {
                                 let by_words = modifiers.jump();
                                 if modifiers.shift() {
-                                    state.cursor.select_visual(
-                                        true,
-                                        by_words,
-                                        rtl,
-                                        &self.value,
-                                    );
+                                    state.cursor.select_visual(true, by_words, rtl, &self.value);
                                 } else {
-                                    state.cursor.move_visual(
-                                        true,
-                                        by_words,
-                                        rtl,
-                                        &self.value,
-                                    );
+                                    state.cursor.move_visual(true, by_words, rtl, &self.value);
                                 }
                             }
 
@@ -1271,8 +1150,7 @@ where
                             state.is_dragging = None;
                             state.is_pasting = None;
 
-                            state.keyboard_modifiers =
-                                keyboard::Modifiers::default();
+                            state.keyboard_modifiers = keyboard::Modifiers::default();
 
                             shell.capture_event();
                         }
@@ -1302,9 +1180,8 @@ where
                 input_method::Event::Opened | input_method::Event::Closed => {
                     let state = state::<Renderer>(tree);
 
-                    state.preedit =
-                        matches!(event, input_method::Event::Opened)
-                            .then(input_method::Preedit::new);
+                    state.preedit = matches!(event, input_method::Event::Opened)
+                        .then(input_method::Preedit::new);
 
                     shell.request_redraw();
                 }
@@ -1329,8 +1206,7 @@ where
                             return;
                         };
 
-                        let mut editor =
-                            Editor::new(&mut self.value, &mut state.cursor);
+                        let mut editor = Editor::new(&mut self.value, &mut state.cursor);
                         editor.paste(Value::new(text));
 
                         focus.updated_at = Instant::now();
@@ -1367,28 +1243,18 @@ where
                 if let Some(focus) = &mut state.is_focused
                     && focus.is_window_focused
                 {
-                    if matches!(
-                        state.cursor.state(&self.value),
-                        cursor::State::Index(_)
-                    ) {
+                    if matches!(state.cursor.state(&self.value), cursor::State::Index(_)) {
                         focus.now = *now;
 
                         let millis_until_redraw = CURSOR_BLINK_INTERVAL_MILLIS
-                            - (*now - focus.updated_at).as_millis()
-                                % CURSOR_BLINK_INTERVAL_MILLIS;
+                            - (*now - focus.updated_at).as_millis() % CURSOR_BLINK_INTERVAL_MILLIS;
 
                         shell.request_redraw_at(
-                            *now + Duration::from_millis(
-                                millis_until_redraw as u64,
-                            ),
+                            *now + Duration::from_millis(millis_until_redraw as u64),
                         );
                     }
 
-                    shell.request_input_method(&self.input_method(
-                        state,
-                        layout,
-                        &self.value,
-                    ));
+                    shell.request_input_method(&self.input_method(state, layout, &self.value));
                 }
             }
             _ => {}
@@ -1401,12 +1267,7 @@ where
         // which shifts the text, which causes the next hit-test to overshoot.
         {
             let text_layout = layout.children().next().unwrap();
-            state.scroll_offset = offset(
-                text_layout.bounds(),
-                &self.value,
-                state,
-                self.alignment,
-            );
+            state.scroll_offset = offset(text_layout.bounds(), &self.value, state, self.alignment);
         }
 
         let is_disabled = self.on_input.is_none();
@@ -1520,9 +1381,7 @@ pub struct State<P: text::Paragraph> {
     scroll_offset: f32,
 }
 
-fn state<Renderer: text::Renderer>(
-    tree: &mut Tree,
-) -> &mut State<Renderer::Paragraph> {
+fn state<Renderer: text::Renderer>(tree: &mut Tree) -> &mut State<Renderer::Paragraph> {
     tree.state.downcast_mut::<State<Renderer::Paragraph>>()
 }
 
@@ -1883,9 +1742,7 @@ fn alignment_offset(
     } else {
         match alignment {
             alignment::Horizontal::Left => 0.0,
-            alignment::Horizontal::Center => {
-                (text_bounds_width - text_min_width) / 2.0
-            }
+            alignment::Horizontal::Center => (text_bounds_width - text_min_width) / 2.0,
             alignment::Horizontal::Right => text_bounds_width - text_min_width,
         }
     }

--- a/widget/src/text_input/cursor.rs
+++ b/widget/src/text_input/cursor.rs
@@ -56,9 +56,7 @@ impl Cursor {
     /// `start` is guaranteed to be <= than `end`.
     pub fn selection(&self, value: &Value) -> Option<(usize, usize)> {
         match self.state(value) {
-            State::Selection { start, end } => {
-                Some((start.min(end), start.max(end)))
-            }
+            State::Selection { start, end } => Some((start.min(end), start.max(end))),
             State::Index(_) => None,
         }
     }
@@ -75,11 +73,7 @@ impl Cursor {
         self.move_to(value.next_end_of_word(self.right(value)));
     }
 
-    pub(crate) fn move_right_by_amount(
-        &mut self,
-        value: &Value,
-        amount: usize,
-    ) {
+    pub(crate) fn move_right_by_amount(&mut self, value: &Value, amount: usize) {
         match self.state(value) {
             State::Index(index) => {
                 self.move_to(index.saturating_add(amount).min(value.len()));
@@ -205,13 +199,7 @@ impl Cursor {
     /// `forward` = `true` is visually rightward
     /// RTL text flips the logical direction so that pressing the right-arrow key
     /// still moves the caret forward visually.
-    pub fn move_visual(
-        &mut self,
-        forward: bool,
-        by_words: bool,
-        rtl: bool,
-        value: &Value,
-    ) {
+    pub fn move_visual(&mut self, forward: bool, by_words: bool, rtl: bool, value: &Value) {
         match (forward ^ rtl, by_words) {
             (true, false) => self.move_right(value),
             (true, true) => self.move_right_by_words(value),
@@ -223,13 +211,7 @@ impl Cursor {
     /// Extends the selection in a visual direction, accounting for RTL text.
     ///
     /// See [`Cursor::move_visual`] for the `forward` / `rtl` semantics.
-    pub fn select_visual(
-        &mut self,
-        forward: bool,
-        by_words: bool,
-        rtl: bool,
-        value: &Value,
-    ) {
+    pub fn select_visual(&mut self, forward: bool, by_words: bool, rtl: bool, value: &Value) {
         match (forward ^ rtl, by_words) {
             (true, false) => self.select_right(value),
             (true, true) => self.select_right_by_words(value),

--- a/widget/src/text_input/value.rs
+++ b/widget/src/text_input/value.rs
@@ -34,16 +34,14 @@ impl Value {
     /// Returns the position of the previous start of a word from the given
     /// grapheme `index`.
     pub fn previous_start_of_word(&self, index: usize) -> usize {
-        let previous_string =
-            &self.graphemes[..index.min(self.graphemes.len())].concat();
+        let previous_string = &self.graphemes[..index.min(self.graphemes.len())].concat();
 
         UnicodeSegmentation::split_word_bound_indices(previous_string as &str)
             .filter(|(_, word)| !word.trim_start().is_empty())
             .next_back()
             .map(|(i, previous_word)| {
                 index
-                    - UnicodeSegmentation::graphemes(previous_word, true)
-                        .count()
+                    - UnicodeSegmentation::graphemes(previous_word, true).count()
                     - UnicodeSegmentation::graphemes(
                         &previous_string[i + previous_word.len()..] as &str,
                         true,
@@ -63,11 +61,7 @@ impl Value {
             .map(|(i, next_word)| {
                 index
                     + UnicodeSegmentation::graphemes(next_word, true).count()
-                    + UnicodeSegmentation::graphemes(
-                        &next_string[..i] as &str,
-                        true,
-                    )
-                    .count()
+                    + UnicodeSegmentation::graphemes(&next_string[..i] as &str, true).count()
             })
             .unwrap_or(self.len())
     }
@@ -75,8 +69,7 @@ impl Value {
     /// Returns a new [`Value`] containing the graphemes from `start` until the
     /// given `end`.
     pub fn select(&self, start: usize, end: usize) -> Self {
-        let graphemes =
-            self.graphemes[start.min(self.len())..end.min(self.len())].to_vec();
+        let graphemes = self.graphemes[start.min(self.len())..end.min(self.len())].to_vec();
 
         Self { graphemes }
     }
@@ -93,10 +86,9 @@ impl Value {
     pub fn insert(&mut self, index: usize, c: char) {
         self.graphemes.insert(index, c.to_string());
 
-        self.graphemes =
-            UnicodeSegmentation::graphemes(&self.to_string() as &str, true)
-                .map(String::from)
-                .collect();
+        self.graphemes = UnicodeSegmentation::graphemes(&self.to_string() as &str, true)
+            .map(String::from)
+            .collect();
     }
 
     /// Inserts a bunch of graphemes at the given grapheme `index`.
@@ -120,11 +112,7 @@ impl Value {
     /// dot ('•') character.
     pub fn secure(&self) -> Self {
         Self {
-            graphemes: std::iter::repeat_n(
-                String::from("•"),
-                self.graphemes.len(),
-            )
-            .collect(),
+            graphemes: std::iter::repeat_n(String::from("•"), self.graphemes.len()).collect(),
         }
     }
 

--- a/widget/src/themer.rs
+++ b/widget/src/themer.rs
@@ -9,8 +9,8 @@ use crate::core::theme;
 use crate::core::widget::Operation;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
-    Background, Clipboard, Color, Element, Event, Layout, Length, Rectangle,
-    Shell, Size, Vector, Widget,
+    Background, Clipboard, Color, Element, Event, Layout, Length, Rectangle, Shell, Size, Vector,
+    Widget,
 };
 
 /// A widget that applies any `Theme` to its contents.
@@ -187,19 +187,14 @@ where
             content: overlay::Element<'a, Message, Theme, Renderer>,
         }
 
-        impl<Message, Theme, Renderer, AnyTheme>
-            overlay::Overlay<Message, AnyTheme, Renderer>
+        impl<Message, Theme, Renderer, AnyTheme> overlay::Overlay<Message, AnyTheme, Renderer>
             for Overlay<'_, Message, Theme, Renderer>
         where
             Theme: theme::Base,
             AnyTheme: theme::Base,
             Renderer: crate::core::Renderer,
         {
-            fn layout(
-                &mut self,
-                renderer: &Renderer,
-                bounds: Size,
-            ) -> layout::Node {
+            fn layout(&mut self, renderer: &Renderer, bounds: Size) -> layout::Node {
                 self.content.as_overlay_mut().layout(renderer, bounds)
             }
 
@@ -259,8 +254,7 @@ where
                 &'b mut self,
                 layout: Layout<'b>,
                 renderer: &Renderer,
-            ) -> Option<overlay::Element<'b, Message, AnyTheme, Renderer>>
-            {
+            ) -> Option<overlay::Element<'b, Message, AnyTheme, Renderer>> {
                 self.content
                     .as_overlay_mut()
                     .overlay(layout, renderer)
@@ -300,8 +294,7 @@ where
     }
 }
 
-impl<'a, Message, Theme, Renderer, AnyTheme>
-    From<Themer<'a, Message, Theme, Renderer>>
+impl<'a, Message, Theme, Renderer, AnyTheme> From<Themer<'a, Message, Theme, Renderer>>
     for Element<'a, Message, AnyTheme, Renderer>
 where
     Message: 'a,

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -45,8 +45,8 @@ use crate::core::text;
 use crate::core::touch;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::{
-    Background, Border, Clipboard, Color, Element, Event, Layout, Length,
-    Pixels, Rectangle, Shell, Size, Theme, Widget, id,
+    Background, Border, Clipboard, Color, Element, Event, Layout, Length, Pixels, Rectangle, Shell,
+    Size, Theme, Widget, id,
 };
 use crate::core::{
     widget::{self, Id},
@@ -85,12 +85,8 @@ use crate::core::{
 ///     }
 /// }
 /// ```
-pub struct Toggler<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct Toggler<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Theme: Catalog,
     Renderer: text::Renderer,
 {
@@ -171,10 +167,7 @@ where
     /// the [`Toggler`].
     ///
     /// If this method is not called, the [`Toggler`] will be disabled.
-    pub fn on_toggle(
-        mut self,
-        on_toggle: impl Fn(bool) -> Message + 'a,
-    ) -> Self {
+    pub fn on_toggle(mut self, on_toggle: impl Fn(bool) -> Message + 'a) -> Self {
         self.on_toggle = Some(Box::new(on_toggle));
         self
     }
@@ -183,10 +176,7 @@ where
     /// the [`Toggler`], if `Some`.
     ///
     /// If `None`, the [`Toggler`] will be disabled.
-    pub fn on_toggle_maybe(
-        mut self,
-        on_toggle: Option<impl Fn(bool) -> Message + 'a>,
-    ) -> Self {
+    pub fn on_toggle_maybe(mut self, on_toggle: Option<impl Fn(bool) -> Message + 'a>) -> Self {
         self.on_toggle = on_toggle.map(|on_toggle| Box::new(on_toggle) as _);
         self
     }
@@ -210,19 +200,13 @@ where
     }
 
     /// Sets the text [`text::LineHeight`] of the [`Toggler`].
-    pub fn text_line_height(
-        mut self,
-        line_height: impl Into<text::LineHeight>,
-    ) -> Self {
+    pub fn text_line_height(mut self, line_height: impl Into<text::LineHeight>) -> Self {
         self.text_line_height = line_height.into();
         self
     }
 
     /// Sets the horizontal alignment of the text of the [`Toggler`]
-    pub fn text_alignment(
-        mut self,
-        alignment: impl Into<text::Alignment>,
-    ) -> Self {
+    pub fn text_alignment(mut self, alignment: impl Into<text::Alignment>) -> Self {
         self.text_alignment = alignment.into();
         self
     }
@@ -286,10 +270,7 @@ where
 
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Toggler`].
-    pub fn description_widget<T: iced_accessibility::Describes>(
-        mut self,
-        description: &T,
-    ) -> Self {
+    pub fn description_widget<T: iced_accessibility::Describes>(mut self, description: &T) -> Self {
         self.description = Some(iced_accessibility::Description::Id(
             description.description(),
         ));
@@ -299,19 +280,14 @@ where
     #[cfg(feature = "a11y")]
     /// Sets the description of the [`Toggler`].
     pub fn description(mut self, description: impl Into<Cow<'a, str>>) -> Self {
-        self.description =
-            Some(iced_accessibility::Description::Text(description.into()));
+        self.description = Some(iced_accessibility::Description::Text(description.into()));
         self
     }
 
     #[cfg(feature = "a11y")]
     /// Sets the label of the [`Toggler`] using another widget.
-    pub fn labeled_by_widget(
-        mut self,
-        label: &dyn iced_accessibility::Labels,
-    ) -> Self {
-        self.labeled_by_widget =
-            Some(label.label().into_iter().map(|l| l.into()).collect());
+    pub fn labeled_by_widget(mut self, label: &dyn iced_accessibility::Labels) -> Self {
+        self.labeled_by_widget = Some(label.label().into_iter().map(|l| l.into()).collect());
         self
     }
 }
@@ -473,8 +449,7 @@ where
 
         if self.label.is_some() {
             let label_layout = children.next().unwrap();
-            let state: &widget::text::State<Renderer::Paragraph> =
-                tree.state.downcast_ref();
+            let state: &widget::text::State<Renderer::Paragraph> = tree.state.downcast_ref();
 
             crate::text::draw(
                 renderer,
@@ -578,12 +553,7 @@ where
             height,
         } = bounds;
 
-        let bounds = Rect::new(
-            x as f64,
-            y as f64,
-            (x + width) as f64,
-            (y + height) as f64,
-        );
+        let bounds = Rect::new(x as f64, y as f64, (x + width) as f64, (y + height) as f64);
 
         let mut node = Node::new(Role::Switch);
         node.add_action(Action::Focus);

--- a/widget/src/tooltip.rs
+++ b/widget/src/tooltip.rs
@@ -34,8 +34,7 @@ use crate::core::time::{Duration, Instant};
 use crate::core::widget::{self, Widget};
 use crate::core::window;
 use crate::core::{
-    Clipboard, Element, Event, Length, Padding, Pixels, Point, Rectangle,
-    Shell, Size, Vector,
+    Clipboard, Element, Event, Length, Padding, Pixels, Point, Rectangle, Shell, Size, Vector,
 };
 
 /// An element to display a widget over another.
@@ -61,12 +60,8 @@ use crate::core::{
 ///     ).into()
 /// }
 /// ```
-pub struct Tooltip<
-    'a,
-    Message,
-    Theme = crate::Theme,
-    Renderer = crate::Renderer,
-> where
+pub struct Tooltip<'a, Message, Theme = crate::Theme, Renderer = crate::Renderer>
+where
     Theme: container::Catalog,
     Renderer: text::Renderer,
 {
@@ -136,10 +131,7 @@ where
 
     /// Sets the style of the [`Tooltip`].
     #[must_use]
-    pub fn style(
-        mut self,
-        style: impl Fn(&Theme) -> container::Style + 'a,
-    ) -> Self
+    pub fn style(mut self, style: impl Fn(&Theme) -> container::Style + 'a) -> Self
     where
         Theme::Class<'a>: From<container::StyleFn<'a, Theme>>,
     {
@@ -186,10 +178,7 @@ where
     }
 
     fn diff(&mut self, tree: &mut widget::Tree) {
-        tree.diff_children(&mut [
-            self.content.as_widget_mut(),
-            self.tooltip.as_widget_mut(),
-        ]);
+        tree.diff_children(&mut [self.content.as_widget_mut(), self.tooltip.as_widget_mut()]);
     }
 
     fn layout(
@@ -198,11 +187,9 @@ where
         renderer: &Renderer,
         limits: &layout::Limits,
     ) -> layout::Node {
-        self.content.as_widget_mut().layout(
-            &mut tree.children[0],
-            renderer,
-            limits,
-        )
+        self.content
+            .as_widget_mut()
+            .layout(&mut tree.children[0], renderer, limits)
     }
 
     fn update(
@@ -216,9 +203,7 @@ where
         shell: &mut Shell<'_, Message>,
         viewport: &Rectangle,
     ) {
-        if let Event::Mouse(_)
-        | Event::Window(window::Event::RedrawRequested(_)) = event
-        {
+        if let Event::Mouse(_) | Event::Window(window::Event::RedrawRequested(_)) = event {
             let state = tree.state.downcast_mut::<State>();
             let now = Instant::now();
             let cursor_position = cursor.position_over(layout.bounds());
@@ -259,10 +244,7 @@ where
                     *state = State::Idle;
                     shell.invalidate_layout();
 
-                    if !matches!(
-                        event,
-                        Event::Window(window::Event::RedrawRequested(_)),
-                    ) {
+                    if !matches!(event, Event::Window(window::Event::RedrawRequested(_)),) {
                         shell.request_redraw();
                     }
                 }
@@ -359,10 +341,8 @@ where
 
         if content.is_some() || tooltip.is_some() {
             Some(
-                overlay::Group::with_children(
-                    content.into_iter().chain(tooltip).collect(),
-                )
-                .overlay(),
+                overlay::Group::with_children(content.into_iter().chain(tooltip).collect())
+                    .overlay(),
             )
         } else {
             None
@@ -471,44 +451,29 @@ where
         );
 
         let text_bounds = tooltip_layout.bounds();
-        let x_center = self.position.x
-            + (self.content_bounds.width - text_bounds.width) / 2.0;
-        let y_center = self.position.y
-            + (self.content_bounds.height - text_bounds.height) / 2.0;
+        let x_center = self.position.x + (self.content_bounds.width - text_bounds.width) / 2.0;
+        let y_center = self.position.y + (self.content_bounds.height - text_bounds.height) / 2.0;
 
         let mut tooltip_bounds = {
             let offset = match self.positioning {
                 Position::Top => Vector::new(
                     x_center,
-                    self.position.y
-                        - text_bounds.height
-                        - self.gap
-                        - self.padding,
+                    self.position.y - text_bounds.height - self.gap - self.padding,
                 ),
                 Position::Bottom => Vector::new(
                     x_center,
-                    self.position.y
-                        + self.content_bounds.height
-                        + self.gap
-                        + self.padding,
+                    self.position.y + self.content_bounds.height + self.gap + self.padding,
                 ),
                 Position::Left => Vector::new(
-                    self.position.x
-                        - text_bounds.width
-                        - self.gap
-                        - self.padding,
+                    self.position.x - text_bounds.width - self.gap - self.padding,
                     y_center,
                 ),
                 Position::Right => Vector::new(
-                    self.position.x
-                        + self.content_bounds.width
-                        + self.gap
-                        + self.padding,
+                    self.position.x + self.content_bounds.width + self.gap + self.padding,
                     y_center,
                 ),
                 Position::FollowCursor => {
-                    let translation =
-                        self.position - self.content_bounds.position();
+                    let translation = self.position - self.content_bounds.position();
 
                     Vector::new(
                         self.cursor_position.x,
@@ -528,29 +493,20 @@ where
         if self.snap_within_viewport {
             if tooltip_bounds.x < viewport.x {
                 tooltip_bounds.x = viewport.x;
-            } else if viewport.x + viewport.width
-                < tooltip_bounds.x + tooltip_bounds.width
-            {
-                tooltip_bounds.x =
-                    viewport.x + viewport.width - tooltip_bounds.width;
+            } else if viewport.x + viewport.width < tooltip_bounds.x + tooltip_bounds.width {
+                tooltip_bounds.x = viewport.x + viewport.width - tooltip_bounds.width;
             }
 
             if tooltip_bounds.y < viewport.y {
                 tooltip_bounds.y = viewport.y;
-            } else if viewport.y + viewport.height
-                < tooltip_bounds.y + tooltip_bounds.height
-            {
-                tooltip_bounds.y =
-                    viewport.y + viewport.height - tooltip_bounds.height;
+            } else if viewport.y + viewport.height < tooltip_bounds.y + tooltip_bounds.height {
+                tooltip_bounds.y = viewport.y + viewport.height - tooltip_bounds.height;
             }
         }
 
         layout::Node::with_children(
             tooltip_bounds.size(),
-            vec![
-                tooltip_layout
-                    .translate(Vector::new(self.padding, self.padding)),
-            ],
+            vec![tooltip_layout.translate(Vector::new(self.padding, self.padding))],
         )
         .translate(Vector::new(tooltip_bounds.x, tooltip_bounds.y))
     }

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -31,8 +31,7 @@
 use std::ops::RangeInclusive;
 
 pub use crate::slider::{
-    Catalog, Handle, HandleShape, RailBackground, Status, Style, StyleFn,
-    default,
+    Catalog, Handle, HandleShape, RailBackground, Status, Style, StyleFn, default,
 };
 
 use crate::core::border::Border;
@@ -45,8 +44,7 @@ use crate::core::touch;
 use crate::core::widget::tree::{self, Tree};
 use crate::core::window;
 use crate::core::{
-    self, Clipboard, Element, Event, Length, Pixels, Point, Rectangle, Shell,
-    Size, Widget,
+    self, Clipboard, Element, Event, Length, Pixels, Point, Rectangle, Shell, Size, Widget,
 };
 
 /// An vertical bar and a handle that selects a single value from a range of
@@ -279,9 +277,8 @@ where
                 let start = (*self.range.start()).into();
                 let end = (*self.range.end()).into();
 
-                let percent = 1.0
-                    - f64::from(cursor_position.y - bounds.y)
-                        / f64::from(bounds.height);
+                let percent =
+                    1.0 - f64::from(cursor_position.y - bounds.y) / f64::from(bounds.height);
 
                 let steps = (percent * (end - start) / step).round();
                 let value = steps * step + start;
@@ -337,12 +334,8 @@ where
         match event {
             Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left))
             | Event::Touch(touch::Event::FingerPressed { .. }) => {
-                if let Some(cursor_position) =
-                    cursor.position_over(layout.bounds())
-                {
-                    if state.keyboard_modifiers.control()
-                        || state.keyboard_modifiers.command()
-                    {
+                if let Some(cursor_position) = cursor.position_over(layout.bounds()) {
+                    if state.keyboard_modifiers.control() || state.keyboard_modifiers.command() {
                         let _ = self.default.map(change);
                         state.is_dragging = false;
                     } else {
@@ -366,8 +359,7 @@ where
             Event::Mouse(mouse::Event::CursorMoved { .. })
             | Event::Touch(touch::Event::FingerMoved { .. }) => {
                 if is_dragging {
-                    let _ =
-                        cursor.land().position().and_then(locate).map(change);
+                    let _ = cursor.land().position().and_then(locate).map(change);
 
                     shell.capture_event();
                 }
@@ -438,20 +430,16 @@ where
     ) {
         let bounds = layout.bounds();
 
-        let style =
-            theme.style(&self.class, self.status.unwrap_or(Status::Active));
+        let style = theme.style(&self.class, self.status.unwrap_or(Status::Active));
 
-        let (handle_width, handle_height, handle_border_radius) =
-            match style.handle.shape {
-                HandleShape::Circle { radius } => {
-                    (radius * 2.0, radius * 2.0, radius.into())
-                }
-                HandleShape::Rectangle {
-                    width,
-                    border_radius,
-                    height,
-                } => (f32::from(width), f32::from(height), border_radius),
-            };
+        let (handle_width, handle_height, handle_border_radius) = match style.handle.shape {
+            HandleShape::Circle { radius } => (radius * 2.0, radius * 2.0, radius.into()),
+            HandleShape::Rectangle {
+                width,
+                border_radius,
+                height,
+            } => (f32::from(width), f32::from(height), border_radius),
+        };
 
         let value = self.value.into() as f32;
         let (range_start, range_end) = {
@@ -463,8 +451,7 @@ where
         let offset = if range_start >= range_end {
             0.0
         } else {
-            (bounds.height - handle_width) * (value - range_end)
-                / (range_start - range_end)
+            (bounds.height - handle_width) * (value - range_end) / (range_start - range_end)
         };
 
         let rail_x = bounds.x + bounds.width / 2.0;
@@ -546,8 +533,7 @@ where
     }
 }
 
-impl<'a, T, Message, Theme, Renderer>
-    From<VerticalSlider<'a, T, Message, Theme>>
+impl<'a, T, Message, Theme, Renderer> From<VerticalSlider<'a, T, Message, Theme>>
     for Element<'a, Message, Theme, Renderer>
 where
     T: Copy + Into<f64> + num_traits::FromPrimitive + 'a,

--- a/winit/src/a11y.rs
+++ b/winit/src/a11y.rs
@@ -13,9 +13,7 @@ pub struct WinitActivationHandler {
 }
 
 impl ActivationHandler for WinitActivationHandler {
-    fn request_initial_tree(
-        &mut self,
-    ) -> Option<iced_accessibility::accesskit::TreeUpdate> {
+    fn request_initial_tree(&mut self) -> Option<iced_accessibility::accesskit::TreeUpdate> {
         let node_id = core::id::window_node_id();
         let _ = self
             .proxy
@@ -38,10 +36,7 @@ pub struct WinitActionHandler {
 }
 
 impl iced_accessibility::accesskit::ActionHandler for WinitActionHandler {
-    fn do_action(
-        &mut self,
-        request: iced_accessibility::accesskit::ActionRequest,
-    ) {
+    fn do_action(&mut self, request: iced_accessibility::accesskit::ActionRequest) {
         let _ = self
             .proxy
             .unbounded_send(Control::Accessibility(self.id, request));
@@ -52,9 +47,7 @@ pub struct WinitDeactivationHandler {
     pub proxy: mpsc::UnboundedSender<Control>,
 }
 
-impl iced_accessibility::accesskit::DeactivationHandler
-    for WinitDeactivationHandler
-{
+impl iced_accessibility::accesskit::DeactivationHandler for WinitDeactivationHandler {
     fn deactivate_accessibility(&mut self) {
         let _ = self
             .proxy

--- a/winit/src/application/drag_resize.rs
+++ b/winit/src/application/drag_resize.rs
@@ -27,14 +27,7 @@ const DRAG_RESIZE_SUPPORTED: bool = false;
 pub fn event_func(
     window: &dyn winit::window::Window,
     border_size: f64,
-) -> Option<
-    Box<
-        dyn FnMut(
-            &dyn winit::window::Window,
-            &winit::event::WindowEvent,
-        ) -> bool,
-    >,
-> {
+) -> Option<Box<dyn FnMut(&dyn winit::window::Window, &winit::event::WindowEvent) -> bool>> {
     if DRAG_RESIZE_SUPPORTED {
         // Keep track of cursor when it is within a resizeable border.
         let mut cursor_prev_resize_direction = None;
@@ -45,10 +38,7 @@ pub fn event_func(
                   -> bool {
                 // Keep track of border resize state and set cursor icon when in range
                 match window_event {
-                    winit::event::WindowEvent::PointerMoved {
-                        position,
-                        ..
-                    } => {
+                    winit::event::WindowEvent::PointerMoved { position, .. } => {
                         if !window.is_decorated() {
                             let location = cursor_resize_direction(
                                 window.surface_size(),
@@ -56,10 +46,7 @@ pub fn event_func(
                                 border_size,
                             );
                             if location != cursor_prev_resize_direction {
-                                window.set_cursor(
-                                    resize_direction_cursor_icon(location)
-                                        .into(),
-                                );
+                                window.set_cursor(resize_direction_cursor_icon(location).into());
                                 cursor_prev_resize_direction = location;
                                 return true;
                             }
@@ -68,12 +55,8 @@ pub fn event_func(
                     winit::event::WindowEvent::PointerButton {
                         state: winit::event::ElementState::Pressed,
                         button:
-                            winit::event::ButtonSource::Mouse(
-                                winit::event::MouseButton::Left,
-                            )
-                            | winit::event::ButtonSource::Touch {
-                                finger_id: _, ..
-                            },
+                            winit::event::ButtonSource::Mouse(winit::event::MouseButton::Left)
+                            | winit::event::ButtonSource::Touch { finger_id: _, .. },
                         primary: true,
                         ..
                     } => {
@@ -94,9 +77,7 @@ pub fn event_func(
 }
 
 /// Get the cursor icon that corresponds to the resize direction.
-fn resize_direction_cursor_icon(
-    resize_direction: Option<ResizeDirection>,
-) -> CursorIcon {
+fn resize_direction_cursor_icon(resize_direction: Option<ResizeDirection>) -> CursorIcon {
     match resize_direction {
         Some(resize_direction) => match resize_direction {
             ResizeDirection::East => CursorIcon::EResize,

--- a/winit/src/clipboard.rs
+++ b/winit/src/clipboard.rs
@@ -50,8 +50,7 @@ enum State {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ControlSender {
-    pub(crate) sender:
-        iced_futures::futures::channel::mpsc::UnboundedSender<crate::Control>,
+    pub(crate) sender: iced_futures::futures::channel::mpsc::UnboundedSender<crate::Control>,
     pub(crate) proxy: winit::event_loop::EventLoopProxy,
 }
 
@@ -60,15 +59,12 @@ impl dnd::Sender<DndSurface> for ControlSender {
         &self,
         event: dnd::DndEvent<DndSurface>,
     ) -> Result<(), std::sync::mpsc::SendError<dnd::DndEvent<DndSurface>>> {
-        let res =
-            self.sender
-                .unbounded_send(Control::Dnd(event))
-                .map_err(|_err| {
-                    std::sync::mpsc::SendError(dnd::DndEvent::Offer(
-                        None,
-                        dnd::OfferEvent::Leave,
-                    ))
-                });
+        let res = self
+            .sender
+            .unbounded_send(Control::Dnd(event))
+            .map_err(|_err| {
+                std::sync::mpsc::SendError(dnd::DndEvent::Offer(None, dnd::OfferEvent::Leave))
+            });
         self.proxy.wake_up();
         res
     }
@@ -76,21 +72,17 @@ impl dnd::Sender<DndSurface> for ControlSender {
 
 impl Clipboard {
     /// Creates a new [`Clipboard`] for the given window.
-    pub(crate) fn connect(
-        window: Arc<dyn Window>,
-        sender: ControlSender,
-    ) -> Clipboard {
+    pub(crate) fn connect(window: Arc<dyn Window>, sender: ControlSender) -> Clipboard {
         #[allow(unsafe_code)]
-        let state =
-            unsafe { window_clipboard::Clipboard::connect(window.as_ref()) }
-                .ok()
-                .map(|c| State::Connected {
-                    clipboard: c,
-                    sender: sender.clone(),
-                    window,
-                    queued_events: Vec::new(),
-                })
-                .unwrap_or(State::Unavailable);
+        let state = unsafe { window_clipboard::Clipboard::connect(window.as_ref()) }
+            .ok()
+            .map(|c| State::Connected {
+                clipboard: c,
+                sender: sender.clone(),
+                window,
+                queued_events: Vec::new(),
+            })
+            .unwrap_or(State::Unavailable);
 
         #[cfg(target_os = "linux")]
         if let State::Connected { clipboard, .. } = &state {
@@ -126,9 +118,7 @@ impl Clipboard {
 
     pub(crate) fn get_queued(&mut self) -> Vec<StartDnd> {
         match &mut self.state {
-            State::Connected { queued_events, .. } => {
-                std::mem::take(queued_events)
-            }
+            State::Connected { queued_events, .. } => std::mem::take(queued_events),
             State::Unavailable => {
                 log::error!("Invalid request for queued dnd events");
                 Vec::<StartDnd>::new()
@@ -153,9 +143,7 @@ impl Clipboard {
             State::Connected { clipboard, .. } => {
                 let result = match kind {
                     Kind::Standard => clipboard.write(contents),
-                    Kind::Primary => {
-                        clipboard.write_primary(contents).unwrap_or(Ok(()))
-                    }
+                    Kind::Primary => clipboard.write_primary(contents).unwrap_or(Ok(())),
                 };
 
                 match result {
@@ -177,11 +165,7 @@ impl Clipboard {
         }
     }
 
-    pub fn read_data(
-        &self,
-        kind: Kind,
-        mimes: Vec<String>,
-    ) -> Option<(Vec<u8>, String)> {
+    pub fn read_data(&self, kind: Kind, mimes: Vec<String>) -> Option<(Vec<u8>, String)> {
         match (&self.state, kind) {
             (State::Connected { clipboard, .. }, Kind::Standard) => {
                 clipboard.read_raw(mimes).and_then(|res| res.ok())
@@ -196,9 +180,7 @@ impl Clipboard {
     pub fn write_data(
         &mut self,
         kind: Kind,
-        contents: ClipboardStoreData<
-            Box<dyn Send + Sync + 'static + mime::AsMimeTypes>,
-        >,
+        contents: ClipboardStoreData<Box<dyn Send + Sync + 'static + mime::AsMimeTypes>>,
     ) {
         match (&mut self.state, kind) {
             (State::Connected { clipboard, .. }, Kind::Standard) => {
@@ -294,9 +276,7 @@ impl Clipboard {
 
     pub fn set_action(&self, action: DndAction) {
         match &self.state {
-            State::Connected { clipboard, .. } => {
-                _ = clipboard.set_action(action)
-            }
+            State::Connected { clipboard, .. } => _ = clipboard.set_action(action),
             State::Unavailable => {}
         }
     }
@@ -316,13 +296,7 @@ impl Clipboard {
     ) {
         match &self.state {
             State::Connected { clipboard, .. } => {
-                _ = clipboard.start_dnd(
-                    internal,
-                    source_surface,
-                    icon_surface,
-                    content,
-                    actions,
-                )
+                _ = clipboard.start_dnd(internal, source_surface, icon_surface, content, actions)
             }
             State::Unavailable => {}
         }
@@ -332,9 +306,7 @@ impl Clipboard {
 impl crate::core::Clipboard for Clipboard {
     fn read(&self, kind: Kind) -> Option<String> {
         match (&self.state, kind) {
-            (State::Connected { clipboard, .. }, Kind::Standard) => {
-                clipboard.read().ok()
-            }
+            (State::Connected { clipboard, .. }, Kind::Standard) => clipboard.read().ok(),
             (State::Connected { clipboard, .. }, Kind::Primary) => {
                 clipboard.read_primary().and_then(|res| res.ok())
             }
@@ -344,9 +316,7 @@ impl crate::core::Clipboard for Clipboard {
 
     fn write(&mut self, kind: Kind, contents: String) {
         match (&mut self.state, kind) {
-            (State::Connected { clipboard, .. }, Kind::Standard) => {
-                _ = clipboard.write(contents)
-            }
+            (State::Connected { clipboard, .. }, Kind::Standard) => _ = clipboard.write(contents),
             (State::Connected { clipboard, .. }, Kind::Primary) => {
                 _ = clipboard.write_primary(contents)
             }
@@ -354,11 +324,7 @@ impl crate::core::Clipboard for Clipboard {
         }
     }
 
-    fn read_data(
-        &self,
-        kind: Kind,
-        mimes: Vec<String>,
-    ) -> Option<(Vec<u8>, String)> {
+    fn read_data(&self, kind: Kind, mimes: Vec<String>) -> Option<(Vec<u8>, String)> {
         match (&self.state, kind) {
             (State::Connected { clipboard, .. }, Kind::Standard) => {
                 clipboard.read_raw(mimes).and_then(|res| res.ok())
@@ -373,9 +339,7 @@ impl crate::core::Clipboard for Clipboard {
     fn write_data(
         &mut self,
         kind: Kind,
-        contents: ClipboardStoreData<
-            Box<dyn Send + Sync + 'static + mime::AsMimeTypes>,
-        >,
+        contents: ClipboardStoreData<Box<dyn Send + Sync + 'static + mime::AsMimeTypes>>,
     ) {
         match (&mut self.state, kind) {
             (State::Connected { clipboard, .. }, Kind::Standard) => {
@@ -472,9 +436,7 @@ impl crate::core::Clipboard for Clipboard {
 
     fn set_action(&self, action: DndAction) {
         match &self.state {
-            State::Connected { clipboard, .. } => {
-                _ = clipboard.set_action(action)
-            }
+            State::Connected { clipboard, .. } => _ = clipboard.set_action(action),
             State::Unavailable => {}
         }
     }

--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -68,26 +68,22 @@ pub fn window_attributes(
         .with_window_level(window_level(settings.level))
         .with_visible(settings.visible);
 
-    if let Some(position) =
-        position(primary_monitor.as_ref(), settings.size, settings.position)
-    {
+    if let Some(position) = position(primary_monitor.as_ref(), settings.size, settings.position) {
         attributes = attributes.with_position(position);
     }
 
     if let Some(min_size) = settings.min_size {
-        attributes =
-            attributes.with_min_surface_size(winit::dpi::LogicalSize {
-                width: min_size.width,
-                height: min_size.height,
-            });
+        attributes = attributes.with_min_surface_size(winit::dpi::LogicalSize {
+            width: min_size.width,
+            height: min_size.height,
+        });
     }
 
     if let Some(max_size) = settings.max_size {
-        attributes =
-            attributes.with_max_surface_size(winit::dpi::LogicalSize {
-                width: max_size.width,
-                height: max_size.height,
-            });
+        attributes = attributes.with_max_surface_size(winit::dpi::LogicalSize {
+            width: max_size.width,
+            height: max_size.height,
+        });
     }
 
     #[cfg(any(
@@ -112,37 +108,25 @@ pub fn window_attributes(
     #[cfg(target_os = "windows")]
     {
         use window::settings::platform;
-        use winit::platform::windows::{
-            CornerPreference, WindowAttributesWindows,
-        };
+        use winit::platform::windows::{CornerPreference, WindowAttributesWindows};
         let mut w_attributes = WindowAttributesWindows::default();
 
-        w_attributes = w_attributes
-            .with_drag_and_drop(settings.platform_specific.drag_and_drop);
+        w_attributes = w_attributes.with_drag_and_drop(settings.platform_specific.drag_and_drop);
 
-        w_attributes = w_attributes
-            .with_skip_taskbar(settings.platform_specific.skip_taskbar);
+        w_attributes = w_attributes.with_skip_taskbar(settings.platform_specific.skip_taskbar);
 
-        w_attributes = w_attributes.with_undecorated_shadow(
-            settings.platform_specific.undecorated_shadow,
-        );
+        w_attributes =
+            w_attributes.with_undecorated_shadow(settings.platform_specific.undecorated_shadow);
 
         w_attributes = w_attributes.with_corner_preference(
             match settings.platform_specific.corner_preference {
-                platform::CornerPreference::Default => {
-                    CornerPreference::Default
-                }
-                platform::CornerPreference::DoNotRound => {
-                    CornerPreference::DoNotRound
-                }
+                platform::CornerPreference::Default => CornerPreference::Default,
+                platform::CornerPreference::DoNotRound => CornerPreference::DoNotRound,
                 platform::CornerPreference::Round => CornerPreference::Round,
-                platform::CornerPreference::RoundSmall => {
-                    CornerPreference::RoundSmall
-                }
+                platform::CornerPreference::RoundSmall => CornerPreference::RoundSmall,
             },
         );
-        attributes =
-            attributes.with_platform_attributes(Box::new(w_attributes));
+        attributes = attributes.with_platform_attributes(Box::new(w_attributes));
     }
 
     #[cfg(target_os = "macos")]
@@ -152,12 +136,8 @@ pub fn window_attributes(
         attributes = attributes.with_platform_attributes(Box::new(
             WindowAttributesMacOS::default()
                 .with_title_hidden(settings.platform_specific.title_hidden)
-                .with_titlebar_transparent(
-                    settings.platform_specific.titlebar_transparent,
-                )
-                .with_fullsize_content_view(
-                    settings.platform_specific.fullsize_content_view,
-                ),
+                .with_titlebar_transparent(settings.platform_specific.titlebar_transparent)
+                .with_fullsize_content_view(settings.platform_specific.fullsize_content_view),
         ));
     }
 
@@ -169,9 +149,7 @@ pub fn window_attributes(
 
             attributes = attributes.with_platform_attributes(Box::new(
                 WindowAttributesX11::default()
-                    .with_override_redirect(
-                        settings.platform_specific.override_redirect,
-                    )
+                    .with_override_redirect(settings.platform_specific.override_redirect)
                     .with_name(
                         &settings.platform_specific.application_id,
                         &settings.platform_specific.application_id,
@@ -213,9 +191,7 @@ pub fn window_event(
                 height: logical_size.height,
             })))
         }
-        WindowEvent::CloseRequested => {
-            Some(Event::Window(window::Event::CloseRequested))
-        }
+        WindowEvent::CloseRequested => Some(Event::Window(window::Event::CloseRequested)),
         WindowEvent::PointerMoved {
             position, source, ..
         } => match source {
@@ -238,22 +214,16 @@ pub fn window_event(
             _ => None,
         },
         // TODO how to handle this for Touch? Is it different than a press? Need to double check winit impl
-        WindowEvent::PointerEntered { .. } => {
-            Some(Event::Mouse(mouse::Event::CursorEntered))
-        }
+        WindowEvent::PointerEntered { .. } => Some(Event::Mouse(mouse::Event::CursorEntered)),
         WindowEvent::PointerLeft { kind, position, .. } => match kind {
-            winit::event::PointerKind::Mouse => {
-                Some(Event::Mouse(mouse::Event::CursorLeft))
-            }
-            winit::event::PointerKind::Touch(finger_id) => {
-                Some(Event::Touch(touch_event(
-                    finger_id,
-                    TouchInternal::Left,
-                    None,
-                    position,
-                    scale_factor,
-                )))
-            }
+            winit::event::PointerKind::Mouse => Some(Event::Mouse(mouse::Event::CursorLeft)),
+            winit::event::PointerKind::Touch(finger_id) => Some(Event::Touch(touch_event(
+                finger_id,
+                TouchInternal::Left,
+                None,
+                position,
+                scale_factor,
+            ))),
             _ => None,
         },
         WindowEvent::PointerButton {
@@ -264,12 +234,8 @@ pub fn window_event(
             let button = mouse_button(button);
 
             Some(Event::Mouse(match state {
-                winit::event::ElementState::Pressed => {
-                    mouse::Event::ButtonPressed(button)
-                }
-                winit::event::ElementState::Released => {
-                    mouse::Event::ButtonReleased(button)
-                }
+                winit::event::ElementState::Pressed => mouse::Event::ButtonPressed(button),
+                winit::event::ElementState::Released => mouse::Event::ButtonReleased(button),
             }))
         }
         WindowEvent::PointerButton {
@@ -347,52 +313,39 @@ pub fn window_event(
             let modifiers = self::modifiers(modifiers);
 
             let location = match location {
-                winit::keyboard::KeyLocation::Standard => {
-                    keyboard::Location::Standard
-                }
+                winit::keyboard::KeyLocation::Standard => keyboard::Location::Standard,
                 winit::keyboard::KeyLocation::Left => keyboard::Location::Left,
-                winit::keyboard::KeyLocation::Right => {
-                    keyboard::Location::Right
-                }
-                winit::keyboard::KeyLocation::Numpad => {
-                    keyboard::Location::Numpad
-                }
+                winit::keyboard::KeyLocation::Right => keyboard::Location::Right,
+                winit::keyboard::KeyLocation::Numpad => keyboard::Location::Numpad,
             };
 
             match state {
-                winit::event::ElementState::Pressed => {
-                    keyboard::Event::KeyPressed {
-                        key,
-                        modified_key,
-                        physical_key,
-                        modifiers,
-                        location,
-                        text,
-                        repeat,
-                    }
-                }
-                winit::event::ElementState::Released => {
-                    keyboard::Event::KeyReleased {
-                        key,
-                        modified_key,
-                        physical_key,
-                        modifiers,
-                        location,
-                    }
-                }
+                winit::event::ElementState::Pressed => keyboard::Event::KeyPressed {
+                    key,
+                    modified_key,
+                    physical_key,
+                    modifiers,
+                    location,
+                    text,
+                    repeat,
+                },
+                winit::event::ElementState::Released => keyboard::Event::KeyReleased {
+                    key,
+                    modified_key,
+                    physical_key,
+                    modifiers,
+                    location,
+                },
             }
         })),
-        WindowEvent::ModifiersChanged(new_modifiers) => {
-            Some(Event::Keyboard(keyboard::Event::ModifiersChanged(
-                self::modifiers(new_modifiers.state()),
-            )))
-        }
+        WindowEvent::ModifiersChanged(new_modifiers) => Some(Event::Keyboard(
+            keyboard::Event::ModifiersChanged(self::modifiers(new_modifiers.state())),
+        )),
         WindowEvent::Ime(event) => Some(Event::InputMethod(match event {
             Ime::Enabled => input_method::Event::Opened,
-            Ime::Preedit(content, size) => input_method::Event::Preedit(
-                content,
-                size.map(|(start, end)| start..end),
-            ),
+            Ime::Preedit(content, size) => {
+                input_method::Event::Preedit(content, size.map(|(start, end)| start..end))
+            }
             Ime::Commit(content) => input_method::Event::Commit(content),
             Ime::Disabled => input_method::Event::Closed,
             Ime::DeleteSurrounding {
@@ -411,13 +364,10 @@ pub fn window_event(
         WindowEvent::DragDropped { paths, .. } => {
             Some(Event::Window(window::Event::FileDropped(paths.clone())))
         }
-        WindowEvent::DragLeft { position } => {
-            Some(Event::Window(window::Event::FilesHoveredLeft))
-        }
+        WindowEvent::DragLeft { position } => Some(Event::Window(window::Event::FilesHoveredLeft)),
 
         WindowEvent::Moved(position) => {
-            let winit::dpi::LogicalPosition { x, y } =
-                position.to_logical(f64::from(scale_factor));
+            let winit::dpi::LogicalPosition { x, y } = position.to_logical(f64::from(scale_factor));
 
             Some(Event::Window(window::Event::Moved(Point::new(x, y))))
         }
@@ -431,11 +381,13 @@ pub fn window_event(
                 Size::new(size.width, size.height)
             });
 
-            Some(Event::PlatformSpecific(iced_futures::core::event::PlatformSpecific::Wayland(
-                iced_runtime::core::event::wayland::Event::Window(
-                    iced_runtime::core::event::wayland::WindowEvent::SuggestedBounds(size)
+            Some(Event::PlatformSpecific(
+                iced_futures::core::event::PlatformSpecific::Wayland(
+                    iced_runtime::core::event::wayland::Event::Window(
+                        iced_runtime::core::event::wayland::WindowEvent::SuggestedBounds(size),
+                    ),
                 ),
-            )))
+            ))
         }
         #[cfg(all(feature = "cctk", target_os = "linux"))]
         WindowEvent::WindowStateChanged => {
@@ -443,11 +395,15 @@ pub fn window_event(
             use winit::platform::wayland::WindowExtWayland;
 
             let s = window.window_state();
-            Some(Event::PlatformSpecific(iced_futures::core::event::PlatformSpecific::Wayland(
-                iced_runtime::core::event::wayland::Event::Window(
-                    iced_runtime::core::event::wayland::WindowEvent::WindowState(s.unwrap_or(WindowState::empty()))
+            Some(Event::PlatformSpecific(
+                iced_futures::core::event::PlatformSpecific::Wayland(
+                    iced_runtime::core::event::wayland::Event::Window(
+                        iced_runtime::core::event::wayland::WindowEvent::WindowState(
+                            s.unwrap_or(WindowState::empty()),
+                        ),
+                    ),
                 ),
-            )))
+            ))
         }
         _ => None,
     }
@@ -459,9 +415,7 @@ pub fn window_event(
 pub fn window_level(level: window::Level) -> winit::window::WindowLevel {
     match level {
         window::Level::Normal => winit::window::WindowLevel::Normal,
-        window::Level::AlwaysOnBottom => {
-            winit::window::WindowLevel::AlwaysOnBottom
-        }
+        window::Level::AlwaysOnBottom => winit::window::WindowLevel::AlwaysOnBottom,
         window::Level::AlwaysOnTop => winit::window::WindowLevel::AlwaysOnTop,
     }
 }
@@ -491,17 +445,13 @@ pub fn position(
                     .map(|m| m.size().to_logical(monitor.scale_factor()))
                     .unwrap_or_default();
 
-                let position = to_position(
-                    size,
-                    Size::new(resolution.width, resolution.height),
-                );
+                let position = to_position(size, Size::new(resolution.width, resolution.height));
 
-                let centered: winit::dpi::PhysicalPosition<i32> =
-                    winit::dpi::LogicalPosition {
-                        x: position.x,
-                        y: position.y,
-                    }
-                    .to_physical(monitor.scale_factor());
+                let centered: winit::dpi::PhysicalPosition<i32> = winit::dpi::LogicalPosition {
+                    x: position.x,
+                    y: position.y,
+                }
+                .to_physical(monitor.scale_factor());
 
                 Some(winit::dpi::Position::Physical(
                     winit::dpi::PhysicalPosition {
@@ -522,12 +472,11 @@ pub fn position(
                     .map(|m| m.size().to_logical(monitor.scale_factor()))
                     .unwrap_or_default();
 
-                let centered: winit::dpi::PhysicalPosition<i32> =
-                    winit::dpi::LogicalPosition {
-                        x: (resolution.width - f64::from(size.width)) / 2.0,
-                        y: (resolution.height - f64::from(size.height)) / 2.0,
-                    }
-                    .to_physical(monitor.scale_factor());
+                let centered: winit::dpi::PhysicalPosition<i32> = winit::dpi::LogicalPosition {
+                    x: (resolution.width - f64::from(size.width)) / 2.0,
+                    y: (resolution.height - f64::from(size.height)) / 2.0,
+                }
+                .to_physical(monitor.scale_factor());
 
                 Some(winit::dpi::Position::Physical(
                     winit::dpi::PhysicalPosition {
@@ -551,9 +500,7 @@ pub fn fullscreen(
 ) -> Option<winit_core::monitor::Fullscreen> {
     match mode {
         window::Mode::Windowed | window::Mode::Hidden => None,
-        window::Mode::Fullscreen => {
-            Some(winit_core::monitor::Fullscreen::Borderless(monitor))
-        }
+        window::Mode::Fullscreen => Some(winit_core::monitor::Fullscreen::Borderless(monitor)),
     }
 }
 
@@ -605,9 +552,7 @@ pub fn mouse_interaction(
     use mouse::Interaction;
 
     Some(match interaction {
-        Interaction::None | Interaction::Idle => {
-            winit_core::cursor::CursorIcon::Default
-        }
+        Interaction::None | Interaction::Idle => winit_core::cursor::CursorIcon::Default,
         Interaction::ContextMenu => winit_core::cursor::CursorIcon::ContextMenu,
         Interaction::Help => winit_core::cursor::CursorIcon::Help,
         Interaction::Pointer => winit_core::cursor::CursorIcon::Pointer,
@@ -623,21 +568,11 @@ pub fn mouse_interaction(
         Interaction::NotAllowed => winit_core::cursor::CursorIcon::NotAllowed,
         Interaction::Grab => winit_core::cursor::CursorIcon::Grab,
         Interaction::Grabbing => winit_core::cursor::CursorIcon::Grabbing,
-        Interaction::ResizingHorizontally => {
-            winit_core::cursor::CursorIcon::EwResize
-        }
-        Interaction::ResizingVertically => {
-            winit_core::cursor::CursorIcon::NsResize
-        }
-        Interaction::ResizingDiagonallyUp => {
-            winit_core::cursor::CursorIcon::NeswResize
-        }
-        Interaction::ResizingDiagonallyDown => {
-            winit_core::cursor::CursorIcon::NwseResize
-        }
-        Interaction::ResizingColumn => {
-            winit_core::cursor::CursorIcon::ColResize
-        }
+        Interaction::ResizingHorizontally => winit_core::cursor::CursorIcon::EwResize,
+        Interaction::ResizingVertically => winit_core::cursor::CursorIcon::NsResize,
+        Interaction::ResizingDiagonallyUp => winit_core::cursor::CursorIcon::NeswResize,
+        Interaction::ResizingDiagonallyDown => winit_core::cursor::CursorIcon::NwseResize,
+        Interaction::ResizingColumn => winit_core::cursor::CursorIcon::ColResize,
         Interaction::ResizingRow => winit_core::cursor::CursorIcon::RowResize,
         Interaction::AllScroll => winit_core::cursor::CursorIcon::AllScroll,
         Interaction::ZoomIn => winit_core::cursor::CursorIcon::ZoomIn,
@@ -672,9 +607,7 @@ pub fn mouse_button(mouse_button: winit::event::MouseButton) -> mouse::Button {
 ///
 /// [`winit`]: https://github.com/rust-windowing/winit
 /// [`iced`]: https://github.com/iced-rs/iced/tree/0.12
-pub fn modifiers(
-    modifiers: winit::keyboard::ModifiersState,
-) -> keyboard::Modifiers {
+pub fn modifiers(modifiers: winit::keyboard::ModifiersState) -> keyboard::Modifiers {
     let mut result = keyboard::Modifiers::empty();
 
     result.set(keyboard::Modifiers::SHIFT, modifiers.shift_key());
@@ -686,10 +619,7 @@ pub fn modifiers(
 }
 
 /// Converts a physical cursor position into a logical `Point`.
-pub fn cursor_position(
-    position: winit::dpi::PhysicalPosition<f64>,
-    scale_factor: f64,
-) -> Point {
+pub fn cursor_position(position: winit::dpi::PhysicalPosition<f64>, scale_factor: f64) -> Point {
     let logical_position = position.to_logical(f64::from(scale_factor));
 
     Point::new(logical_position.x, logical_position.y)
@@ -715,8 +645,7 @@ pub fn touch_event(
     let id = touch::Finger(s);
 
     let position = {
-        let location =
-            position.unwrap_or_default().to_logical::<f64>(scale_factor);
+        let location = position.unwrap_or_default().to_logical::<f64>(scale_factor);
 
         Point::new(location.x as f32, location.y as f32)
     };
@@ -742,318 +671,312 @@ pub fn key(key: winit::keyboard::Key) -> keyboard::Key {
 
     match key {
         winit::keyboard::Key::Character(c) => keyboard::Key::Character(c),
-        winit::keyboard::Key::Named(named_key) => {
-            keyboard::Key::Named(match named_key {
-                NamedKey::Alt => Named::Alt,
-                NamedKey::AltGraph => Named::AltGraph,
-                NamedKey::CapsLock => Named::CapsLock,
-                NamedKey::Control => Named::Control,
-                NamedKey::Fn => Named::Fn,
-                NamedKey::FnLock => Named::FnLock,
-                NamedKey::NumLock => Named::NumLock,
-                NamedKey::ScrollLock => Named::ScrollLock,
-                NamedKey::Shift => Named::Shift,
-                NamedKey::Symbol => Named::Symbol,
-                NamedKey::SymbolLock => Named::SymbolLock,
-                NamedKey::Meta => Named::Super,
-                NamedKey::Enter => Named::Enter,
-                NamedKey::Tab => Named::Tab,
-                NamedKey::ArrowDown => Named::ArrowDown,
-                NamedKey::ArrowLeft => Named::ArrowLeft,
-                NamedKey::ArrowRight => Named::ArrowRight,
-                NamedKey::ArrowUp => Named::ArrowUp,
-                NamedKey::End => Named::End,
-                NamedKey::Home => Named::Home,
-                NamedKey::PageDown => Named::PageDown,
-                NamedKey::PageUp => Named::PageUp,
-                NamedKey::Backspace => Named::Backspace,
-                NamedKey::Clear => Named::Clear,
-                NamedKey::Copy => Named::Copy,
-                NamedKey::CrSel => Named::CrSel,
-                NamedKey::Cut => Named::Cut,
-                NamedKey::Delete => Named::Delete,
-                NamedKey::EraseEof => Named::EraseEof,
-                NamedKey::ExSel => Named::ExSel,
-                NamedKey::Insert => Named::Insert,
-                NamedKey::Paste => Named::Paste,
-                NamedKey::Redo => Named::Redo,
-                NamedKey::Undo => Named::Undo,
-                NamedKey::Accept => Named::Accept,
-                NamedKey::Again => Named::Again,
-                NamedKey::Attn => Named::Attn,
-                NamedKey::Cancel => Named::Cancel,
-                NamedKey::ContextMenu => Named::ContextMenu,
-                NamedKey::Escape => Named::Escape,
-                NamedKey::Execute => Named::Execute,
-                NamedKey::Find => Named::Find,
-                NamedKey::Help => Named::Help,
-                NamedKey::Pause => Named::Pause,
-                NamedKey::Play => Named::Play,
-                NamedKey::Props => Named::Props,
-                NamedKey::Select => Named::Select,
-                NamedKey::ZoomIn => Named::ZoomIn,
-                NamedKey::ZoomOut => Named::ZoomOut,
-                NamedKey::BrightnessDown => Named::BrightnessDown,
-                NamedKey::BrightnessUp => Named::BrightnessUp,
-                NamedKey::Eject => Named::Eject,
-                NamedKey::LogOff => Named::LogOff,
-                NamedKey::Power => Named::Power,
-                NamedKey::PowerOff => Named::PowerOff,
-                NamedKey::PrintScreen => Named::PrintScreen,
-                NamedKey::Hibernate => Named::Hibernate,
-                NamedKey::Standby => Named::Standby,
-                NamedKey::WakeUp => Named::WakeUp,
-                NamedKey::AllCandidates => Named::AllCandidates,
-                NamedKey::Alphanumeric => Named::Alphanumeric,
-                NamedKey::CodeInput => Named::CodeInput,
-                NamedKey::Compose => Named::Compose,
-                NamedKey::Convert => Named::Convert,
-                NamedKey::FinalMode => Named::FinalMode,
-                NamedKey::GroupFirst => Named::GroupFirst,
-                NamedKey::GroupLast => Named::GroupLast,
-                NamedKey::GroupNext => Named::GroupNext,
-                NamedKey::GroupPrevious => Named::GroupPrevious,
-                NamedKey::ModeChange => Named::ModeChange,
-                NamedKey::NextCandidate => Named::NextCandidate,
-                NamedKey::NonConvert => Named::NonConvert,
-                NamedKey::PreviousCandidate => Named::PreviousCandidate,
-                NamedKey::Process => Named::Process,
-                NamedKey::SingleCandidate => Named::SingleCandidate,
-                NamedKey::HangulMode => Named::HangulMode,
-                NamedKey::HanjaMode => Named::HanjaMode,
-                NamedKey::JunjaMode => Named::JunjaMode,
-                NamedKey::Eisu => Named::Eisu,
-                NamedKey::Hankaku => Named::Hankaku,
-                NamedKey::Hiragana => Named::Hiragana,
-                NamedKey::HiraganaKatakana => Named::HiraganaKatakana,
-                NamedKey::KanaMode => Named::KanaMode,
-                NamedKey::KanjiMode => Named::KanjiMode,
-                NamedKey::Katakana => Named::Katakana,
-                NamedKey::Romaji => Named::Romaji,
-                NamedKey::Zenkaku => Named::Zenkaku,
-                NamedKey::ZenkakuHankaku => Named::ZenkakuHankaku,
-                NamedKey::Soft1 => Named::Soft1,
-                NamedKey::Soft2 => Named::Soft2,
-                NamedKey::Soft3 => Named::Soft3,
-                NamedKey::Soft4 => Named::Soft4,
-                NamedKey::ChannelDown => Named::ChannelDown,
-                NamedKey::ChannelUp => Named::ChannelUp,
-                NamedKey::Close => Named::Close,
-                NamedKey::MailForward => Named::MailForward,
-                NamedKey::MailReply => Named::MailReply,
-                NamedKey::MailSend => Named::MailSend,
-                NamedKey::MediaClose => Named::MediaClose,
-                NamedKey::MediaFastForward => Named::MediaFastForward,
-                NamedKey::MediaPause => Named::MediaPause,
-                NamedKey::MediaPlay => Named::MediaPlay,
-                NamedKey::MediaPlayPause => Named::MediaPlayPause,
-                NamedKey::MediaRecord => Named::MediaRecord,
-                NamedKey::MediaRewind => Named::MediaRewind,
-                NamedKey::MediaStop => Named::MediaStop,
-                NamedKey::MediaTrackNext => Named::MediaTrackNext,
-                NamedKey::MediaTrackPrevious => Named::MediaTrackPrevious,
-                NamedKey::New => Named::New,
-                NamedKey::Open => Named::Open,
-                NamedKey::Print => Named::Print,
-                NamedKey::Save => Named::Save,
-                NamedKey::SpellCheck => Named::SpellCheck,
-                NamedKey::Key11 => Named::Key11,
-                NamedKey::Key12 => Named::Key12,
-                NamedKey::AudioBalanceLeft => Named::AudioBalanceLeft,
-                NamedKey::AudioBalanceRight => Named::AudioBalanceRight,
-                NamedKey::AudioBassBoostDown => Named::AudioBassBoostDown,
-                NamedKey::AudioBassBoostToggle => Named::AudioBassBoostToggle,
-                NamedKey::AudioBassBoostUp => Named::AudioBassBoostUp,
-                NamedKey::AudioFaderFront => Named::AudioFaderFront,
-                NamedKey::AudioFaderRear => Named::AudioFaderRear,
-                NamedKey::AudioSurroundModeNext => Named::AudioSurroundModeNext,
-                NamedKey::AudioTrebleDown => Named::AudioTrebleDown,
-                NamedKey::AudioTrebleUp => Named::AudioTrebleUp,
-                NamedKey::AudioVolumeDown => Named::AudioVolumeDown,
-                NamedKey::AudioVolumeUp => Named::AudioVolumeUp,
-                NamedKey::AudioVolumeMute => Named::AudioVolumeMute,
-                NamedKey::MicrophoneToggle => Named::MicrophoneToggle,
-                NamedKey::MicrophoneVolumeDown => Named::MicrophoneVolumeDown,
-                NamedKey::MicrophoneVolumeUp => Named::MicrophoneVolumeUp,
-                NamedKey::MicrophoneVolumeMute => Named::MicrophoneVolumeMute,
-                NamedKey::SpeechCorrectionList => Named::SpeechCorrectionList,
-                NamedKey::SpeechInputToggle => Named::SpeechInputToggle,
-                NamedKey::LaunchApplication1 => Named::LaunchApplication1,
-                NamedKey::LaunchApplication2 => Named::LaunchApplication2,
-                NamedKey::LaunchCalendar => Named::LaunchCalendar,
-                NamedKey::LaunchContacts => Named::LaunchContacts,
-                NamedKey::LaunchMail => Named::LaunchMail,
-                NamedKey::LaunchMediaPlayer => Named::LaunchMediaPlayer,
-                NamedKey::LaunchMusicPlayer => Named::LaunchMusicPlayer,
-                NamedKey::LaunchPhone => Named::LaunchPhone,
-                NamedKey::LaunchScreenSaver => Named::LaunchScreenSaver,
-                NamedKey::LaunchSpreadsheet => Named::LaunchSpreadsheet,
-                NamedKey::LaunchWebBrowser => Named::LaunchWebBrowser,
-                NamedKey::LaunchWebCam => Named::LaunchWebCam,
-                NamedKey::LaunchWordProcessor => Named::LaunchWordProcessor,
-                NamedKey::BrowserBack => Named::BrowserBack,
-                NamedKey::BrowserFavorites => Named::BrowserFavorites,
-                NamedKey::BrowserForward => Named::BrowserForward,
-                NamedKey::BrowserHome => Named::BrowserHome,
-                NamedKey::BrowserRefresh => Named::BrowserRefresh,
-                NamedKey::BrowserSearch => Named::BrowserSearch,
-                NamedKey::BrowserStop => Named::BrowserStop,
-                NamedKey::AppSwitch => Named::AppSwitch,
-                NamedKey::Call => Named::Call,
-                NamedKey::Camera => Named::Camera,
-                NamedKey::CameraFocus => Named::CameraFocus,
-                NamedKey::EndCall => Named::EndCall,
-                NamedKey::GoBack => Named::GoBack,
-                NamedKey::GoHome => Named::GoHome,
-                NamedKey::HeadsetHook => Named::HeadsetHook,
-                NamedKey::LastNumberRedial => Named::LastNumberRedial,
-                NamedKey::Notification => Named::Notification,
-                NamedKey::MannerMode => Named::MannerMode,
-                NamedKey::VoiceDial => Named::VoiceDial,
-                NamedKey::TV => Named::TV,
-                NamedKey::TV3DMode => Named::TV3DMode,
-                NamedKey::TVAntennaCable => Named::TVAntennaCable,
-                NamedKey::TVAudioDescription => Named::TVAudioDescription,
-                NamedKey::TVAudioDescriptionMixDown => {
-                    Named::TVAudioDescriptionMixDown
-                }
-                NamedKey::TVAudioDescriptionMixUp => {
-                    Named::TVAudioDescriptionMixUp
-                }
-                NamedKey::TVContentsMenu => Named::TVContentsMenu,
-                NamedKey::TVDataService => Named::TVDataService,
-                NamedKey::TVInput => Named::TVInput,
-                NamedKey::TVInputComponent1 => Named::TVInputComponent1,
-                NamedKey::TVInputComponent2 => Named::TVInputComponent2,
-                NamedKey::TVInputComposite1 => Named::TVInputComposite1,
-                NamedKey::TVInputComposite2 => Named::TVInputComposite2,
-                NamedKey::TVInputHDMI1 => Named::TVInputHDMI1,
-                NamedKey::TVInputHDMI2 => Named::TVInputHDMI2,
-                NamedKey::TVInputHDMI3 => Named::TVInputHDMI3,
-                NamedKey::TVInputHDMI4 => Named::TVInputHDMI4,
-                NamedKey::TVInputVGA1 => Named::TVInputVGA1,
-                NamedKey::TVMediaContext => Named::TVMediaContext,
-                NamedKey::TVNetwork => Named::TVNetwork,
-                NamedKey::TVNumberEntry => Named::TVNumberEntry,
-                NamedKey::TVPower => Named::TVPower,
-                NamedKey::TVRadioService => Named::TVRadioService,
-                NamedKey::TVSatellite => Named::TVSatellite,
-                NamedKey::TVSatelliteBS => Named::TVSatelliteBS,
-                NamedKey::TVSatelliteCS => Named::TVSatelliteCS,
-                NamedKey::TVSatelliteToggle => Named::TVSatelliteToggle,
-                NamedKey::TVTerrestrialAnalog => Named::TVTerrestrialAnalog,
-                NamedKey::TVTerrestrialDigital => Named::TVTerrestrialDigital,
-                NamedKey::TVTimer => Named::TVTimer,
-                NamedKey::AVRInput => Named::AVRInput,
-                NamedKey::AVRPower => Named::AVRPower,
-                NamedKey::ColorF0Red => Named::ColorF0Red,
-                NamedKey::ColorF1Green => Named::ColorF1Green,
-                NamedKey::ColorF2Yellow => Named::ColorF2Yellow,
-                NamedKey::ColorF3Blue => Named::ColorF3Blue,
-                NamedKey::ColorF4Grey => Named::ColorF4Grey,
-                NamedKey::ColorF5Brown => Named::ColorF5Brown,
-                NamedKey::ClosedCaptionToggle => Named::ClosedCaptionToggle,
-                NamedKey::Dimmer => Named::Dimmer,
-                NamedKey::DisplaySwap => Named::DisplaySwap,
-                NamedKey::DVR => Named::DVR,
-                NamedKey::Exit => Named::Exit,
-                NamedKey::FavoriteClear0 => Named::FavoriteClear0,
-                NamedKey::FavoriteClear1 => Named::FavoriteClear1,
-                NamedKey::FavoriteClear2 => Named::FavoriteClear2,
-                NamedKey::FavoriteClear3 => Named::FavoriteClear3,
-                NamedKey::FavoriteRecall0 => Named::FavoriteRecall0,
-                NamedKey::FavoriteRecall1 => Named::FavoriteRecall1,
-                NamedKey::FavoriteRecall2 => Named::FavoriteRecall2,
-                NamedKey::FavoriteRecall3 => Named::FavoriteRecall3,
-                NamedKey::FavoriteStore0 => Named::FavoriteStore0,
-                NamedKey::FavoriteStore1 => Named::FavoriteStore1,
-                NamedKey::FavoriteStore2 => Named::FavoriteStore2,
-                NamedKey::FavoriteStore3 => Named::FavoriteStore3,
-                NamedKey::Guide => Named::Guide,
-                NamedKey::GuideNextDay => Named::GuideNextDay,
-                NamedKey::GuidePreviousDay => Named::GuidePreviousDay,
-                NamedKey::Info => Named::Info,
-                NamedKey::InstantReplay => Named::InstantReplay,
-                NamedKey::Link => Named::Link,
-                NamedKey::ListProgram => Named::ListProgram,
-                NamedKey::LiveContent => Named::LiveContent,
-                NamedKey::Lock => Named::Lock,
-                NamedKey::MediaApps => Named::MediaApps,
-                NamedKey::MediaAudioTrack => Named::MediaAudioTrack,
-                NamedKey::MediaLast => Named::MediaLast,
-                NamedKey::MediaSkipBackward => Named::MediaSkipBackward,
-                NamedKey::MediaSkipForward => Named::MediaSkipForward,
-                NamedKey::MediaStepBackward => Named::MediaStepBackward,
-                NamedKey::MediaStepForward => Named::MediaStepForward,
-                NamedKey::MediaTopMenu => Named::MediaTopMenu,
-                NamedKey::NavigateIn => Named::NavigateIn,
-                NamedKey::NavigateNext => Named::NavigateNext,
-                NamedKey::NavigateOut => Named::NavigateOut,
-                NamedKey::NavigatePrevious => Named::NavigatePrevious,
-                NamedKey::NextFavoriteChannel => Named::NextFavoriteChannel,
-                NamedKey::NextUserProfile => Named::NextUserProfile,
-                NamedKey::OnDemand => Named::OnDemand,
-                NamedKey::Pairing => Named::Pairing,
-                NamedKey::PinPDown => Named::PinPDown,
-                NamedKey::PinPMove => Named::PinPMove,
-                NamedKey::PinPToggle => Named::PinPToggle,
-                NamedKey::PinPUp => Named::PinPUp,
-                NamedKey::PlaySpeedDown => Named::PlaySpeedDown,
-                NamedKey::PlaySpeedReset => Named::PlaySpeedReset,
-                NamedKey::PlaySpeedUp => Named::PlaySpeedUp,
-                NamedKey::RandomToggle => Named::RandomToggle,
-                NamedKey::RcLowBattery => Named::RcLowBattery,
-                NamedKey::RecordSpeedNext => Named::RecordSpeedNext,
-                NamedKey::RfBypass => Named::RfBypass,
-                NamedKey::ScanChannelsToggle => Named::ScanChannelsToggle,
-                NamedKey::ScreenModeNext => Named::ScreenModeNext,
-                NamedKey::Settings => Named::Settings,
-                NamedKey::SplitScreenToggle => Named::SplitScreenToggle,
-                NamedKey::STBInput => Named::STBInput,
-                NamedKey::STBPower => Named::STBPower,
-                NamedKey::Subtitle => Named::Subtitle,
-                NamedKey::Teletext => Named::Teletext,
-                NamedKey::VideoModeNext => Named::VideoModeNext,
-                NamedKey::Wink => Named::Wink,
-                NamedKey::ZoomToggle => Named::ZoomToggle,
-                NamedKey::F1 => Named::F1,
-                NamedKey::F2 => Named::F2,
-                NamedKey::F3 => Named::F3,
-                NamedKey::F4 => Named::F4,
-                NamedKey::F5 => Named::F5,
-                NamedKey::F6 => Named::F6,
-                NamedKey::F7 => Named::F7,
-                NamedKey::F8 => Named::F8,
-                NamedKey::F9 => Named::F9,
-                NamedKey::F10 => Named::F10,
-                NamedKey::F11 => Named::F11,
-                NamedKey::F12 => Named::F12,
-                NamedKey::F13 => Named::F13,
-                NamedKey::F14 => Named::F14,
-                NamedKey::F15 => Named::F15,
-                NamedKey::F16 => Named::F16,
-                NamedKey::F17 => Named::F17,
-                NamedKey::F18 => Named::F18,
-                NamedKey::F19 => Named::F19,
-                NamedKey::F20 => Named::F20,
-                NamedKey::F21 => Named::F21,
-                NamedKey::F22 => Named::F22,
-                NamedKey::F23 => Named::F23,
-                NamedKey::F24 => Named::F24,
-                NamedKey::F25 => Named::F25,
-                NamedKey::F26 => Named::F26,
-                NamedKey::F27 => Named::F27,
-                NamedKey::F28 => Named::F28,
-                NamedKey::F29 => Named::F29,
-                NamedKey::F30 => Named::F30,
-                NamedKey::F31 => Named::F31,
-                NamedKey::F32 => Named::F32,
-                NamedKey::F33 => Named::F33,
-                NamedKey::F34 => Named::F34,
-                NamedKey::F35 => Named::F35,
-                _ => return keyboard::Key::Unidentified,
-            })
-        }
+        winit::keyboard::Key::Named(named_key) => keyboard::Key::Named(match named_key {
+            NamedKey::Alt => Named::Alt,
+            NamedKey::AltGraph => Named::AltGraph,
+            NamedKey::CapsLock => Named::CapsLock,
+            NamedKey::Control => Named::Control,
+            NamedKey::Fn => Named::Fn,
+            NamedKey::FnLock => Named::FnLock,
+            NamedKey::NumLock => Named::NumLock,
+            NamedKey::ScrollLock => Named::ScrollLock,
+            NamedKey::Shift => Named::Shift,
+            NamedKey::Symbol => Named::Symbol,
+            NamedKey::SymbolLock => Named::SymbolLock,
+            NamedKey::Meta => Named::Super,
+            NamedKey::Enter => Named::Enter,
+            NamedKey::Tab => Named::Tab,
+            NamedKey::ArrowDown => Named::ArrowDown,
+            NamedKey::ArrowLeft => Named::ArrowLeft,
+            NamedKey::ArrowRight => Named::ArrowRight,
+            NamedKey::ArrowUp => Named::ArrowUp,
+            NamedKey::End => Named::End,
+            NamedKey::Home => Named::Home,
+            NamedKey::PageDown => Named::PageDown,
+            NamedKey::PageUp => Named::PageUp,
+            NamedKey::Backspace => Named::Backspace,
+            NamedKey::Clear => Named::Clear,
+            NamedKey::Copy => Named::Copy,
+            NamedKey::CrSel => Named::CrSel,
+            NamedKey::Cut => Named::Cut,
+            NamedKey::Delete => Named::Delete,
+            NamedKey::EraseEof => Named::EraseEof,
+            NamedKey::ExSel => Named::ExSel,
+            NamedKey::Insert => Named::Insert,
+            NamedKey::Paste => Named::Paste,
+            NamedKey::Redo => Named::Redo,
+            NamedKey::Undo => Named::Undo,
+            NamedKey::Accept => Named::Accept,
+            NamedKey::Again => Named::Again,
+            NamedKey::Attn => Named::Attn,
+            NamedKey::Cancel => Named::Cancel,
+            NamedKey::ContextMenu => Named::ContextMenu,
+            NamedKey::Escape => Named::Escape,
+            NamedKey::Execute => Named::Execute,
+            NamedKey::Find => Named::Find,
+            NamedKey::Help => Named::Help,
+            NamedKey::Pause => Named::Pause,
+            NamedKey::Play => Named::Play,
+            NamedKey::Props => Named::Props,
+            NamedKey::Select => Named::Select,
+            NamedKey::ZoomIn => Named::ZoomIn,
+            NamedKey::ZoomOut => Named::ZoomOut,
+            NamedKey::BrightnessDown => Named::BrightnessDown,
+            NamedKey::BrightnessUp => Named::BrightnessUp,
+            NamedKey::Eject => Named::Eject,
+            NamedKey::LogOff => Named::LogOff,
+            NamedKey::Power => Named::Power,
+            NamedKey::PowerOff => Named::PowerOff,
+            NamedKey::PrintScreen => Named::PrintScreen,
+            NamedKey::Hibernate => Named::Hibernate,
+            NamedKey::Standby => Named::Standby,
+            NamedKey::WakeUp => Named::WakeUp,
+            NamedKey::AllCandidates => Named::AllCandidates,
+            NamedKey::Alphanumeric => Named::Alphanumeric,
+            NamedKey::CodeInput => Named::CodeInput,
+            NamedKey::Compose => Named::Compose,
+            NamedKey::Convert => Named::Convert,
+            NamedKey::FinalMode => Named::FinalMode,
+            NamedKey::GroupFirst => Named::GroupFirst,
+            NamedKey::GroupLast => Named::GroupLast,
+            NamedKey::GroupNext => Named::GroupNext,
+            NamedKey::GroupPrevious => Named::GroupPrevious,
+            NamedKey::ModeChange => Named::ModeChange,
+            NamedKey::NextCandidate => Named::NextCandidate,
+            NamedKey::NonConvert => Named::NonConvert,
+            NamedKey::PreviousCandidate => Named::PreviousCandidate,
+            NamedKey::Process => Named::Process,
+            NamedKey::SingleCandidate => Named::SingleCandidate,
+            NamedKey::HangulMode => Named::HangulMode,
+            NamedKey::HanjaMode => Named::HanjaMode,
+            NamedKey::JunjaMode => Named::JunjaMode,
+            NamedKey::Eisu => Named::Eisu,
+            NamedKey::Hankaku => Named::Hankaku,
+            NamedKey::Hiragana => Named::Hiragana,
+            NamedKey::HiraganaKatakana => Named::HiraganaKatakana,
+            NamedKey::KanaMode => Named::KanaMode,
+            NamedKey::KanjiMode => Named::KanjiMode,
+            NamedKey::Katakana => Named::Katakana,
+            NamedKey::Romaji => Named::Romaji,
+            NamedKey::Zenkaku => Named::Zenkaku,
+            NamedKey::ZenkakuHankaku => Named::ZenkakuHankaku,
+            NamedKey::Soft1 => Named::Soft1,
+            NamedKey::Soft2 => Named::Soft2,
+            NamedKey::Soft3 => Named::Soft3,
+            NamedKey::Soft4 => Named::Soft4,
+            NamedKey::ChannelDown => Named::ChannelDown,
+            NamedKey::ChannelUp => Named::ChannelUp,
+            NamedKey::Close => Named::Close,
+            NamedKey::MailForward => Named::MailForward,
+            NamedKey::MailReply => Named::MailReply,
+            NamedKey::MailSend => Named::MailSend,
+            NamedKey::MediaClose => Named::MediaClose,
+            NamedKey::MediaFastForward => Named::MediaFastForward,
+            NamedKey::MediaPause => Named::MediaPause,
+            NamedKey::MediaPlay => Named::MediaPlay,
+            NamedKey::MediaPlayPause => Named::MediaPlayPause,
+            NamedKey::MediaRecord => Named::MediaRecord,
+            NamedKey::MediaRewind => Named::MediaRewind,
+            NamedKey::MediaStop => Named::MediaStop,
+            NamedKey::MediaTrackNext => Named::MediaTrackNext,
+            NamedKey::MediaTrackPrevious => Named::MediaTrackPrevious,
+            NamedKey::New => Named::New,
+            NamedKey::Open => Named::Open,
+            NamedKey::Print => Named::Print,
+            NamedKey::Save => Named::Save,
+            NamedKey::SpellCheck => Named::SpellCheck,
+            NamedKey::Key11 => Named::Key11,
+            NamedKey::Key12 => Named::Key12,
+            NamedKey::AudioBalanceLeft => Named::AudioBalanceLeft,
+            NamedKey::AudioBalanceRight => Named::AudioBalanceRight,
+            NamedKey::AudioBassBoostDown => Named::AudioBassBoostDown,
+            NamedKey::AudioBassBoostToggle => Named::AudioBassBoostToggle,
+            NamedKey::AudioBassBoostUp => Named::AudioBassBoostUp,
+            NamedKey::AudioFaderFront => Named::AudioFaderFront,
+            NamedKey::AudioFaderRear => Named::AudioFaderRear,
+            NamedKey::AudioSurroundModeNext => Named::AudioSurroundModeNext,
+            NamedKey::AudioTrebleDown => Named::AudioTrebleDown,
+            NamedKey::AudioTrebleUp => Named::AudioTrebleUp,
+            NamedKey::AudioVolumeDown => Named::AudioVolumeDown,
+            NamedKey::AudioVolumeUp => Named::AudioVolumeUp,
+            NamedKey::AudioVolumeMute => Named::AudioVolumeMute,
+            NamedKey::MicrophoneToggle => Named::MicrophoneToggle,
+            NamedKey::MicrophoneVolumeDown => Named::MicrophoneVolumeDown,
+            NamedKey::MicrophoneVolumeUp => Named::MicrophoneVolumeUp,
+            NamedKey::MicrophoneVolumeMute => Named::MicrophoneVolumeMute,
+            NamedKey::SpeechCorrectionList => Named::SpeechCorrectionList,
+            NamedKey::SpeechInputToggle => Named::SpeechInputToggle,
+            NamedKey::LaunchApplication1 => Named::LaunchApplication1,
+            NamedKey::LaunchApplication2 => Named::LaunchApplication2,
+            NamedKey::LaunchCalendar => Named::LaunchCalendar,
+            NamedKey::LaunchContacts => Named::LaunchContacts,
+            NamedKey::LaunchMail => Named::LaunchMail,
+            NamedKey::LaunchMediaPlayer => Named::LaunchMediaPlayer,
+            NamedKey::LaunchMusicPlayer => Named::LaunchMusicPlayer,
+            NamedKey::LaunchPhone => Named::LaunchPhone,
+            NamedKey::LaunchScreenSaver => Named::LaunchScreenSaver,
+            NamedKey::LaunchSpreadsheet => Named::LaunchSpreadsheet,
+            NamedKey::LaunchWebBrowser => Named::LaunchWebBrowser,
+            NamedKey::LaunchWebCam => Named::LaunchWebCam,
+            NamedKey::LaunchWordProcessor => Named::LaunchWordProcessor,
+            NamedKey::BrowserBack => Named::BrowserBack,
+            NamedKey::BrowserFavorites => Named::BrowserFavorites,
+            NamedKey::BrowserForward => Named::BrowserForward,
+            NamedKey::BrowserHome => Named::BrowserHome,
+            NamedKey::BrowserRefresh => Named::BrowserRefresh,
+            NamedKey::BrowserSearch => Named::BrowserSearch,
+            NamedKey::BrowserStop => Named::BrowserStop,
+            NamedKey::AppSwitch => Named::AppSwitch,
+            NamedKey::Call => Named::Call,
+            NamedKey::Camera => Named::Camera,
+            NamedKey::CameraFocus => Named::CameraFocus,
+            NamedKey::EndCall => Named::EndCall,
+            NamedKey::GoBack => Named::GoBack,
+            NamedKey::GoHome => Named::GoHome,
+            NamedKey::HeadsetHook => Named::HeadsetHook,
+            NamedKey::LastNumberRedial => Named::LastNumberRedial,
+            NamedKey::Notification => Named::Notification,
+            NamedKey::MannerMode => Named::MannerMode,
+            NamedKey::VoiceDial => Named::VoiceDial,
+            NamedKey::TV => Named::TV,
+            NamedKey::TV3DMode => Named::TV3DMode,
+            NamedKey::TVAntennaCable => Named::TVAntennaCable,
+            NamedKey::TVAudioDescription => Named::TVAudioDescription,
+            NamedKey::TVAudioDescriptionMixDown => Named::TVAudioDescriptionMixDown,
+            NamedKey::TVAudioDescriptionMixUp => Named::TVAudioDescriptionMixUp,
+            NamedKey::TVContentsMenu => Named::TVContentsMenu,
+            NamedKey::TVDataService => Named::TVDataService,
+            NamedKey::TVInput => Named::TVInput,
+            NamedKey::TVInputComponent1 => Named::TVInputComponent1,
+            NamedKey::TVInputComponent2 => Named::TVInputComponent2,
+            NamedKey::TVInputComposite1 => Named::TVInputComposite1,
+            NamedKey::TVInputComposite2 => Named::TVInputComposite2,
+            NamedKey::TVInputHDMI1 => Named::TVInputHDMI1,
+            NamedKey::TVInputHDMI2 => Named::TVInputHDMI2,
+            NamedKey::TVInputHDMI3 => Named::TVInputHDMI3,
+            NamedKey::TVInputHDMI4 => Named::TVInputHDMI4,
+            NamedKey::TVInputVGA1 => Named::TVInputVGA1,
+            NamedKey::TVMediaContext => Named::TVMediaContext,
+            NamedKey::TVNetwork => Named::TVNetwork,
+            NamedKey::TVNumberEntry => Named::TVNumberEntry,
+            NamedKey::TVPower => Named::TVPower,
+            NamedKey::TVRadioService => Named::TVRadioService,
+            NamedKey::TVSatellite => Named::TVSatellite,
+            NamedKey::TVSatelliteBS => Named::TVSatelliteBS,
+            NamedKey::TVSatelliteCS => Named::TVSatelliteCS,
+            NamedKey::TVSatelliteToggle => Named::TVSatelliteToggle,
+            NamedKey::TVTerrestrialAnalog => Named::TVTerrestrialAnalog,
+            NamedKey::TVTerrestrialDigital => Named::TVTerrestrialDigital,
+            NamedKey::TVTimer => Named::TVTimer,
+            NamedKey::AVRInput => Named::AVRInput,
+            NamedKey::AVRPower => Named::AVRPower,
+            NamedKey::ColorF0Red => Named::ColorF0Red,
+            NamedKey::ColorF1Green => Named::ColorF1Green,
+            NamedKey::ColorF2Yellow => Named::ColorF2Yellow,
+            NamedKey::ColorF3Blue => Named::ColorF3Blue,
+            NamedKey::ColorF4Grey => Named::ColorF4Grey,
+            NamedKey::ColorF5Brown => Named::ColorF5Brown,
+            NamedKey::ClosedCaptionToggle => Named::ClosedCaptionToggle,
+            NamedKey::Dimmer => Named::Dimmer,
+            NamedKey::DisplaySwap => Named::DisplaySwap,
+            NamedKey::DVR => Named::DVR,
+            NamedKey::Exit => Named::Exit,
+            NamedKey::FavoriteClear0 => Named::FavoriteClear0,
+            NamedKey::FavoriteClear1 => Named::FavoriteClear1,
+            NamedKey::FavoriteClear2 => Named::FavoriteClear2,
+            NamedKey::FavoriteClear3 => Named::FavoriteClear3,
+            NamedKey::FavoriteRecall0 => Named::FavoriteRecall0,
+            NamedKey::FavoriteRecall1 => Named::FavoriteRecall1,
+            NamedKey::FavoriteRecall2 => Named::FavoriteRecall2,
+            NamedKey::FavoriteRecall3 => Named::FavoriteRecall3,
+            NamedKey::FavoriteStore0 => Named::FavoriteStore0,
+            NamedKey::FavoriteStore1 => Named::FavoriteStore1,
+            NamedKey::FavoriteStore2 => Named::FavoriteStore2,
+            NamedKey::FavoriteStore3 => Named::FavoriteStore3,
+            NamedKey::Guide => Named::Guide,
+            NamedKey::GuideNextDay => Named::GuideNextDay,
+            NamedKey::GuidePreviousDay => Named::GuidePreviousDay,
+            NamedKey::Info => Named::Info,
+            NamedKey::InstantReplay => Named::InstantReplay,
+            NamedKey::Link => Named::Link,
+            NamedKey::ListProgram => Named::ListProgram,
+            NamedKey::LiveContent => Named::LiveContent,
+            NamedKey::Lock => Named::Lock,
+            NamedKey::MediaApps => Named::MediaApps,
+            NamedKey::MediaAudioTrack => Named::MediaAudioTrack,
+            NamedKey::MediaLast => Named::MediaLast,
+            NamedKey::MediaSkipBackward => Named::MediaSkipBackward,
+            NamedKey::MediaSkipForward => Named::MediaSkipForward,
+            NamedKey::MediaStepBackward => Named::MediaStepBackward,
+            NamedKey::MediaStepForward => Named::MediaStepForward,
+            NamedKey::MediaTopMenu => Named::MediaTopMenu,
+            NamedKey::NavigateIn => Named::NavigateIn,
+            NamedKey::NavigateNext => Named::NavigateNext,
+            NamedKey::NavigateOut => Named::NavigateOut,
+            NamedKey::NavigatePrevious => Named::NavigatePrevious,
+            NamedKey::NextFavoriteChannel => Named::NextFavoriteChannel,
+            NamedKey::NextUserProfile => Named::NextUserProfile,
+            NamedKey::OnDemand => Named::OnDemand,
+            NamedKey::Pairing => Named::Pairing,
+            NamedKey::PinPDown => Named::PinPDown,
+            NamedKey::PinPMove => Named::PinPMove,
+            NamedKey::PinPToggle => Named::PinPToggle,
+            NamedKey::PinPUp => Named::PinPUp,
+            NamedKey::PlaySpeedDown => Named::PlaySpeedDown,
+            NamedKey::PlaySpeedReset => Named::PlaySpeedReset,
+            NamedKey::PlaySpeedUp => Named::PlaySpeedUp,
+            NamedKey::RandomToggle => Named::RandomToggle,
+            NamedKey::RcLowBattery => Named::RcLowBattery,
+            NamedKey::RecordSpeedNext => Named::RecordSpeedNext,
+            NamedKey::RfBypass => Named::RfBypass,
+            NamedKey::ScanChannelsToggle => Named::ScanChannelsToggle,
+            NamedKey::ScreenModeNext => Named::ScreenModeNext,
+            NamedKey::Settings => Named::Settings,
+            NamedKey::SplitScreenToggle => Named::SplitScreenToggle,
+            NamedKey::STBInput => Named::STBInput,
+            NamedKey::STBPower => Named::STBPower,
+            NamedKey::Subtitle => Named::Subtitle,
+            NamedKey::Teletext => Named::Teletext,
+            NamedKey::VideoModeNext => Named::VideoModeNext,
+            NamedKey::Wink => Named::Wink,
+            NamedKey::ZoomToggle => Named::ZoomToggle,
+            NamedKey::F1 => Named::F1,
+            NamedKey::F2 => Named::F2,
+            NamedKey::F3 => Named::F3,
+            NamedKey::F4 => Named::F4,
+            NamedKey::F5 => Named::F5,
+            NamedKey::F6 => Named::F6,
+            NamedKey::F7 => Named::F7,
+            NamedKey::F8 => Named::F8,
+            NamedKey::F9 => Named::F9,
+            NamedKey::F10 => Named::F10,
+            NamedKey::F11 => Named::F11,
+            NamedKey::F12 => Named::F12,
+            NamedKey::F13 => Named::F13,
+            NamedKey::F14 => Named::F14,
+            NamedKey::F15 => Named::F15,
+            NamedKey::F16 => Named::F16,
+            NamedKey::F17 => Named::F17,
+            NamedKey::F18 => Named::F18,
+            NamedKey::F19 => Named::F19,
+            NamedKey::F20 => Named::F20,
+            NamedKey::F21 => Named::F21,
+            NamedKey::F22 => Named::F22,
+            NamedKey::F23 => Named::F23,
+            NamedKey::F24 => Named::F24,
+            NamedKey::F25 => Named::F25,
+            NamedKey::F26 => Named::F26,
+            NamedKey::F27 => Named::F27,
+            NamedKey::F28 => Named::F28,
+            NamedKey::F29 => Named::F29,
+            NamedKey::F30 => Named::F30,
+            NamedKey::F31 => Named::F31,
+            NamedKey::F32 => Named::F32,
+            NamedKey::F33 => Named::F33,
+            NamedKey::F34 => Named::F34,
+            NamedKey::F35 => Named::F35,
+            _ => return keyboard::Key::Unidentified,
+        }),
         _ => keyboard::Key::Unidentified,
     }
 }
@@ -1062,15 +985,13 @@ pub fn key(key: winit::keyboard::Key) -> keyboard::Key {
 ///
 /// [`winit`]: https://github.com/rust-windowing/winit
 /// [`iced`]: https://github.com/iced-rs/iced/tree/0.12
-pub fn physical_key(
-    physical_key: winit::keyboard::PhysicalKey,
-) -> keyboard::key::Physical {
+pub fn physical_key(physical_key: winit::keyboard::PhysicalKey) -> keyboard::key::Physical {
     match physical_key {
-        winit::keyboard::PhysicalKey::Code(code) => key_code(code)
-            .map(keyboard::key::Physical::Code)
-            .unwrap_or(keyboard::key::Physical::Unidentified(
-                keyboard::key::NativeCode::Unidentified,
-            )),
+        winit::keyboard::PhysicalKey::Code(code) => {
+            key_code(code).map(keyboard::key::Physical::Code).unwrap_or(
+                keyboard::key::Physical::Unidentified(keyboard::key::NativeCode::Unidentified),
+            )
+        }
         winit::keyboard::PhysicalKey::Unidentified(code) => {
             keyboard::key::Physical::Unidentified(native_key_code(code))
         }
@@ -1081,9 +1002,7 @@ pub fn physical_key(
 ///
 /// [`winit`]: https://github.com/rust-windowing/winit
 /// [`iced`]: https://github.com/iced-rs/iced/tree/0.12
-pub fn key_code(
-    key_code: winit::keyboard::KeyCode,
-) -> Option<keyboard::key::Code> {
+pub fn key_code(key_code: winit::keyboard::KeyCode) -> Option<keyboard::key::Code> {
     use winit::keyboard::KeyCode;
 
     Some(match key_code {
@@ -1195,9 +1114,7 @@ pub fn key_code(
         KeyCode::NumpadMemoryClear => keyboard::key::Code::NumpadMemoryClear,
         KeyCode::NumpadMemoryRecall => keyboard::key::Code::NumpadMemoryRecall,
         KeyCode::NumpadMemoryStore => keyboard::key::Code::NumpadMemoryStore,
-        KeyCode::NumpadMemorySubtract => {
-            keyboard::key::Code::NumpadMemorySubtract
-        }
+        KeyCode::NumpadMemorySubtract => keyboard::key::Code::NumpadMemorySubtract,
         KeyCode::NumpadMultiply => keyboard::key::Code::NumpadMultiply,
         KeyCode::NumpadParenLeft => keyboard::key::Code::NumpadParenLeft,
         KeyCode::NumpadParenRight => keyboard::key::Code::NumpadParenRight,
@@ -1285,9 +1202,7 @@ pub fn key_code(
     })
 }
 
-pub fn winit_key_code(
-    key_code: keyboard::key::Code,
-) -> Option<winit::keyboard::KeyCode> {
+pub fn winit_key_code(key_code: keyboard::key::Code) -> Option<winit::keyboard::KeyCode> {
     use winit::keyboard::KeyCode;
 
     Some(match key_code {
@@ -1399,9 +1314,7 @@ pub fn winit_key_code(
         keyboard::key::Code::NumpadMemoryClear => KeyCode::NumpadMemoryClear,
         keyboard::key::Code::NumpadMemoryRecall => KeyCode::NumpadMemoryRecall,
         keyboard::key::Code::NumpadMemoryStore => KeyCode::NumpadMemoryStore,
-        keyboard::key::Code::NumpadMemorySubtract => {
-            KeyCode::NumpadMemorySubtract
-        }
+        keyboard::key::Code::NumpadMemorySubtract => KeyCode::NumpadMemorySubtract,
         keyboard::key::Code::NumpadMultiply => KeyCode::NumpadMultiply,
         keyboard::key::Code::NumpadParenLeft => KeyCode::NumpadParenLeft,
         keyboard::key::Code::NumpadParenRight => KeyCode::NumpadParenRight,
@@ -1492,25 +1405,13 @@ pub fn winit_key_code(
 }
 
 #[cfg(all(feature = "cctk", target_os = "linux"))]
-fn winit_native_key_code(
-    keycode: keyboard::key::NativeCode,
-) -> winit::keyboard::NativeKeyCode {
+fn winit_native_key_code(keycode: keyboard::key::NativeCode) -> winit::keyboard::NativeKeyCode {
     match keycode {
-        keyboard::key::NativeCode::Unidentified => {
-            winit::keyboard::NativeKeyCode::Unidentified
-        }
-        keyboard::key::NativeCode::Android(k) => {
-            winit::keyboard::NativeKeyCode::Android(k)
-        }
-        keyboard::key::NativeCode::MacOS(k) => {
-            winit::keyboard::NativeKeyCode::MacOS(k)
-        }
-        keyboard::key::NativeCode::Windows(k) => {
-            winit::keyboard::NativeKeyCode::Windows(k)
-        }
-        keyboard::key::NativeCode::Xkb(k) => {
-            winit::keyboard::NativeKeyCode::Xkb(k)
-        }
+        keyboard::key::NativeCode::Unidentified => winit::keyboard::NativeKeyCode::Unidentified,
+        keyboard::key::NativeCode::Android(k) => winit::keyboard::NativeKeyCode::Android(k),
+        keyboard::key::NativeCode::MacOS(k) => winit::keyboard::NativeKeyCode::MacOS(k),
+        keyboard::key::NativeCode::Windows(k) => winit::keyboard::NativeKeyCode::Windows(k),
+        keyboard::key::NativeCode::Xkb(k) => winit::keyboard::NativeKeyCode::Xkb(k),
     }
 }
 
@@ -1521,11 +1422,9 @@ pub fn physical_to_scancode(physical: keyboard::key::Physical) -> Option<u32> {
         keyboard::key::Physical::Code(code) => {
             winit_key_code(code).map(|k| winit::keyboard::PhysicalKey::Code(k))
         }
-        keyboard::key::Physical::Unidentified(native_code) => {
-            Some(winit::keyboard::PhysicalKey::Unidentified(
-                winit_native_key_code(native_code),
-            ))
-        }
+        keyboard::key::Physical::Unidentified(native_code) => Some(
+            winit::keyboard::PhysicalKey::Unidentified(winit_native_key_code(native_code)),
+        ),
     }) else {
         return None;
     };
@@ -1544,13 +1443,9 @@ pub fn native_key_code(
 
     match native_key_code {
         NativeKeyCode::Unidentified => keyboard::key::NativeCode::Unidentified,
-        NativeKeyCode::Android(code) => {
-            keyboard::key::NativeCode::Android(code)
-        }
+        NativeKeyCode::Android(code) => keyboard::key::NativeCode::Android(code),
         NativeKeyCode::MacOS(code) => keyboard::key::NativeCode::MacOS(code),
-        NativeKeyCode::Windows(code) => {
-            keyboard::key::NativeCode::Windows(code)
-        }
+        NativeKeyCode::Windows(code) => keyboard::key::NativeCode::Windows(code),
         NativeKeyCode::Xkb(code) => keyboard::key::NativeCode::Xkb(code),
     }
 }
@@ -1558,40 +1453,24 @@ pub fn native_key_code(
 /// Converts some [`UserAttention`] into its `winit` counterpart.
 ///
 /// [`UserAttention`]: window::UserAttention
-pub fn user_attention(
-    user_attention: window::UserAttention,
-) -> winit::window::UserAttentionType {
+pub fn user_attention(user_attention: window::UserAttention) -> winit::window::UserAttentionType {
     match user_attention {
-        window::UserAttention::Critical => {
-            winit::window::UserAttentionType::Critical
-        }
-        window::UserAttention::Informational => {
-            winit::window::UserAttentionType::Informational
-        }
+        window::UserAttention::Critical => winit::window::UserAttentionType::Critical,
+        window::UserAttention::Informational => winit::window::UserAttentionType::Informational,
     }
 }
 
 /// Converts some [`window::Direction`] into a [`winit::window::ResizeDirection`].
-pub fn resize_direction(
-    resize_direction: window::Direction,
-) -> winit::window::ResizeDirection {
+pub fn resize_direction(resize_direction: window::Direction) -> winit::window::ResizeDirection {
     match resize_direction {
         window::Direction::North => winit::window::ResizeDirection::North,
         window::Direction::South => winit::window::ResizeDirection::South,
         window::Direction::East => winit::window::ResizeDirection::East,
         window::Direction::West => winit::window::ResizeDirection::West,
-        window::Direction::NorthEast => {
-            winit::window::ResizeDirection::NorthEast
-        }
-        window::Direction::NorthWest => {
-            winit::window::ResizeDirection::NorthWest
-        }
-        window::Direction::SouthEast => {
-            winit::window::ResizeDirection::SouthEast
-        }
-        window::Direction::SouthWest => {
-            winit::window::ResizeDirection::SouthWest
-        }
+        window::Direction::NorthEast => winit::window::ResizeDirection::NorthEast,
+        window::Direction::NorthWest => winit::window::ResizeDirection::NorthWest,
+        window::Direction::SouthEast => winit::window::ResizeDirection::SouthEast,
+        window::Direction::SouthWest => winit::window::ResizeDirection::SouthWest,
     }
 }
 
@@ -1613,9 +1492,7 @@ pub fn icon(icon: window::Icon) -> Option<winit_core::icon::Icon> {
 }
 
 /// Converts some [`input_method::Purpose`] into its `winit` counterpart.
-pub fn ime_purpose(
-    purpose: input_method::Purpose,
-) -> winit::window::ImePurpose {
+pub fn ime_purpose(purpose: input_method::Purpose) -> winit::window::ImePurpose {
     match purpose {
         input_method::Purpose::Normal => winit::window::ImePurpose::Normal,
         input_method::Purpose::Secure => winit::window::ImePurpose::Password,
@@ -1629,12 +1506,8 @@ fn is_private_use(c: char) -> bool {
 }
 
 #[cfg(feature = "a11y")]
-pub(crate) fn a11y(
-    event: iced_accessibility::accesskit::ActionRequest,
-) -> Event {
+pub(crate) fn a11y(event: iced_accessibility::accesskit::ActionRequest) -> Event {
     // TODO include newly added target tree
-    let id = iced_runtime::core::id::Id::from(
-        u128::from(event.target_node.0) as u64
-    );
+    let id = iced_runtime::core::id::Id::from(u128::from(event.target_node.0) as u64);
     Event::A11y(id, event)
 }

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -41,10 +41,9 @@ pub mod conversion;
 pub mod platform_specific;
 
 #[cfg(feature = "program")]
-pub mod program;
+pub use program::Program;
 
-#[cfg(feature = "system")]
-pub mod system;
+pub use platform_specific::*;
 
 mod error;
 mod proxy;
@@ -99,8 +98,7 @@ where
     let event_loop = EventLoop::new().expect("Create event loop");
 
     #[cfg(all(feature = "cctk", target_os = "linux"))]
-    let is_wayland =
-        winit::platform::wayland::EventLoopExtWayland::is_wayland(&event_loop);
+    let is_wayland = winit::platform::wayland::EventLoopExtWayland::is_wayland(&event_loop);
     #[cfg(not(all(feature = "cctk", target_os = "linux")))]
     let is_wayland = false;
 
@@ -122,8 +120,7 @@ where
     }
 
     let mut runtime = {
-        let executor =
-            P::Executor::new().map_err(Error::ExecutorCreationFailed)?;
+        let executor = P::Executor::new().map_err(Error::ExecutorCreationFailed)?;
         executor.spawn(worker);
 
         Runtime::new(executor, proxy.clone())
@@ -193,10 +190,13 @@ where
         error: Option<Error>,
         system_theme: Option<oneshot::Sender<theme::Mode>>,
         control_sender: mpsc::UnboundedSender<Control>,
-        
+
         #[cfg(feature = "a11y")]
-        adapters: std::collections::HashMap<window::Id, (u64, iced_accessibility::accesskit_winit::Adapter)>,
-    
+        adapters: std::collections::HashMap<
+            window::Id,
+            (u64, iced_accessibility::accesskit_winit::Adapter),
+        >,
+
         #[cfg(target_arch = "wasm32")]
         is_booted: std::rc::Rc<std::cell::RefCell<bool>>,
         #[cfg(target_arch = "wasm32")]
@@ -232,10 +232,7 @@ where
     where
         F: Future<Output = ()>,
     {
-        fn proxy_wake_up(
-            &mut self,
-            event_loop: &dyn winit::event_loop::ActiveEventLoop,
-        ) {
+        fn proxy_wake_up(&mut self, event_loop: &dyn winit::event_loop::ActiveEventLoop) {
             self.process_event(event_loop, None);
         }
 
@@ -259,37 +256,27 @@ where
             #[cfg(target_os = "windows")]
             let is_move_or_resize = matches!(
                 event,
-                winit::event::WindowEvent::SurfaceResized(_)
-                    | winit::event::WindowEvent::Moved(_)
+                winit::event::WindowEvent::SurfaceResized(_) | winit::event::WindowEvent::Moved(_)
             );
 
             #[cfg(all(feature = "cctk", target_os = "linux"))]
             {
                 if matches!(event, WindowEvent::RedrawRequested) {
-                    for id in
-                        crate::subsurface_widget::subsurface_ids(window_id)
-                    {
-                        _ = self.sender.start_send(Event::Winit(
-                            id,
-                            WindowEvent::RedrawRequested,
-                        ));
+                    for id in crate::subsurface_widget::subsurface_ids(window_id) {
+                        _ = self
+                            .sender
+                            .start_send(Event::Winit(id, WindowEvent::RedrawRequested));
                     }
                 } else if matches!(event, WindowEvent::CloseRequested) {
-                    for id in
-                        crate::subsurface_widget::subsurface_ids(window_id)
-                    {
-                        _ = self.sender.start_send(Event::Winit(
-                            id,
-                            WindowEvent::CloseRequested,
-                        ));
+                    for id in crate::subsurface_widget::subsurface_ids(window_id) {
+                        _ = self
+                            .sender
+                            .start_send(Event::Winit(id, WindowEvent::CloseRequested));
                     }
                 }
             }
 
-            self.process_event(
-                event_loop,
-                Some(Event::Winit(window_id, event)),
-            );
+            self.process_event(event_loop, Some(Event::Winit(window_id, event)));
 
             // TODO: Remove when unnecessary
             // On Windows, we emulate an `AboutToWait` event after every `Resized` event
@@ -308,17 +295,11 @@ where
             }
         }
 
-        fn about_to_wait(
-            &mut self,
-            event_loop: &dyn winit::event_loop::ActiveEventLoop,
-        ) {
+        fn about_to_wait(&mut self, event_loop: &dyn winit::event_loop::ActiveEventLoop) {
             self.process_event(event_loop, Some(Event::AboutToWait));
         }
 
-        fn can_create_surfaces(
-            &mut self,
-            event_loop: &dyn winit::event_loop::ActiveEventLoop,
-        ) {
+        fn can_create_surfaces(&mut self, event_loop: &dyn winit::event_loop::ActiveEventLoop) {
             // create initial window
             let Some(BootConfig {
                 sender,
@@ -336,9 +317,7 @@ where
             };
 
             #[cfg(not(target_arch = "wasm32"))]
-            if let Err(error) =
-                crate::futures::futures::executor::block_on(finish_boot)
-            {
+            if let Err(error) = crate::futures::futures::executor::block_on(finish_boot) {
                 self.error = Some(Error::GraphicsCreationFailed(error));
                 event_loop.exit();
             }
@@ -353,8 +332,7 @@ where
                     *is_booted.borrow_mut() = true;
                 });
 
-                event_loop
-                    .set_control_flow(winit::event_loop::ControlFlow::Poll);
+                event_loop.set_control_flow(winit::event_loop::ControlFlow::Poll);
             }
         }
     }
@@ -389,10 +367,8 @@ where
                                         ControlFlow::WaitUntil(current),
                                         ControlFlow::WaitUntil(new),
                                     ) if current < new => {}
-                                    (
-                                        ControlFlow::WaitUntil(target),
-                                        ControlFlow::Wait,
-                                    ) if target > Instant::now() => {}
+                                    (ControlFlow::WaitUntil(target), ControlFlow::Wait)
+                                        if target > Instant::now() => {}
                                     _ => {
                                         event_loop.set_control_flow(flow);
                                     }
@@ -406,31 +382,26 @@ where
                                 monitor,
                                 on_open,
                             } => {
-                                let exit_on_close_request =
-                                    settings.exit_on_close_request;
+                                let exit_on_close_request = settings.exit_on_close_request;
 
                                 let visible = settings.visible;
 
                                 #[cfg(target_arch = "wasm32")]
-                                let target =
-                                    settings.platform_specific.target.clone();
+                                let target = settings.platform_specific.target.clone();
                                 let resize_border = settings.resize_border;
-                                let window_attributes =
-                                    conversion::window_attributes(
-                                        settings,
-                                        &title,
-                                        scale_factor,
-                                        monitor
-                                            .or(event_loop.primary_monitor()),
-                                        self.id.clone(),
-                                    )
-                                    .with_visible(false);
+                                let window_attributes = conversion::window_attributes(
+                                    settings,
+                                    &title,
+                                    scale_factor,
+                                    monitor.or(event_loop.primary_monitor()),
+                                    self.id.clone(),
+                                )
+                                .with_visible(false);
 
                                 #[cfg(target_arch = "wasm32")]
                                 let window_attributes = {
                                     use winit::platform::web::WindowAttributesExtWebSys;
-                                    window_attributes
-                                        .with_canvas(self.canvas.take())
+                                    window_attributes.with_canvas(self.canvas.take())
                                 };
 
                                 log::info!(
@@ -444,8 +415,7 @@ where
                                 let mut window_attributes = window_attributes;
 
                                 #[cfg(target_os = "macos")]
-                                let position =
-                                    window_attributes.position.take();
+                                let position = window_attributes.position.take();
 
                                 let window = event_loop
                                     .create_window(window_attributes)
@@ -460,9 +430,7 @@ where
                                 {
                                     use winit::platform::web::WindowExtWebSys;
 
-                                    let canvas = window
-                                        .canvas()
-                                        .expect("Get window canvas");
+                                    let canvas = window.canvas().expect("Get window canvas");
 
                                     let _ = canvas.set_attribute(
                                         "style",
@@ -474,34 +442,26 @@ where
                                     let body = document.body().unwrap();
 
                                     let target = target.and_then(|target| {
-                                        body.query_selector(&format!(
-                                            "#{target}"
-                                        ))
-                                        .ok()
-                                        .unwrap_or(None)
+                                        body.query_selector(&format!("#{target}"))
+                                            .ok()
+                                            .unwrap_or(None)
                                     });
 
                                     match target {
                                         Some(node) => {
-                                            let _ = node
-                                                .replace_with_with_node_1(
-                                                    &canvas,
-                                                )
-                                                .expect(&format!(
-                                                    "Could not replace #{}",
-                                                    node.id()
-                                                ));
+                                            let _ = node.replace_with_with_node_1(&canvas).expect(
+                                                &format!("Could not replace #{}", node.id()),
+                                            );
                                         }
                                         None => {
                                             let _ = body
                                                 .append_child(&canvas)
-                                                .expect(
-                                                "Append canvas to HTML body",
-                                            );
+                                                .expect("Append canvas to HTML body");
                                         }
                                     };
                                 }
-                                let window: Arc<dyn winit::window::Window + 'static> = Arc::from(window);
+                                let window: Arc<dyn winit::window::Window + 'static> =
+                                    Arc::from(window);
                                 #[cfg(feature = "a11y")]
                                 self.init_adapter(event_loop, id, window.clone());
 
@@ -517,16 +477,10 @@ where
                                     }),
                                 );
                                 #[cfg(feature = "a11y")]
-                                self.process_event(
-                                    event_loop,
-                                    Some(Event::A11yAdapter(id)),
-                                );
+                                self.process_event(event_loop, Some(Event::A11yAdapter(id)));
                             }
                             Control::Exit => {
-                                self.process_event(
-                                    event_loop,
-                                    Some(Event::Exit),
-                                );
+                                self.process_event(event_loop, Some(Event::Exit));
                                 event_loop.exit();
                                 break;
                             }
@@ -538,10 +492,7 @@ where
                                 #[cfg(target_os = "macos")]
                                 {
                                     use winit::platform::macos::ActiveEventLoopExtMacOS;
-                                    event_loop
-                                        .set_allows_automatic_window_tabbing(
-                                            _enabled,
-                                        );
+                                    event_loop.set_allows_automatic_window_tabbing(_enabled);
                                 }
                             }
                             Control::Dnd(e) => {
@@ -562,9 +513,7 @@ where
                                 );
                             }
                             Control::PlatformSpecific(e) => {
-                                self.sender
-                                    .start_send(Event::PlatformSpecific(e))
-                                    .unwrap();
+                                self.sender.start_send(Event::PlatformSpecific(e)).unwrap();
                             }
                             Control::AboutToWait => {
                                 self.sender
@@ -574,52 +523,40 @@ where
                             Control::Winit(id, e) => {
                                 #[cfg(all(feature = "cctk", target_os = "linux"))]
                                 {
-                                    if matches!(e, WindowEvent::RedrawRequested)
-                                    {                    
-                                        
+                                    if matches!(e, WindowEvent::RedrawRequested) {
                                         for id in crate::subsurface_widget::subsurface_ids(id) {
-                                            _ = self.sender
-                                                .unbounded_send(Event::Winit(
+                                            _ = self.sender.unbounded_send(Event::Winit(
                                                 id,
                                                 WindowEvent::RedrawRequested,
                                             ));
                                         }
-                                    } else if matches!(
-                                        e,
-                                        WindowEvent::CloseRequested
-                                    ) {
+                                    } else if matches!(e, WindowEvent::CloseRequested) {
                                         for id in crate::subsurface_widget::subsurface_ids(id) {
-                                            _ = self.sender
-                                                .start_send(Event::Winit(
+                                            _ = self.sender.start_send(Event::Winit(
                                                 id,
                                                 WindowEvent::CloseRequested,
                                             ));
                                         }
                                     }
                                 }
-                                
+
                                 self.sender
                                     .start_send(Event::Winit(id, e))
                                     .expect("Send event");
                             }
                             Control::StartDnd => {
-                                self.sender
-                                    .start_send(Event::StartDnd)
-                                    .expect("Send event");
+                                self.sender.start_send(Event::StartDnd).expect("Send event");
                             }
                             #[cfg(feature = "a11y")]
                             Control::InitAdapter(id, window) => {
                                 self.init_adapter(event_loop, id, window);
-                            
-                                self.process_event(
-                                    event_loop,
-                                    Some(Event::A11yAdapter(id)),
-                                );
+
+                                self.process_event(event_loop, Some(Event::A11yAdapter(id)));
                             }
                             #[cfg(feature = "a11y")]
                             Control::Cleanup(id) => {
-                               _ = self.adapters.remove(&id);
-                            },
+                                _ = self.adapters.remove(&id);
+                            }
                         },
                         _ => {
                             break;
@@ -633,34 +570,35 @@ where
             }
         }
 
-    #[cfg(feature = "a11y")]
-    fn init_adapter(&mut self, event_loop: &(dyn winit::event_loop::ActiveEventLoop + 'static), id: core::window::Id, window: Arc<dyn winit::window::Window + 'static>) {
+        #[cfg(feature = "a11y")]
+        fn init_adapter(
+            &mut self,
+            event_loop: &(dyn winit::event_loop::ActiveEventLoop + 'static),
+            id: core::window::Id,
+            window: Arc<dyn winit::window::Window + 'static>,
+        ) {
             use crate::a11y::*;
             use iced_accessibility::accesskit::{
-                ActivationHandler, Node, NodeId, Role,
-                Tree, TreeUpdate,
+                ActivationHandler, Node, NodeId, Role, Tree, TreeUpdate,
             };
             use iced_accessibility::accesskit_winit::Adapter;
-        
-            let node_id =
-                iced_runtime::core::id::window_node_id();
-        
-            let activation_handler =
-                WinitActivationHandler {
-                    proxy: self.control_sender.clone(),
-                    title: String::new(),
-                };
-        
+
+            let node_id = iced_runtime::core::id::window_node_id();
+
+            let activation_handler = WinitActivationHandler {
+                proxy: self.control_sender.clone(),
+                title: String::new(),
+            };
+
             let action_handler = WinitActionHandler {
                 id,
                 proxy: self.control_sender.clone(),
             };
-        
-            let deactivation_handler =
-                WinitDeactivationHandler {
-                    proxy: self.control_sender.clone(),
-                };
-        
+
+            let deactivation_handler = WinitDeactivationHandler {
+                proxy: self.control_sender.clone(),
+            };
+
             _ = self.adapters.insert(
                 id,
                 (
@@ -674,8 +612,6 @@ where
                     ),
                 ),
             );
-        
-            
         }
     }
 
@@ -768,8 +704,7 @@ async fn run_instance<P>(
 
     _ = boot.await.expect("Receive boot");
 
-    let mut platform_specific_handler =
-        crate::platform_specific::PlatformSpecific::default();
+    let mut platform_specific_handler = crate::platform_specific::PlatformSpecific::default();
     #[cfg(all(feature = "cctk", target_os = "linux"))]
     if is_wayland {
         platform_specific_handler = platform_specific_handler.with_wayland(
@@ -795,9 +730,7 @@ async fn run_instance<P>(
     let mut clipboard = Clipboard::unconnected();
     let mut cur_dnd_surface: Option<window::Id> = None;
 
-    let mut dnd_surface: Option<
-        Arc<Box<dyn HasWindowHandle + Send + Sync + 'static>>,
-    > = None;
+    let mut dnd_surface: Option<Arc<Box<dyn HasWindowHandle + Send + Sync + 'static>>> = None;
     let mut dnd_surface_id: Option<window::Id> = None;
 
     #[cfg(feature = "a11y")]
@@ -833,8 +766,7 @@ async fn run_instance<P>(
     };
 
     #[cfg(not(all(feature = "linux-theme-detection", target_os = "linux")))]
-    let mut system_theme =
-        _system_theme.try_recv().ok().flatten().unwrap_or_default();
+    let mut system_theme = _system_theme.try_recv().ok().flatten().unwrap_or_default();
 
     log::info!("System theme: {system_theme:?}");
 
@@ -857,13 +789,11 @@ async fn run_instance<P>(
                 exit_on_close_request,
                 make_visible,
                 on_open,
-                resize_border
+                resize_border,
             } => {
-                
                 #[cfg(all(feature = "cctk", target_os = "linux"))]
-                platform_specific_handler.send_wayland(
-                    platform_specific::Action::TrackWindow(window.clone(), id),
-                );
+                platform_specific_handler
+                    .send_wayland(platform_specific::Action::TrackWindow(window.clone(), id));
                 match create_compositor::<P>(
                     window.clone(),
                     CreateCompositor {
@@ -881,9 +811,7 @@ async fn run_instance<P>(
                     }
                     Err(error) => {
                         control_sender
-                            .start_send(Control::Crash(
-                                Error::GraphicsCreationFailed(error),
-                            ))
+                            .start_send(Control::Crash(Error::GraphicsCreationFailed(error)))
                             .expect("Send control message");
                         continue;
                     }
@@ -897,15 +825,12 @@ async fn run_instance<P>(
                 if system_theme != window_theme {
                     system_theme = window_theme;
 
-                    runtime.broadcast(subscription::Event::SystemThemeChanged(
-                        window_theme,
-                    ));
+                    runtime.broadcast(subscription::Event::SystemThemeChanged(window_theme));
                 }
 
                 let is_first = window_manager.is_empty();
-                let compositor: &mut <<P as Program>::Renderer as compositor::Default >::Compositor = compositor
-                    .as_mut()
-                    .expect("Compositor must be initialized");
+                let compositor: &mut <<P as Program>::Renderer as compositor::Default>::Compositor =
+                    compositor.as_mut().expect("Compositor must be initialized");
                 let window = window_manager.insert(
                     id,
                     window,
@@ -913,12 +838,12 @@ async fn run_instance<P>(
                     compositor,
                     exit_on_close_request,
                     system_theme,
-                    resize_border
+                    resize_border,
                 );
 
-                window.raw.set_theme(conversion::window_theme(
-                    window.state.theme_mode(),
-                ));
+                window
+                    .raw
+                    .set_theme(conversion::window_theme(window.state.theme_mode()));
 
                 debug::theme_changed(|| {
                     if is_first {
@@ -975,9 +900,7 @@ async fn run_instance<P>(
                     window.raw.request_redraw();
                 }
             }
-            Event::NewEvents(event::StartCause::ResumeTimeReached {
-                ..
-            }) => {
+            Event::NewEvents(event::StartCause::ResumeTimeReached { .. }) => {
                 let now = Instant::now();
 
                 for (_id, window) in window_manager.iter_mut() {
@@ -990,12 +913,10 @@ async fn run_instance<P>(
                 }
 
                 if let Some(redraw_at) = window_manager.redraw_at() {
-                    let _ = control_sender.start_send(Control::ChangeFlow(
-                        ControlFlow::WaitUntil(redraw_at),
-                    ));
-                } else {
                     let _ = control_sender
-                        .start_send(Control::ChangeFlow(ControlFlow::Wait));
+                        .start_send(Control::ChangeFlow(ControlFlow::WaitUntil(redraw_at)));
+                } else {
+                    let _ = control_sender.start_send(Control::ChangeFlow(ControlFlow::Wait));
                 }
             }
             Event::UserEvent(action) => {
@@ -1025,9 +946,7 @@ async fn run_instance<P>(
                     continue;
                 };
 
-                let Some((id, mut window))  =
-                    window_manager.get_mut_alias(window_id)
-                else {
+                let Some((id, mut window)) = window_manager.get_mut_alias(window_id) else {
                     continue;
                 };
                 window.redraw_requested = false;
@@ -1040,16 +959,15 @@ async fn run_instance<P>(
                         ))
                         .expect("Send redraw event");
                     continue;
-                } 
+                }
                 // XX must force update to corner radius before the surface is committed.
                 #[cfg(all(feature = "cctk", target_os = "linux"))]
                 if (window.surface_version != window.state.surface_version()
-                    || window.logical_size() != window.state.logical_size()
-                    ) && !crate::subsurface_widget::is_subsurface(window_id)
+                    || window.logical_size() != window.state.logical_size())
+                    && !crate::subsurface_widget::is_subsurface(window_id)
                 {
-                    platform_specific_handler.send_wayland(
-                        platform_specific::Action::ResizeWindow(id),
-                    );
+                    platform_specific_handler
+                        .send_wayland(platform_specific::Action::ResizeWindow(id));
                     window.redraw_requested = true;
                     control_sender
                         .start_send(Control::Winit(
@@ -1069,15 +987,11 @@ async fn run_instance<P>(
 
                 // Window was resized between redraws
                 if window.surface_version != window.state.surface_version() {
-                    let ui = user_interfaces
-                        .remove(&id)
-                        .expect("Remove user interface");
+                    let ui = user_interfaces.remove(&id).expect("Remove user interface");
 
                     let layout_span = debug::layout(id);
-                    let _ = user_interfaces.insert(
-                        id,
-                        ui.relayout(logical_size, &mut window.renderer),
-                    );
+                    let _ =
+                        user_interfaces.insert(id, ui.relayout(logical_size, &mut window.renderer));
                     layout_span.finish();
 
                     current_compositor.configure_surface(
@@ -1089,14 +1003,12 @@ async fn run_instance<P>(
                     window.surface_version = window.state.surface_version();
                 }
 
-                let redraw_event = core::Event::Window(
-                    window::Event::RedrawRequested(Instant::now()),
-                );
+                let redraw_event =
+                    core::Event::Window(window::Event::RedrawRequested(Instant::now()));
 
                 let cursor = window.state.cursor();
 
-                let mut interface =
-                    user_interfaces.get_mut(&id).expect("Get user interface");
+                let mut interface = user_interfaces.get_mut(&id).expect("Get user interface");
 
                 let interact_span = debug::interact(id);
                 let mut redraw_count = 0;
@@ -1111,9 +1023,7 @@ async fn run_instance<P>(
                         &mut messages,
                     );
 
-                    if message_count == messages.len()
-                        && !state.has_layout_changed()
-                    {
+                    if message_count == messages.len() && !state.has_layout_changed() {
                         break state;
                     }
 
@@ -1129,24 +1039,19 @@ async fn run_instance<P>(
                     redraw_count += 1;
 
                     if !messages.is_empty() {
-                        let caches: FxHashMap<_, _> =
-                            ManuallyDrop::into_inner(user_interfaces)
-                                .into_iter()
-                                .map(|(id, interface)| {
-                                    (id, interface.into_cache())
-                                })
-                                .collect();
+                        let caches: FxHashMap<_, _> = ManuallyDrop::into_inner(user_interfaces)
+                            .into_iter()
+                            .map(|(id, interface)| (id, interface.into_cache()))
+                            .collect();
 
-                        let actions =
-                            update(&mut program, &mut runtime, &mut messages);
+                        let actions = update(&mut program, &mut runtime, &mut messages);
 
-                        user_interfaces =
-                            ManuallyDrop::new(build_user_interfaces(
-                                &program,
-                                &mut window_manager,
-                                caches,
-                                &mut clipboard,
-                            ));
+                        user_interfaces = ManuallyDrop::new(build_user_interfaces(
+                            &program,
+                            &mut window_manager,
+                            caches,
+                            &mut clipboard,
+                        ));
 
                         for action in actions {
                             // Defer all window actions to avoid compositor
@@ -1194,19 +1099,13 @@ async fn run_instance<P>(
                         if logical_size != window.state.logical_size() {
                             logical_size = window.state.logical_size();
 
-                            log::debug!(
-                                "Window scale factor changed during a redraw request"
-                            );
+                            log::debug!("Window scale factor changed during a redraw request");
 
-                            let ui = user_interfaces
-                                .remove(&id)
-                                .expect("Remove user interface");
+                            let ui = user_interfaces.remove(&id).expect("Remove user interface");
 
                             let layout_span = debug::layout(id);
-                            let _ = user_interfaces.insert(
-                                id,
-                                ui.relayout(logical_size, &mut window.renderer),
-                            );
+                            let _ = user_interfaces
+                                .insert(id, ui.relayout(logical_size, &mut window.renderer));
                             layout_span.finish();
                         }
 
@@ -1226,8 +1125,7 @@ async fn run_instance<P>(
                     },
                     cursor,
                 );
-                platform_specific_handler
-                    .update_subsurfaces(id, window.raw.rwh_06_window_handle());
+                platform_specific_handler.update_subsurfaces(id, window.raw.rwh_06_window_handle());
                 draw_span.finish();
 
                 if let user_interface::State::Updated {
@@ -1266,20 +1164,18 @@ async fn run_instance<P>(
                             // This is an unrecoverable error.
                             panic!("{error:?}");
                         }
-                        compositor::SurfaceError::Outdated
-                        | compositor::SurfaceError::Lost => {
+                        compositor::SurfaceError::Outdated | compositor::SurfaceError::Lost => {
                             present_span.finish();
 
                             // Reconfigure surface and try redrawing
                             let physical_size = window.state.physical_size();
 
                             if error == compositor::SurfaceError::Lost {
-                                window.surface = current_compositor
-                                    .create_surface(
-                                        window.raw.clone(),
-                                        physical_size.width,
-                                        physical_size.height,
-                                    );
+                                window.surface = current_compositor.create_surface(
+                                    window.raw.clone(),
+                                    physical_size.width,
+                                    physical_size.height,
+                                );
                             } else {
                                 current_compositor.configure_surface(
                                     &mut window.surface,
@@ -1320,15 +1216,11 @@ async fn run_instance<P>(
                     continue;
                 }
 
-                let Some((id, window)) =
-                    window_manager.get_mut_alias(window_id)
-                else {
+                let Some((id, window)) = window_manager.get_mut_alias(window_id) else {
                     continue;
                 };
                 // Initiates a drag resize window state when found.
-                if let Some(func) =
-                    window.drag_resize_window_func.as_mut()
-                {
+                if let Some(func) = window.drag_resize_window_func.as_mut() {
                     if func(window.raw.as_ref(), &event) {
                         continue;
                     }
@@ -1343,9 +1235,7 @@ async fn run_instance<P>(
                         if mode != system_theme {
                             system_theme = mode;
 
-                            runtime.broadcast(
-                                subscription::Event::SystemThemeChanged(mode),
-                            );
+                            runtime.broadcast(subscription::Event::SystemThemeChanged(mode));
                         }
                     }
                     _ => {}
@@ -1429,8 +1319,7 @@ async fn run_instance<P>(
                             &mut clipboard,
                             &mut messages,
                         );
-                    let mut needs_redraw =
-                        !no_window_events || !messages.is_empty();
+                    let mut needs_redraw = !no_window_events || !messages.is_empty();
                     if let Some(requested_size) =
                         clipboard.requested_logical_size.lock().unwrap().take()
                     {
@@ -1442,17 +1331,14 @@ async fn run_instance<P>(
 
                         let physical_size = window.state.physical_size();
                         if requested_physical_size.width != physical_size.width
-                            || requested_physical_size.height
-                                != physical_size.height
+                            || requested_physical_size.height != physical_size.height
                         {
                             // FIXME what to do when we are stuck in a configure event/resize request loop
                             // We don't have control over how winit handles this.
                             window.resize_enabled = true;
                             resized = true;
                             needs_redraw = true;
-                            let s = winit::dpi::Size::Logical(
-                                requested_size.cast(),
-                            );
+                            let s = winit::dpi::Size::Logical(requested_size.cast());
                             _ = window.raw.request_surface_size(s);
                             window.raw.set_min_surface_size(Some(s));
                             window.raw.set_max_surface_size(Some(s));
@@ -1460,15 +1346,9 @@ async fn run_instance<P>(
                             window.state.update(
                                 &program,
                                 window.raw.as_ref(),
-                                &WindowEvent::SurfaceResized(
-                                    requested_physical_size,
-                                ),
+                                &WindowEvent::SurfaceResized(requested_physical_size),
                             );
-                            window.state.synchronize(
-                                &program,
-                                id,
-                                window.raw.as_ref(),
-                            );
+                            window.state.synchronize(&program, id, window.raw.as_ref());
                         }
                     }
 
@@ -1476,9 +1356,7 @@ async fn run_instance<P>(
                     window.request_redraw(window::RedrawRequest::NextFrame);
 
                     if needs_redraw {
-                        window.request_redraw(
-                            core::window::RedrawRequest::NextFrame,
-                        );
+                        window.request_redraw(core::window::RedrawRequest::NextFrame);
                     }
                     match ui_state {
                         user_interface::State::Updated {
@@ -1496,9 +1374,7 @@ async fn run_instance<P>(
                         }
                     }
 
-                    for (event, status) in
-                        window_events.into_iter().zip(statuses.into_iter())
-                    {
+                    for (event, status) in window_events.into_iter().zip(statuses.into_iter()) {
                         runtime.broadcast(subscription::Event::Interaction {
                             window: id,
                             event,
@@ -1518,8 +1394,7 @@ async fn run_instance<P>(
                                 | core::Event::Mouse(_)
                         )
                     {
-                        _ = control_sender
-                            .start_send(Control::ChangeFlow(ControlFlow::Wait));
+                        _ = control_sender.start_send(Control::ChangeFlow(ControlFlow::Wait));
                         continue;
                     }
                     runtime.broadcast(subscription::Event::Interaction {
@@ -1536,8 +1411,7 @@ async fn run_instance<P>(
                             .map(|(id, ui)| (id, ui.into_cache()))
                             .collect();
 
-                    let actions =
-                        update(&mut program, &mut runtime, &mut messages);
+                    let actions = update(&mut program, &mut runtime, &mut messages);
 
                     user_interfaces = ManuallyDrop::new(build_user_interfaces(
                         &program,
@@ -1569,8 +1443,7 @@ async fn run_instance<P>(
                     }
 
                     platform_specific_handler.retain_subsurfaces(|id| {
-                        window_manager.get(id).is_some()
-                            || dnd_surface_id == Some(id)
+                        window_manager.get(id).is_some() || dnd_surface_id == Some(id)
                     });
 
                     for (_id, window) in window_manager.iter_mut() {
@@ -1587,12 +1460,10 @@ async fn run_instance<P>(
                     }
                 }
                 if let Some(redraw_at) = window_manager.redraw_at() {
-                    let _ = control_sender.start_send(Control::ChangeFlow(
-                        ControlFlow::WaitUntil(redraw_at),
-                    ));
-                } else {
                     let _ = control_sender
-                        .start_send(Control::ChangeFlow(ControlFlow::Wait));
+                        .start_send(Control::ChangeFlow(ControlFlow::WaitUntil(redraw_at)));
+                } else {
+                    let _ = control_sender.start_send(Control::ChangeFlow(ControlFlow::Wait));
                 }
             }
             Event::Exit => {
@@ -1610,27 +1481,22 @@ async fn run_instance<P>(
                         // the data event comes after
                         // cur_dnd_surface = None;
                     }
-                    dnd::DndEvent::Offer(
-                        _,
-                        dnd::OfferEvent::Enter { surface, .. },
-                    ) => {
+                    dnd::DndEvent::Offer(_, dnd::OfferEvent::Enter { surface, .. }) => {
                         let window_handle = surface.0.window_handle().ok();
-                        let window_id = window_manager.iter_mut().find_map(
-                            |(id, window)| {
-                                if window
-                                    .raw
-                                    .window_handle()
-                                    .ok()
-                                    .zip(window_handle)
-                                    .map(|(a, b)| a == b)
-                                    .unwrap_or_default()
-                                {
-                                    Some(id)
-                                } else {
-                                    None
-                                }
-                            },
-                        );
+                        let window_id = window_manager.iter_mut().find_map(|(id, window)| {
+                            if window
+                                .raw
+                                .window_handle()
+                                .ok()
+                                .zip(window_handle)
+                                .map(|(a, b)| a == b)
+                                .unwrap_or_default()
+                            {
+                                Some(id)
+                            } else {
+                                None
+                            }
+                        });
                         cur_dnd_surface = window_id;
                         events.push((cur_dnd_surface, core::Event::Dnd(e)));
                     }
@@ -1639,8 +1505,7 @@ async fn run_instance<P>(
                     }
                     dnd::DndEvent::Source(evt) => {
                         match evt {
-                            dnd::SourceEvent::Finished
-                            | dnd::SourceEvent::Cancelled => {
+                            dnd::SourceEvent::Finished | dnd::SourceEvent::Cancelled => {
                                 dnd_surface_id = None;
                                 dnd_surface = None;
                             }
@@ -1706,23 +1571,16 @@ async fn run_instance<P>(
                     let Some(window_id) = source_surface.and_then(|source| {
                         match source {
                             core::clipboard::DndSource::Surface(s) => {
-                                log::trace!(
-                                    "start_dnd: using explicit surface {:?}",
-                                    s
-                                );
+                                log::trace!("start_dnd: using explicit surface {:?}", s);
                                 Some(s)
                             }
                             core::clipboard::DndSource::Widget(w) => {
-                                log::trace!(
-                                    "start_dnd: searching for widget {:?}",
-                                    w
-                                );
+                                log::trace!("start_dnd: searching for widget {:?}", w);
                                 // if user intefaces is just 1 len, use the single id instead of wasting time searching
-                                let result = if user_interfaces.len() ==1 {
+                                let result = if user_interfaces.len() == 1 {
                                     user_interfaces.keys().next().cloned()
                                 } else {
-                                    user_interfaces.iter_mut().find_map(
-                                    |(ui_id, ui)| {
+                                    user_interfaces.iter_mut().find_map(|(ui_id, ui)| {
                                         let Some(ui_renderer) = window_manager
                                             .get_mut(ui_id.clone())
                                             .map(|w| &w.renderer)
@@ -1730,49 +1588,34 @@ async fn run_instance<P>(
                                             return None;
                                         };
 
-                                        let operation: Box<
-                                            dyn operation::Operation<()>,
-                                        > = Box::new(operation::map(
-                                            Box::new(
-                                                operation::search_id::search_id(
+                                        let operation: Box<dyn operation::Operation<()>> =
+                                            Box::new(operation::map(
+                                                Box::new(operation::search_id::search_id(
                                                     w.clone(),
-                                                ),
-                                            ),
-                                            |_| {},
-                                        ));
-                                        let mut current_operation =
-                                            Some(operation);
+                                                )),
+                                                |_| {},
+                                            ));
+                                        let mut current_operation = Some(operation);
 
-                                        while let Some(mut operation) =
-                                            current_operation.take()
-                                        {
-                                            ui.operate(
-                                                ui_renderer,
-                                                operation.as_mut(),
-                                            );
+                                        while let Some(mut operation) = current_operation.take() {
+                                            ui.operate(ui_renderer, operation.as_mut());
 
                                             match operation.finish() {
                                                 operation::Outcome::None => {}
-                                                operation::Outcome::Some(
-                                                    (),
-                                                ) => {
+                                                operation::Outcome::Some(()) => {
                                                     return Some(ui_id.clone());
                                                 }
-                                                operation::Outcome::Chain(
-                                                    next,
-                                                ) => {
-                                                    current_operation =
-                                                        Some(next);
+                                                operation::Outcome::Chain(next) => {
+                                                    current_operation = Some(next);
                                                 }
                                             }
                                         }
                                         None
-                                    },
-                                )
+                                    })
                                 };
 
                                 // search windows for widget with operation
-                                 
+
                                 if result.is_none() {
                                     log::warn!(
                                         "start_dnd: widget {:?} not found; drag will fail",
@@ -1795,8 +1638,7 @@ async fn run_instance<P>(
                     let state = &window.state;
                     let mut dnd_buffer = None;
                     let icon_surface = icon_surface.map(|i| {
-                        let mut icon_surface =
-                            i.downcast::<P::Theme, P::Renderer>();
+                        let mut icon_surface = i.downcast::<P::Theme, P::Renderer>();
 
                         let mut renderer = compositor.create_renderer();
 
@@ -1812,10 +1654,7 @@ async fn run_instance<P>(
                             id: icon_surface.element.as_widget().id(),
                             tag: icon_surface.element.as_widget().tag(),
                             state: icon_surface.state,
-                            children: icon_surface
-                                .element
-                                .as_widget()
-                                .children(),
+                            children: icon_surface.element.as_widget().children(),
                         };
 
                         let size = icon_surface
@@ -1824,16 +1663,12 @@ async fn run_instance<P>(
                             .layout(&mut tree, &renderer, &lim);
                         icon_surface.element.as_widget_mut().diff(&mut tree);
 
-                        let size = lim.resolve(
-                            core::Length::Shrink,
-                            core::Length::Shrink,
-                            size.size(),
+                        let size =
+                            lim.resolve(core::Length::Shrink, core::Length::Shrink, size.size());
+                        let viewport = iced_graphics::Viewport::with_logical_size(
+                            size,
+                            state.viewport().scale_factor(),
                         );
-                        let viewport =
-                            iced_graphics::Viewport::with_logical_size(
-                                size,
-                                state.viewport().scale_factor(),
-                            );
 
                         let mut ui = UserInterface::build(
                             icon_surface.element,
@@ -1861,13 +1696,10 @@ async fn run_instance<P>(
                             pix.swap(0, 2);
                         }
                         // update subsurfaces
-                        if let Some(surface) =
-                            platform_specific_handler.create_surface()
-                        {
+                        if let Some(surface) = platform_specific_handler.create_surface() {
                             // TODO Remove id
                             let id = window::Id::unique();
-                            platform_specific_handler
-                                .update_subsurfaces(id, &surface);
+                            platform_specific_handler.update_subsurfaces(id, &surface);
                             let surface = Arc::new(surface);
                             dnd_surface = Some(surface.clone());
                             dnd_surface_id = Some(id);
@@ -1946,10 +1778,7 @@ async fn create_compositor<'a, P>(
         default_fonts,
         runtime,
     }: CreateCompositor<'a, P>,
-) -> Result<
-    <<P as Program>::Renderer as compositor::Default>::Compositor,
-    iced_graphics::Error,
->
+) -> Result<<<P as Program>::Renderer as compositor::Default>::Compositor, iced_graphics::Error>
 where
     P: Program,
 {
@@ -1965,14 +1794,13 @@ where
         async move {
             let shell = Shell::new(proxy.clone());
 
-            let mut compositor =
-                <P::Renderer as compositor::Default>::Compositor::new(
-                    graphics_settings,
-                    display_handle,
-                    window,
-                    shell,
-                )
-                .await;
+            let mut compositor = <P::Renderer as compositor::Default>::Compositor::new(
+                graphics_settings,
+                display_handle,
+                window,
+                shell,
+            )
+            .await;
 
             if let Ok(compositor) = &mut compositor {
                 for font in default_fonts {
@@ -1991,9 +1819,7 @@ where
             {
                 let (sender, _receiver) = oneshot::channel();
 
-                proxy.send_action(Action::Window(
-                    runtime::window::Action::GetLatest(sender),
-                ));
+                proxy.send_action(Action::Window(runtime::window::Action::GetLatest(sender)));
             }
         }
     };
@@ -2029,11 +1855,10 @@ where
     let user_interface = UserInterface::build(view, size, cache, renderer);
     layout_span.finish();
 
-    let dnd_rectangles = user_interface
-        .dnd_rectangles(prev_dnd_destination_rectangles_count, renderer);
+    let dnd_rectangles =
+        user_interface.dnd_rectangles(prev_dnd_destination_rectangles_count, renderer);
     let new_dnd_rectangles_count = dnd_rectangles.as_ref().len();
-    if new_dnd_rectangles_count > 0 || prev_dnd_destination_rectangles_count > 0
-    {
+    if new_dnd_rectangles_count > 0 || prev_dnd_destination_rectangles_count > 0 {
         clipboard.register_dnd_destination(
             DndSurface(Arc::new(Box::new(raw.clone()))),
             dnd_rectangles.into_rectangles(),
@@ -2097,10 +1922,7 @@ fn run_action<'a, P, C>(
     messages: &mut Vec<P::Message>,
     clipboard: &mut Clipboard,
     control_sender: &mut mpsc::UnboundedSender<Control>,
-    interfaces: &mut FxHashMap<
-        window::Id,
-        UserInterface<'a, P::Message, P::Theme, P::Renderer>,
-    >,
+    interfaces: &mut FxHashMap<window::Id, UserInterface<'a, P::Message, P::Theme, P::Renderer>>,
     window_manager: &mut WindowManager<P, C>,
     ui_caches: &mut FxHashMap<window::Id, user_interface::Cache>,
     is_window_opening: &mut bool,
@@ -2148,7 +1970,7 @@ where
                         on_open: channel,
                     })
                     .expect("Send control action");
-                
+
                 *is_window_opening = true;
             }
             window::Action::Close(id) => {
@@ -2160,8 +1982,7 @@ where
                 }
                 let proxy = clipboard.proxy();
                 #[cfg(all(feature = "cctk", target_os = "linux"))]
-                platform_specific
-                    .send_wayland(platform_specific::Action::RemoveWindow(id));
+                platform_specific.send_wayland(platform_specific::Action::RemoveWindow(id));
                 if let Some(window) = window_manager.remove(id) {
                     clipboard.register_dnd_destination(
                         DndSurface(Arc::new(Box::new(window.raw.clone()))),
@@ -2184,10 +2005,7 @@ where
                             .unwrap_or_else(Clipboard::unconnected);
                     }
 
-                    events.push((
-                        Some(id),
-                        core::Event::Window(core::window::Event::Closed),
-                    ));
+                    events.push((Some(id), core::Event::Window(core::window::Event::Closed)));
                 }
 
                 if window_manager.is_empty() {
@@ -2195,14 +2013,12 @@ where
                 }
             }
             window::Action::GetOldest(channel) => {
-                let id =
-                    window_manager.iter_mut().next().map(|(id, _window)| id);
+                let id = window_manager.iter_mut().next().map(|(id, _window)| id);
 
                 let _ = channel.send(id);
             }
             window::Action::GetLatest(channel) => {
-                let id =
-                    window_manager.iter_mut().last().map(|(id, _window)| id);
+                let id = window_manager.iter_mut().last().map(|(id, _window)| id);
 
                 let _ = channel.send(id);
             }
@@ -2213,9 +2029,9 @@ where
             }
             window::Action::DragResize(id, direction) => {
                 if let Some(window) = window_manager.get_mut(id) {
-                    let _ = window.raw.drag_resize_window(
-                        conversion::resize_direction(direction),
-                    );
+                    let _ = window
+                        .raw
+                        .drag_resize_window(conversion::resize_direction(direction));
                 }
             }
             window::Action::Resize(id, size) => {
@@ -2253,15 +2069,15 @@ where
             }
             window::Action::SetResizeIncrements(id, increments) => {
                 if let Some(window) = window_manager.get_mut(id) {
-                    window.raw.set_surface_resize_increments(increments.map(
-                        |size| {
+                    window
+                        .raw
+                        .set_surface_resize_increments(increments.map(|size| {
                             winit::dpi::LogicalSize {
                                 width: size.width,
                                 height: size.height,
                             }
                             .into()
-                        },
-                    ));
+                        }));
                 }
             }
             window::Action::SetResizable(id, resizable) => {
@@ -2301,8 +2117,7 @@ where
                         .raw
                         .outer_position()
                         .map(|position: PhysicalPosition<i32>| {
-                            let position = position
-                                .to_logical::<f32>(window.raw.scale_factor());
+                            let position = position.to_logical::<f32>(window.raw.scale_factor());
 
                             Point::new(position.x, position.y)
                         })
@@ -2332,10 +2147,9 @@ where
             window::Action::SetMode(id, mode) => {
                 if let Some(window) = window_manager.get_mut(id) {
                     window.raw.set_visible(conversion::visible(mode));
-                    window.raw.set_fullscreen(conversion::fullscreen(
-                        window.raw.current_monitor(),
-                        mode,
-                    ));
+                    window
+                        .raw
+                        .set_fullscreen(conversion::fullscreen(window.raw.current_monitor(), mode));
                 }
             }
             window::Action::SetIcon(id, icon) => {
@@ -2366,9 +2180,9 @@ where
             }
             window::Action::RequestUserAttention(id, attention_type) => {
                 if let Some(window) = window_manager.get_mut(id) {
-                    window.raw.request_user_attention(
-                        attention_type.map(conversion::user_attention),
-                    );
+                    window
+                        .raw
+                        .request_user_attention(attention_type.map(conversion::user_attention));
                 }
             }
             window::Action::GainFocus(id) => {
@@ -2378,15 +2192,12 @@ where
             }
             window::Action::SetLevel(id, level) => {
                 if let Some(window) = window_manager.get_mut(id) {
-                    window
-                        .raw
-                        .set_window_level(conversion::window_level(level));
+                    window.raw.set_window_level(conversion::window_level(level));
                 }
             }
             window::Action::ShowSystemMenu(id) => {
                 if let Some(window) = window_manager.get_mut(id)
-                    && let mouse::Cursor::Available(point) =
-                        window.state.cursor()
+                    && let mouse::Cursor::Available(point) = window.state.cursor()
                 {
                     window.raw.show_window_menu(
                         winit::dpi::LogicalPosition {
@@ -2442,8 +2253,7 @@ where
                         .and_then(|m| m.current_video_mode())
                         .map(|monitor| {
                             let scale = window.state.scale_factor();
-                            let size =
-                                monitor.size().to_logical(f64::from(scale));
+                            let size = monitor.size().to_logical(f64::from(scale));
 
                             Size::new(size.width, size.height)
                         });
@@ -2466,10 +2276,7 @@ where
                     if let Some(ui) = interfaces.remove(&id) {
                         let _ = interfaces.insert(
                             id,
-                            ui.relayout(
-                                window.state.logical_size(),
-                                &mut window.renderer,
-                            ),
+                            ui.relayout(window.state.logical_size(), &mut window.renderer),
                         );
                     }
 
@@ -2519,9 +2326,7 @@ where
                 if mode != *system_theme {
                     *system_theme = mode;
 
-                    runtime.broadcast(subscription::Event::SystemThemeChanged(
-                        mode,
-                    ));
+                    runtime.broadcast(subscription::Event::SystemThemeChanged(mode));
                 }
 
                 let Some(theme) = conversion::window_theme(mode) else {
@@ -2562,12 +2367,9 @@ where
 
                 // TODO: Shared image cache in compositor
                 if let Some((_id, window)) = window_manager.iter_mut().next() {
-                    window.renderer.allocate_image(
-                        &handle,
-                        move |allocation| {
-                            let _ = sender.send(allocation);
-                        },
-                    );
+                    window.renderer.allocate_image(&handle, move |allocation| {
+                        let _ = sender.send(allocation);
+                    });
                 }
             }
         },
@@ -2701,9 +2503,7 @@ pub fn user_force_quit(
 }
 
 #[cfg(feature = "sysinfo")]
-fn system_information(
-    graphics: compositor::Information,
-) -> system::Information {
+fn system_information(graphics: compositor::Information) -> system::Information {
     use sysinfo::{Process, System};
 
     let mut system = System::new_all();
@@ -2733,7 +2533,3 @@ fn system_information(
         graphics_backend: graphics.backend,
     }
 }
-#[cfg(feature = "program")]
-pub use program::Program;
-
-pub use platform_specific::*;

--- a/winit/src/platform_specific/mod.rs
+++ b/winit/src/platform_specific/mod.rs
@@ -66,10 +66,7 @@ pub struct PlatformSpecific {
 }
 
 impl PlatformSpecific {
-    pub(crate) fn send_action(
-        &mut self,
-        action: iced_runtime::platform_specific::Action,
-    ) {
+    pub(crate) fn send_action(&mut self, action: iced_runtime::platform_specific::Action) {
         match action {
             #[cfg(all(feature = "cctk", target_os = "linux"))]
             iced_runtime::platform_specific::Action::Wayland(a) => {
@@ -78,10 +75,7 @@ impl PlatformSpecific {
         }
     }
 
-    pub(crate) fn retain_subsurfaces<F: Fn(window::Id) -> bool>(
-        &mut self,
-        keep: F,
-    ) {
+    pub(crate) fn retain_subsurfaces<F: Fn(window::Id) -> bool>(&mut self, keep: F) {
         #[cfg(all(feature = "cctk", target_os = "linux"))]
         {
             self.wayland.retain_subsurfaces(keep);
@@ -95,16 +89,10 @@ impl PlatformSpecific {
         }
     }
 
-    pub(crate) fn update_subsurfaces(
-        &mut self,
-        id: window::Id,
-        window: &dyn HasWindowHandle,
-    ) {
+    pub(crate) fn update_subsurfaces(&mut self, id: window::Id, window: &dyn HasWindowHandle) {
         #[cfg(all(feature = "cctk", target_os = "linux"))]
         {
-            use cctk::sctk::reexports::client::{
-                Proxy, protocol::wl_surface::WlSurface,
-            };
+            use cctk::sctk::reexports::client::{Proxy, protocol::wl_surface::WlSurface};
             use wayland_backend::client::ObjectId;
 
             let Some(conn) = self.wayland.conn() else {
@@ -117,9 +105,7 @@ impl PlatformSpecific {
                 return;
             };
             let wl_surface = match raw.as_raw() {
-                raw_window_handle::RawWindowHandle::Wayland(
-                    wayland_window_handle,
-                ) => {
+                raw_window_handle::RawWindowHandle::Wayland(wayland_window_handle) => {
                     let res = unsafe {
                         ObjectId::from_ptr(
                             WlSurface::interface(),
@@ -127,9 +113,7 @@ impl PlatformSpecific {
                         )
                     };
                     let Ok(id) = res else {
-                        log::error!(
-                            "Could not create WlSurface Id from window"
-                        );
+                        log::error!("Could not create WlSurface Id from window");
                         return;
                     };
                     let Ok(surface) = WlSurface::from_id(&conn, id) else {
@@ -169,9 +153,9 @@ impl PlatformSpecific {
     ) {
         #[cfg(all(feature = "cctk", target_os = "linux"))]
         {
-            return self.wayland.update_surface_shm(
-                surface, width, height, scale, data, offset,
-            );
+            return self
+                .wayland
+                .update_surface_shm(surface, width, height, scale, data, offset);
         }
     }
 }
@@ -181,9 +165,7 @@ pub(crate) async fn handle_event<'a, 'b, P>(
     events: &mut Vec<(Option<window::Id>, iced_runtime::core::Event)>,
     platform_specific: &mut PlatformSpecific,
     program: &'a crate::program::Instance<P>,
-    compositor: &mut Option<
-        <<P as Program>::Renderer as compositor::Default>::Compositor,
-    >,
+    compositor: &mut Option<<<P as Program>::Renderer as compositor::Default>::Compositor>,
     window_manager: &mut WindowManager<
         P,
         <<P as Program>::Renderer as compositor::Default>::Compositor,

--- a/winit/src/platform_specific/wayland/commands/activation.rs
+++ b/winit/src/platform_specific/wayland/commands/activation.rs
@@ -1,23 +1,18 @@
 use crate::core::window::Id as SurfaceId;
 use iced_runtime::{
-    self,
+    self, Action, Task,
     platform_specific::{self, wayland},
-    task, Action, Task,
+    task,
 };
 
-pub fn request_token(
-    app_id: Option<String>,
-    window: Option<SurfaceId>,
-) -> Task<Option<String>> {
+pub fn request_token(app_id: Option<String>, window: Option<SurfaceId>) -> Task<Option<String>> {
     task::oneshot(|channel| {
         Action::PlatformSpecific(platform_specific::Action::Wayland(
-            wayland::Action::Activation(
-                wayland::activation::Action::RequestToken {
-                    app_id,
-                    window,
-                    channel,
-                },
-            ),
+            wayland::Action::Activation(wayland::activation::Action::RequestToken {
+                app_id,
+                window,
+                channel,
+            }),
         ))
     })
 }

--- a/winit/src/platform_specific/wayland/commands/corner_radius.rs
+++ b/winit/src/platform_specific/wayland/commands/corner_radius.rs
@@ -1,17 +1,14 @@
 use iced_futures::core::window;
 use iced_runtime::{
-    self,
+    self, Action, Task,
     platform_specific::{
         self,
         wayland::{self, CornerRadius},
     },
-    task, Action, Task,
+    task,
 };
 
-pub fn corner_radius(
-    id: window::Id,
-    corners: Option<CornerRadius>,
-) -> Task<()> {
+pub fn corner_radius(id: window::Id, corners: Option<CornerRadius>) -> Task<()> {
     task::oneshot(|_| {
         Action::PlatformSpecific(platform_specific::Action::Wayland(
             wayland::Action::RoundedCorners(id, corners),

--- a/winit/src/platform_specific/wayland/commands/keyboard_shortcuts_inhibit.rs
+++ b/winit/src/platform_specific/wayland/commands/keyboard_shortcuts_inhibit.rs
@@ -1,7 +1,7 @@
 use iced_runtime::{
-    self,
+    self, Action, Task,
     platform_specific::{self, wayland},
-    task, Action, Task,
+    task,
 };
 
 pub fn inhibit_shortcuts(inhibit: bool) -> Task<()> {

--- a/winit/src/platform_specific/wayland/commands/layer_surface.rs
+++ b/winit/src/platform_specific/wayland/commands/layer_surface.rs
@@ -2,7 +2,7 @@
 
 use crate::core::window::Id as SurfaceId;
 use iced_runtime::{
-    self,
+    self, Action, Task,
     platform_specific::{
         self,
         wayland::{
@@ -10,16 +10,14 @@ use iced_runtime::{
             layer_surface::{IcedMargin, SctkLayerSurfaceSettings},
         },
     },
-    task, Action, Task,
+    task,
 };
 
 pub use cctk::sctk::shell::wlr_layer::{Anchor, KeyboardInteractivity, Layer};
 
 // TODO ASHLEY: maybe implement as builder that outputs a batched commands
 /// <https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_shell_v1:request:get_layer_surface>
-pub fn get_layer_surface<Message>(
-    builder: SctkLayerSurfaceSettings,
-) -> Task<Message> {
+pub fn get_layer_surface<Message>(builder: SctkLayerSurfaceSettings) -> Task<Message> {
     task::effect(Action::PlatformSpecific(
         platform_specific::Action::Wayland(wayland::Action::LayerSurface(
             wayland::layer_surface::Action::LayerSurface { builder },
@@ -37,11 +35,7 @@ pub fn destroy_layer_surface<Message>(id: SurfaceId) -> Task<Message> {
 }
 
 /// <https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:request:set_size>
-pub fn set_size<Message>(
-    id: SurfaceId,
-    width: Option<u32>,
-    height: Option<u32>,
-) -> Task<Message> {
+pub fn set_size<Message>(id: SurfaceId, width: Option<u32>, height: Option<u32>) -> Task<Message> {
     task::effect(Action::PlatformSpecific(
         platform_specific::Action::Wayland(wayland::Action::LayerSurface(
             wayland::layer_surface::Action::Size { id, width, height },

--- a/winit/src/platform_specific/wayland/commands/overlap_notify.rs
+++ b/winit/src/platform_specific/wayland/commands/overlap_notify.rs
@@ -1,14 +1,13 @@
 use iced_futures::core::window::Id;
 use iced_runtime::{
+    Action, Task,
     platform_specific::{self, wayland},
-    task, Action, Task,
+    task,
 };
 
 /// Request subscription for overlap notification events on the surface
 pub fn overlap_notify<Message>(id: Id, enable: bool) -> Task<Message> {
     task::effect(Action::PlatformSpecific(
-        platform_specific::Action::Wayland(wayland::Action::OverlapNotify(
-            id, enable,
-        )),
+        platform_specific::Action::Wayland(wayland::Action::OverlapNotify(id, enable)),
     ))
 }

--- a/winit/src/platform_specific/wayland/commands/popup.rs
+++ b/winit/src/platform_specific/wayland/commands/popup.rs
@@ -1,34 +1,32 @@
 //! Interact with the popups of your application.
 use crate::core::window::Id as SurfaceId;
 use iced_runtime::{
-    self,
+    self, Action, Task,
     platform_specific::{
         self,
         wayland::{self, popup::SctkPopupSettings},
     },
-    task, Action, Task,
+    task,
 };
 
 /// <https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:request:get_popup>
 /// <https://wayland.app/protocols/xdg-shell#xdg_surface:request:get_popup>
 pub fn get_popup<Message>(popup: SctkPopupSettings) -> Task<Message> {
     task::effect(Action::PlatformSpecific(
-        platform_specific::Action::Wayland(wayland::Action::Popup(
-            wayland::popup::Action::Popup { popup },
-        )),
+        platform_specific::Action::Wayland(wayland::Action::Popup(wayland::popup::Action::Popup {
+            popup,
+        })),
     ))
 }
 
 /// <https://wayland.app/protocols/xdg-shell#xdg_popup:request:reposition>
-pub fn set_size<Message>(
-    id: SurfaceId,
-    width: u32,
-    height: u32,
-) -> Task<Message> {
+pub fn set_size<Message>(id: SurfaceId, width: u32, height: u32) -> Task<Message> {
     task::effect(Action::PlatformSpecific(
-        platform_specific::Action::Wayland(wayland::Action::Popup(
-            wayland::popup::Action::Size { id, width, height },
-        )),
+        platform_specific::Action::Wayland(wayland::Action::Popup(wayland::popup::Action::Size {
+            id,
+            width,
+            height,
+        })),
     ))
 }
 

--- a/winit/src/platform_specific/wayland/commands/session_lock.rs
+++ b/winit/src/platform_specific/wayland/commands/session_lock.rs
@@ -1,9 +1,9 @@
 use crate::core::window::Id as SurfaceId;
 use cctk::sctk::reexports::client::protocol::wl_output::WlOutput;
 use iced_runtime::{
-    self,
+    self, Action, Task,
     platform_specific::{self, wayland},
-    task, Action, Task,
+    task,
 };
 
 pub fn lock<Message>() -> Task<Message> {
@@ -22,10 +22,7 @@ pub fn unlock<Message>() -> Task<Message> {
     ))
 }
 
-pub fn get_lock_surface<Message>(
-    id: SurfaceId,
-    output: WlOutput,
-) -> Task<Message> {
+pub fn get_lock_surface<Message>(id: SurfaceId, output: WlOutput) -> Task<Message> {
     task::effect(Action::PlatformSpecific(
         platform_specific::Action::Wayland(wayland::Action::SessionLock(
             wayland::session_lock::Action::LockSurface { id, output },

--- a/winit/src/platform_specific/wayland/commands/subsurface.rs
+++ b/winit/src/platform_specific/wayland/commands/subsurface.rs
@@ -1,17 +1,15 @@
 use crate::core::window::Id as SurfaceId;
 pub use cctk::sctk::shell::wlr_layer::{Anchor, KeyboardInteractivity, Layer};
 use iced_runtime::{
-    self,
+    self, Action, Task,
     platform_specific::{
         self,
         wayland::{self, subsurface::SctkSubsurfaceSettings},
     },
-    task, Action, Task,
+    task,
 };
 
-pub fn get_subsurface<Message>(
-    subsurface: SctkSubsurfaceSettings,
-) -> Task<Message> {
+pub fn get_subsurface<Message>(subsurface: SctkSubsurfaceSettings) -> Task<Message> {
     task::effect(Action::PlatformSpecific(
         platform_specific::Action::Wayland(wayland::Action::Subsurface(
             wayland::subsurface::Action::Subsurface { subsurface },
@@ -27,11 +25,7 @@ pub fn destroy_subsurface<Message>(id: SurfaceId) -> Task<Message> {
     ))
 }
 
-pub fn reposition_subsurface<Message>(
-    id: SurfaceId,
-    x: i32,
-    y: i32,
-) -> Task<Message> {
+pub fn reposition_subsurface<Message>(id: SurfaceId, x: i32, y: i32) -> Task<Message> {
     task::effect(Action::PlatformSpecific(
         platform_specific::Action::Wayland(wayland::Action::Subsurface(
             wayland::subsurface::Action::Reposition { id, x, y },

--- a/winit/src/platform_specific/wayland/conversion.rs
+++ b/winit/src/platform_specific/wayland/conversion.rs
@@ -2,9 +2,7 @@ use cctk::sctk::{
     reexports::client::protocol::wl_pointer::AxisSource,
     seat::{
         keyboard::Modifiers,
-        pointer::{
-            AxisScroll, BTN_EXTRA, BTN_LEFT, BTN_MIDDLE, BTN_RIGHT, BTN_SIDE,
-        },
+        pointer::{AxisScroll, BTN_EXTRA, BTN_LEFT, BTN_MIDDLE, BTN_RIGHT, BTN_SIDE},
     },
 };
 use iced_runtime::core::{

--- a/winit/src/platform_specific/wayland/event_loop/mod.rs
+++ b/winit/src/platform_specific/wayland/event_loop/mod.rs
@@ -7,14 +7,10 @@ use crate::platform_specific::SurfaceIdWrapper;
 use crate::{
     Control,
     futures::futures::channel::mpsc,
-    handlers::{
-        ext_background_effect, overlap::OverlapNotifyV1,
-        text_input::TextInputManager,
-    },
+    handlers::{ext_background_effect, overlap::OverlapNotifyV1, text_input::TextInputManager},
     platform_specific::wayland::{
         handlers::{
-            wp_fractional_scaling::FractionalScalingManager,
-            wp_viewporter::ViewporterState,
+            wp_fractional_scaling::FractionalScalingManager, wp_viewporter::ViewporterState,
         },
         sctk_event::SctkEvent,
     },
@@ -22,7 +18,8 @@ use crate::{
 };
 
 use cctk::{
-    cosmic_protocols::corner_radius::v1::client::cosmic_corner_radius_manager_v1::CosmicCornerRadiusManagerV1, sctk::reexports::calloop_wayland_source::WaylandSource, toplevel_info::ToplevelInfoState
+    cosmic_protocols::corner_radius::v1::client::cosmic_corner_radius_manager_v1::CosmicCornerRadiusManagerV1,
+    sctk::reexports::calloop_wayland_source::WaylandSource, toplevel_info::ToplevelInfoState,
 };
 use cctk::{
     sctk::{
@@ -32,9 +29,7 @@ use cctk::{
         output::OutputState,
         reexports::{
             calloop::{self, EventLoop},
-            client::{
-                ConnectError, Connection, Proxy, globals::registry_queue_init,
-            },
+            client::{ConnectError, Connection, Proxy, globals::registry_queue_init},
         },
         registry::RegistryState,
         seat::SeatState,
@@ -44,6 +39,7 @@ use cctk::{
     },
     toplevel_management::ToplevelManagerState,
 };
+use log::error;
 use raw_window_handle::HasDisplayHandle;
 use state::{FrameStatus, SctkWindow, send_event};
 #[cfg(feature = "a11y")]
@@ -52,10 +48,12 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
 };
-use log::error;
 use wayland_backend::client::Backend;
 use wayland_client::globals::GlobalError;
-use wayland_protocols::wp::{keyboard_shortcuts_inhibit::zv1::client::zwp_keyboard_shortcuts_inhibit_manager_v1, text_input::zv3::client::zwp_text_input_v3::{ContentHint, ContentPurpose}};
+use wayland_protocols::wp::{
+    keyboard_shortcuts_inhibit::zv1::client::zwp_keyboard_shortcuts_inhibit_manager_v1,
+    text_input::zv3::client::zwp_text_input_v3::{ContentHint, ContentPurpose},
+};
 use winit::{dpi::LogicalSize, event_loop::OwnedDisplayHandle, window::ImePurpose};
 
 use self::state::SctkState;
@@ -84,40 +82,31 @@ impl SctkEventLoop {
         winit_event_sender: mpsc::UnboundedSender<Control>,
         proxy: winit::event_loop::EventLoopProxy,
         display: OwnedDisplayHandle,
-    ) -> Result<
-        calloop::channel::Sender<super::Action>,
-        Box<dyn std::any::Any + std::marker::Send>,
-    > {
+    ) -> Result<calloop::channel::Sender<super::Action>, Box<dyn std::any::Any + std::marker::Send>>
+    {
         let Ok(dh) = display.display_handle() else {
             log::error!("Failed to get display handle");
             return Err(Box::new(Error::NoDisplayHandle));
         };
-        let raw_window_handle::RawDisplayHandle::Wayland(wayland_dh) =
-            dh.as_raw()
-        else {
+        let raw_window_handle::RawDisplayHandle::Wayland(wayland_dh) = dh.as_raw() else {
             log::error!("Display handle is not Wayland");
             return Err(Box::new(Error::NoWaylandDisplay));
         };
 
-        let backend = unsafe {
-            Backend::from_foreign_display(wayland_dh.display.as_ptr().cast())
-        };
+        let backend = unsafe { Backend::from_foreign_display(wayland_dh.display.as_ptr().cast()) };
         let connection = Connection::from_backend(backend);
 
         let (action_tx, action_rx) = calloop::channel::channel();
-        let res: std::thread::JoinHandle<Result<(), Error>> =
-            std::thread::spawn(move || {
-                let _display = connection.display();
-                let (globals, event_queue) =
-                    registry_queue_init(&connection).map_err(Error::Global)?;
-                let event_loop = calloop::EventLoop::<SctkState>::try_new()
-                    .map_err(Error::Calloop)?;
-                let loop_handle = event_loop.handle();
+        let res: std::thread::JoinHandle<Result<(), Error>> = std::thread::spawn(move || {
+            let _display = connection.display();
+            let (globals, event_queue) = registry_queue_init(&connection).map_err(Error::Global)?;
+            let event_loop = calloop::EventLoop::<SctkState>::try_new().map_err(Error::Calloop)?;
+            let loop_handle = event_loop.handle();
 
-                let qh = event_queue.handle();
-                let registry_state = RegistryState::new(&globals);
+            let qh = event_queue.handle();
+            let registry_state = RegistryState::new(&globals);
 
-                _ = loop_handle
+            _ = loop_handle
                 .insert_source(action_rx, |event, _, state| {
                     match event {
                         calloop::channel::Event::Msg(e) => match e {
@@ -285,45 +274,38 @@ impl SctkEventLoop {
                     }
                 })
                 .unwrap();
-                let wayland_source =
-                    WaylandSource::new(connection.clone(), event_queue);
+            let wayland_source = WaylandSource::new(connection.clone(), event_queue);
 
-                let wayland_dispatcher = calloop::Dispatcher::new(
-                    wayland_source,
-                    |_, queue, winit_state| queue.dispatch_pending(winit_state),
-                );
+            let wayland_dispatcher =
+                calloop::Dispatcher::new(wayland_source, |_, queue, winit_state| {
+                    queue.dispatch_pending(winit_state)
+                });
 
-                let _wayland_source_dispatcher = event_loop
-                    .handle()
-                    .register_dispatcher(wayland_dispatcher.clone())
-                    .unwrap();
+            let _wayland_source_dispatcher = event_loop
+                .handle()
+                .register_dispatcher(wayland_dispatcher.clone())
+                .unwrap();
 
-                let (viewporter_state, fractional_scaling_manager) =
-                    match FractionalScalingManager::new(&globals, &qh) {
-                        Ok(m) => {
-                            let viewporter_state: Option<ViewporterState> =
-                                match ViewporterState::new(&globals, &qh) {
-                                    Ok(s) => Some(s),
-                                    Err(e) => {
-                                        error!(
-                                            "Failed to initialize viewporter: {}",
-                                            e
-                                        );
-                                        None
-                                    }
-                                };
-                            (viewporter_state, Some(m))
-                        }
-                        Err(e) => {
-                            error!(
-                                "Failed to initialize fractional scaling manager: {}",
-                                e
-                            );
-                            (None, None)
-                        }
-                    };
+            let (viewporter_state, fractional_scaling_manager) =
+                match FractionalScalingManager::new(&globals, &qh) {
+                    Ok(m) => {
+                        let viewporter_state: Option<ViewporterState> =
+                            match ViewporterState::new(&globals, &qh) {
+                                Ok(s) => Some(s),
+                                Err(e) => {
+                                    error!("Failed to initialize viewporter: {}", e);
+                                    None
+                                }
+                            };
+                        (viewporter_state, Some(m))
+                    }
+                    Err(e) => {
+                        error!("Failed to initialize fractional scaling manager: {}", e);
+                        (None, None)
+                    }
+                };
 
-                let mut state = Self {
+            let mut state = Self {
                     event_loop,
                     state: SctkState {
                         connection,
@@ -405,154 +387,137 @@ impl SctkEventLoop {
                     },
                     _features: Default::default(),
                 };
-                let wl_compositor = state
+            let wl_compositor = state
+                .state
+                .registry_state
+                .bind_one(&state.state.queue_handle, 1..=6, GlobalData)
+                .unwrap();
+            let wl_subcompositor =
+                state
                     .state
                     .registry_state
-                    .bind_one(&state.state.queue_handle, 1..=6, GlobalData)
-                    .unwrap();
-                let wl_subcompositor = state.state.registry_state.bind_one(
-                    &state.state.queue_handle,
-                    1..=1,
-                    GlobalData,
-                );
-                let wp_viewporter = state.state.registry_state.bind_one(
-                    &state.state.queue_handle,
-                    1..=1,
-                    GlobalData,
-                );
-                let wl_shm = state
+                    .bind_one(&state.state.queue_handle, 1..=1, GlobalData);
+            let wp_viewporter =
+                state
                     .state
                     .registry_state
-                    .bind_one(&state.state.queue_handle, 1..=1, GlobalData)
-                    .unwrap();
-                let wp_dmabuf = state
-                    .state
-                    .registry_state
-                    .bind_one(&state.state.queue_handle, 2..=4, GlobalData)
-                    .ok();
-                let wp_alpha_modifier = state
-                    .state
-                    .registry_state
-                    .bind_one(&state.state.queue_handle, 1..=1, ())
-                    .ok();
+                    .bind_one(&state.state.queue_handle, 1..=1, GlobalData);
+            let wl_shm = state
+                .state
+                .registry_state
+                .bind_one(&state.state.queue_handle, 1..=1, GlobalData)
+                .unwrap();
+            let wp_dmabuf = state
+                .state
+                .registry_state
+                .bind_one(&state.state.queue_handle, 2..=4, GlobalData)
+                .ok();
+            let wp_alpha_modifier = state
+                .state
+                .registry_state
+                .bind_one(&state.state.queue_handle, 1..=1, ())
+                .ok();
 
-                if let (Ok(wl_subcompositor), Ok(wp_viewporter)) =
-                    (wl_subcompositor, wp_viewporter)
+            if let (Ok(wl_subcompositor), Ok(wp_viewporter)) = (wl_subcompositor, wp_viewporter) {
+                let subsurface_state = SubsurfaceState {
+                    wl_compositor,
+                    wl_subcompositor,
+                    wp_viewporter,
+                    wl_shm,
+                    wp_dmabuf,
+                    wp_alpha_modifier,
+                    qh: state.state.queue_handle.clone(),
+                    buffers: HashMap::new(),
+                    unmapped_subsurfaces: Vec::new(),
+                    new_iced_subsurfaces: Vec::new(),
+                };
+                state.state.subsurface_state = Some(subsurface_state.clone());
+                state::send_event(
+                    &state.state.events_sender,
+                    &state.state.proxy,
+                    SctkEvent::Subcompositor(subsurface_state),
+                );
+            } else {
+                log::warn!("Subsurfaces not supported.")
+            }
+
+            log::info!("SCTK setup complete.");
+            loop {
+                match state
+                    .state
+                    .events_sender
+                    .unbounded_send(Control::AboutToWait)
                 {
-                    let subsurface_state = SubsurfaceState {
-                        wl_compositor,
-                        wl_subcompositor,
-                        wp_viewporter,
-                        wl_shm,
-                        wp_dmabuf,
-                        wp_alpha_modifier,
-                        qh: state.state.queue_handle.clone(),
-                        buffers: HashMap::new(),
-                        unmapped_subsurfaces: Vec::new(),
-                        new_iced_subsurfaces: Vec::new(),
-                    };
-                    state.state.subsurface_state =
-                        Some(subsurface_state.clone());
-                    state::send_event(
-                        &state.state.events_sender,
-                        &state.state.proxy,
-                        SctkEvent::Subcompositor(subsurface_state),
-                    );
-                } else {
-                    log::warn!("Subsurfaces not supported.")
-                }
-
-                log::info!("SCTK setup complete.");
-                loop {
-                    match state
-                        .state
-                        .events_sender
-                        .unbounded_send(Control::AboutToWait)
-                    {
-                        Ok(_) => {}
-                        Err(err) => {
-                            log::error!(
-                                "SCTK failed to send Control::AboutToWait. {err:?}"
-                            );
-                            if state.state.events_sender.is_closed() {
-                                return Ok(());
-                            }
+                    Ok(_) => {}
+                    Err(err) => {
+                        log::error!("SCTK failed to send Control::AboutToWait. {err:?}");
+                        if state.state.events_sender.is_closed() {
+                            return Ok(());
                         }
                     }
+                }
 
-                    if let Err(err) =
-                        state.event_loop.dispatch(None, &mut state.state)
-                    {
-                        log::error!("SCTK dispatch error: {err}");
-                    }
-                    let had_events = !state.state.sctk_events.is_empty();
-                    let mut wake_up = had_events;
+                if let Err(err) = state.event_loop.dispatch(None, &mut state.state) {
+                    log::error!("SCTK dispatch error: {err}");
+                }
+                let had_events = !state.state.sctk_events.is_empty();
+                let mut wake_up = had_events;
 
-                    for s in
+                for s in state
+                    .state
+                    .layer_surfaces
+                    .iter()
+                    .map(|s| s.surface.wl_surface())
+                    .chain(state.state.popups.iter().map(|s| s.popup.wl_surface()))
+                    .chain(
                         state
                             .state
-                            .layer_surfaces
+                            .lock_surfaces
                             .iter()
-                            .map(|s| s.surface.wl_surface())
-                            .chain(
-                                state
-                                    .state
-                                    .popups
-                                    .iter()
-                                    .map(|s| s.popup.wl_surface()),
-                            )
-                            .chain(
-                                state.state.lock_surfaces.iter().map(|s| {
-                                    s.session_lock_surface.wl_surface()
-                                }),
-                            )
+                            .map(|s| s.session_lock_surface.wl_surface()),
+                    )
+                {
+                    let id = s.id();
+                    if state
+                        .state
+                        .frame_status
+                        .get(&id)
+                        .map(|v| !matches!(v, state::FrameStatus::Ready))
+                        .unwrap_or(true)
+                        || !state.state.id_map.contains_key(&id)
                     {
-                        let id = s.id();
-                        if state
+                        continue;
+                    }
+                    wake_up = true;
+
+                    _ = s.frame(&state.state.queue_handle, s.clone());
+                    _ = state.state.frame_status.remove(&id);
+                    _ = state.state.events_sender.unbounded_send(Control::Winit(
+                        winit::window::WindowId::from_raw(id.as_ptr() as usize),
+                        winit::event::WindowEvent::RedrawRequested,
+                    ));
+                }
+
+                for e in state.state.sctk_events.drain(..) {
+                    if let SctkEvent::Winit(id, e) = e {
+                        _ = state
                             .state
-                            .frame_status
-                            .get(&id)
-                            .map(|v| !matches!(v, state::FrameStatus::Ready))
-                            .unwrap_or(true)
-                            || !state.state.id_map.contains_key(&id)
-                        {
-                            continue;
-                        }
-                        wake_up = true;
-
-                        _ = s.frame(&state.state.queue_handle, s.clone());
-                        _ = state.state.frame_status.remove(&id);
-                        _ = state.state.events_sender.unbounded_send(
-                            Control::Winit(
-                                winit::window::WindowId::from_raw(
-                                    id.as_ptr() as usize
-                                ),
-                                winit::event::WindowEvent::RedrawRequested,
-                            ),
-                        );
-                    }
-
-                    for e in state.state.sctk_events.drain(..) {
-                        if let SctkEvent::Winit(id, e) = e {
-                            _ = state
-                                .state
-                                .events_sender
-                                .unbounded_send(Control::Winit(id, e));
-                        } else {
-                            _ =
-                                state
-                                    .state
-                                    .events_sender
-                                    .unbounded_send(Control::PlatformSpecific(
-                                    crate::platform_specific::Event::Wayland(e),
-                                ));
-                        }
-                    }
-                    if wake_up {
-                        state.state.proxy.wake_up();
+                            .events_sender
+                            .unbounded_send(Control::Winit(id, e));
+                    } else {
+                        _ = state
+                            .state
+                            .events_sender
+                            .unbounded_send(Control::PlatformSpecific(
+                                crate::platform_specific::Event::Wayland(e),
+                            ));
                     }
                 }
-            });
+                if wake_up {
+                    state.state.proxy.wake_up();
+                }
+            }
+        });
 
         if res.is_finished() {
             log::warn!("SCTK thread finished.");

--- a/winit/src/platform_specific/wayland/event_loop/proxy.rs
+++ b/winit/src/platform_specific/wayland/event_loop/proxy.rs
@@ -1,8 +1,8 @@
 use cctk::sctk::reexports::calloop;
 use iced_futures::futures::{
+    Sink,
     channel::mpsc,
     task::{Context, Poll},
-    Sink,
 };
 use std::pin::Pin;
 
@@ -34,33 +34,21 @@ impl<Message: 'static> Proxy<Message> {
 impl<Message: 'static> Sink<Message> for Proxy<Message> {
     type Error = mpsc::SendError;
 
-    fn poll_ready(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
-    fn start_send(
-        self: Pin<&mut Self>,
-        message: Message,
-    ) -> Result<(), Self::Error> {
+    fn start_send(self: Pin<&mut Self>, message: Message) -> Result<(), Self::Error> {
         let _ = self.raw.send(message);
 
         Ok(())
     }
 
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_close(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 }

--- a/winit/src/platform_specific/wayland/event_loop/state.rs
+++ b/winit/src/platform_specific/wayland/event_loop/state.rs
@@ -10,8 +10,7 @@ use crate::{
         Event,
         wayland::{
             handlers::{
-                wp_fractional_scaling::FractionalScalingManager,
-                wp_viewporter::ViewporterState,
+                wp_fractional_scaling::FractionalScalingManager, wp_viewporter::ViewporterState,
             },
             sctk_event::{LayerSurfaceEventVariant, SctkEvent},
         },
@@ -76,8 +75,7 @@ use cctk::{
             touch::TouchData,
         },
         session_lock::{
-            SessionLock, SessionLockState, SessionLockSurface,
-            SessionLockSurfaceConfigure,
+            SessionLock, SessionLockState, SessionLockSurface, SessionLockSurfaceConfigure,
         },
         shell::{
             WaylandSurface,
@@ -113,8 +111,7 @@ use wayland_protocols::{
     wp::{
         fractional_scale::v1::client::wp_fractional_scale_v1::WpFractionalScaleV1,
         keyboard_shortcuts_inhibit::zv1::client::{
-            zwp_keyboard_shortcuts_inhibit_manager_v1,
-            zwp_keyboard_shortcuts_inhibitor_v1,
+            zwp_keyboard_shortcuts_inhibit_manager_v1, zwp_keyboard_shortcuts_inhibitor_v1,
         },
         text_input::zv3::client::zwp_text_input_v3::ZwpTextInputV3,
         viewporter::client::wp_viewport::WpViewport,
@@ -162,8 +159,7 @@ pub struct SctkLayerSurface {
     pub(crate) margin: IcedMargin,
     pub(crate) exclusive_zone: i32,
     pub(crate) last_configure: Option<LayerSurfaceConfigure>,
-    pub(crate) _pending_requests:
-        Vec<platform_specific::wayland::layer_surface::Action>,
+    pub(crate) _pending_requests: Vec<platform_specific::wayland::layer_surface::Action>,
     pub(crate) wp_fractional_scale: Option<WpFractionalScaleV1>,
     pub(crate) common: Arc<Mutex<Common>>,
 }
@@ -197,9 +193,7 @@ pub enum PopupParent {
 impl PopupParent {
     pub fn wl_surface(&self) -> &WlSurface {
         match self {
-            PopupParent::LayerSurface(s)
-            | PopupParent::Window(s)
-            | PopupParent::Popup(s) => s,
+            PopupParent::LayerSurface(s) | PopupParent::Window(s) | PopupParent::Popup(s) => s,
         }
     }
 }
@@ -221,9 +215,7 @@ impl CommonSurface {
         let wl_surface = match self {
             CommonSurface::Popup(popup, _) => popup.wl_surface(),
             CommonSurface::Layer(layer_surface) => layer_surface.wl_surface(),
-            CommonSurface::Lock(session_lock_surface) => {
-                session_lock_surface.wl_surface()
-            }
+            CommonSurface::Lock(session_lock_surface) => session_lock_surface.wl_surface(),
             CommonSurface::Subsurface { wl_surface, .. } => wl_surface,
         };
         wl_surface
@@ -268,8 +260,7 @@ impl From<LogicalSize<u32>> for Common {
 pub struct SctkPopup {
     pub(crate) popup: Popup,
     pub(crate) last_configure: Option<PopupConfigure>,
-    pub(crate) _pending_requests:
-        Vec<platform_specific::wayland::popup::Action>,
+    pub(crate) _pending_requests: Vec<platform_specific::wayland::popup::Action>,
     pub(crate) data: SctkPopupData,
     pub(crate) common: Arc<Mutex<Common>>,
     pub(crate) wp_fractional_scale: Option<WpFractionalScaleV1>,
@@ -365,17 +356,13 @@ impl SctkWindow {
     pub fn wl_surface(&self, conn: &Connection) -> WlSurface {
         let window_handle = self.window.window_handle().unwrap();
         let ptr = {
-            let raw_window_handle::RawWindowHandle::Wayland(h) =
-                window_handle.as_raw()
-            else {
+            let raw_window_handle::RawWindowHandle::Wayland(h) = window_handle.as_raw() else {
                 panic!("Invalid window handle");
             };
             h.surface
         };
-        let id = unsafe {
-            ObjectId::from_ptr(WlSurface::interface(), ptr.as_ptr().cast())
-        }
-        .unwrap();
+        let id =
+            unsafe { ObjectId::from_ptr(WlSurface::interface(), ptr.as_ptr().cast()) }.unwrap();
         WlSurface::from_id(conn, id).unwrap()
     }
 
@@ -387,23 +374,17 @@ impl SctkWindow {
                 .expect("Invalid window handle");
             h.as_raw()
         };
-        let id = unsafe {
-            ObjectId::from_ptr(XdgSurface::interface(), ptr.as_ptr().cast())
-        }
-        .unwrap();
+        let id =
+            unsafe { ObjectId::from_ptr(XdgSurface::interface(), ptr.as_ptr().cast()) }.unwrap();
         XdgSurface::from_id(conn, id).unwrap()
     }
 
     pub fn xdg_toplevel(&self, conn: &Connection) -> XdgToplevel {
         let window_handle = self.window.xdg_toplevel().unwrap();
 
-        let id = unsafe {
-            ObjectId::from_ptr(
-                XdgToplevel::interface(),
-                window_handle.as_ptr().cast(),
-            )
-        }
-        .unwrap();
+        let id =
+            unsafe { ObjectId::from_ptr(XdgToplevel::interface(), window_handle.as_ptr().cast()) }
+                .unwrap();
         XdgToplevel::from_id(conn, id).unwrap()
     }
 }
@@ -427,8 +408,7 @@ pub struct SctkState {
     pub(crate) _multipool: Option<MultiPool<WlSurface>>,
 
     /// all notification objects
-    pub(crate) overlap_notifications:
-        HashMap<ObjectId, ZcosmicOverlapNotificationV1>,
+    pub(crate) overlap_notifications: HashMap<ObjectId, ZcosmicOverlapNotificationV1>,
 
     /// all present outputs
     pub(crate) outputs: Vec<WlOutput>,
@@ -488,14 +468,17 @@ pub struct SctkState {
     pub(crate) toplevel_info: Option<ToplevelInfoState>,
     pub(crate) toplevel_manager: Option<ToplevelManagerState>,
     pub(crate) subsurface_state: Option<SubsurfaceState>,
-    pub(crate) ext_background_effect_manager: Option<ext_background_effect::ExtBackgroundEffectManager>,
+    pub(crate) ext_background_effect_manager:
+        Option<ext_background_effect::ExtBackgroundEffectManager>,
 
     pub(crate) activation_token_ctr: u32,
     pub(crate) token_senders: HashMap<u32, oneshot::Sender<Option<String>>>,
 
-    pub(crate) inhibitor: Option<zwp_keyboard_shortcuts_inhibitor_v1::ZwpKeyboardShortcutsInhibitorV1>,
+    pub(crate) inhibitor:
+        Option<zwp_keyboard_shortcuts_inhibitor_v1::ZwpKeyboardShortcutsInhibitorV1>,
     pub(crate) inhibited: bool,
-    pub(crate) inhibitor_manager: Option<zwp_keyboard_shortcuts_inhibit_manager_v1::ZwpKeyboardShortcutsInhibitManagerV1>,
+    pub(crate) inhibitor_manager:
+        Option<zwp_keyboard_shortcuts_inhibit_manager_v1::ZwpKeyboardShortcutsInhibitManagerV1>,
 
     pub(crate) corner_radius_manager: Option<CosmicCornerRadiusManagerV1>,
     pub(crate) pending_corner_radius: HashMap<core::window::Id, CornerRadius>,
@@ -559,10 +542,7 @@ pub enum SubsurfaceCreationError {
     Unsupported,
 }
 
-pub(crate) fn receive_frame(
-    frame_status: &mut HashMap<ObjectId, FrameStatus>,
-    s: &WlSurface,
-) {
+pub(crate) fn receive_frame(frame_status: &mut HashMap<ObjectId, FrameStatus>, s: &WlSurface) {
     let e = frame_status.entry(s.id()).or_insert(FrameStatus::Received);
     if matches!(e, FrameStatus::RequestedRedraw) {
         *e = FrameStatus::Ready;
@@ -580,12 +560,7 @@ impl SctkState {
         }
     }
 
-    pub fn scale_factor_changed(
-        &mut self,
-        surface: &WlSurface,
-        scale_factor: f64,
-        legacy: bool,
-    ) {
+    pub fn scale_factor_changed(&mut self, surface: &WlSurface, scale_factor: f64, legacy: bool) {
         let mut id = None;
 
         for subsurface in &self.subsurfaces {
@@ -684,33 +659,30 @@ impl SctkState {
         ),
         PopupCreationError,
     > {
-        let (parent, toplevel) = if let Some(parent) =
-            self.layer_surfaces.iter().find(|l| l.id == settings.parent)
-        {
-            (
-                PopupParent::LayerSurface(parent.surface.wl_surface().clone()),
-                parent.surface.wl_surface().clone(),
-            )
-        } else if let Some(parent) =
-            self.windows.iter().find(|w| w.id == settings.parent)
-        {
-            (
-                PopupParent::Window(parent.wl_surface(&self.connection)),
-                parent.wl_surface(&self.connection),
-            )
-        } else if let Some(i) = self
-            .popups
-            .iter()
-            .position(|p| p.data.id == settings.parent)
-        {
-            let parent = &self.popups[i];
-            (
-                PopupParent::Popup(parent.popup.wl_surface().clone()),
-                parent.data.toplevel.clone(),
-            )
-        } else {
-            return Err(PopupCreationError::ParentMissing);
-        };
+        let (parent, toplevel) =
+            if let Some(parent) = self.layer_surfaces.iter().find(|l| l.id == settings.parent) {
+                (
+                    PopupParent::LayerSurface(parent.surface.wl_surface().clone()),
+                    parent.surface.wl_surface().clone(),
+                )
+            } else if let Some(parent) = self.windows.iter().find(|w| w.id == settings.parent) {
+                (
+                    PopupParent::Window(parent.wl_surface(&self.connection)),
+                    parent.wl_surface(&self.connection),
+                )
+            } else if let Some(i) = self
+                .popups
+                .iter()
+                .position(|p| p.data.id == settings.parent)
+            {
+                let parent = &self.popups[i];
+                (
+                    PopupParent::Popup(parent.popup.wl_surface().clone()),
+                    parent.data.toplevel.clone(),
+                )
+            } else {
+                return Err(PopupCreationError::ParentMissing);
+            };
 
         let size = if settings.positioner.size.is_none() {
             log::info!("No configured popup size");
@@ -728,16 +700,11 @@ impl SctkState {
             settings.positioner.anchor_rect.width,
             settings.positioner.anchor_rect.height,
         );
-        if let Ok(constraint_adjustment) =
-            settings.positioner.constraint_adjustment.try_into()
-        {
+        if let Ok(constraint_adjustment) = settings.positioner.constraint_adjustment.try_into() {
             positioner.set_constraint_adjustment(constraint_adjustment);
         }
         positioner.set_gravity(settings.positioner.gravity);
-        positioner.set_offset(
-            settings.positioner.offset.0,
-            settings.positioner.offset.1,
-        );
+        positioner.set_offset(settings.positioner.offset.0, settings.positioner.offset.1);
         if positioner.version() >= 3 && settings.positioner.reactive {
             positioner.set_reactive();
         }
@@ -745,8 +712,7 @@ impl SctkState {
 
         let grab = settings.grab;
 
-        let wl_surface =
-            self.compositor_state.create_surface(&self.queue_handle);
+        let wl_surface = self.compositor_state.create_surface(&self.queue_handle);
         _ = self.id_map.insert(wl_surface.id(), settings.id.clone());
         if let Some(zone) = &settings.input_zone {
             let region = self
@@ -763,75 +729,72 @@ impl SctkState {
             }
             wl_surface.set_input_region(Some(&region));
         }
-        let (toplevel, popup) = match &parent {
-            PopupParent::LayerSurface(parent) => {
-                let Some(parent_layer_surface) = self
-                    .layer_surfaces
-                    .iter()
-                    .find(|w| w.surface.wl_surface() == parent)
-                else {
-                    return Err(PopupCreationError::ParentMissing);
-                };
-                let popup = Popup::from_surface(
-                    None,
-                    &positioner,
-                    &self.queue_handle,
-                    wl_surface.clone(),
-                    &self.xdg_shell_state,
-                )
-                .map_err(PopupCreationError::PopupCreationFailed)?;
-                parent_layer_surface.surface.get_popup(popup.xdg_popup());
-                (parent_layer_surface.surface.wl_surface(), popup)
-            }
-            PopupParent::Window(parent) => {
-                let Some(parent_window) = self
-                    .windows
-                    .iter()
-                    .find(|w| &w.wl_surface(&self.connection) == parent)
-                else {
-                    return Err(PopupCreationError::ParentMissing);
-                };
-
-                (
-                    &parent_window.wl_surface(&self.connection),
-                    Popup::from_surface(
-                        Some(&parent_window.xdg_surface(&self.connection)),
+        let (toplevel, popup) =
+            match &parent {
+                PopupParent::LayerSurface(parent) => {
+                    let Some(parent_layer_surface) = self
+                        .layer_surfaces
+                        .iter()
+                        .find(|w| w.surface.wl_surface() == parent)
+                    else {
+                        return Err(PopupCreationError::ParentMissing);
+                    };
+                    let popup = Popup::from_surface(
+                        None,
                         &positioner,
                         &self.queue_handle,
                         wl_surface.clone(),
                         &self.xdg_shell_state,
                     )
-                    .map_err(PopupCreationError::PopupCreationFailed)?,
-                )
-            }
-            PopupParent::Popup(parent) => {
-                let Some(parent_xdg) = self.popups.iter().find_map(|p| {
-                    (p.popup.wl_surface() == parent)
-                        .then(|| p.popup.xdg_surface())
-                }) else {
-                    return Err(PopupCreationError::ParentMissing);
-                };
+                    .map_err(PopupCreationError::PopupCreationFailed)?;
+                    parent_layer_surface.surface.get_popup(popup.xdg_popup());
+                    (parent_layer_surface.surface.wl_surface(), popup)
+                }
+                PopupParent::Window(parent) => {
+                    let Some(parent_window) = self
+                        .windows
+                        .iter()
+                        .find(|w| &w.wl_surface(&self.connection) == parent)
+                    else {
+                        return Err(PopupCreationError::ParentMissing);
+                    };
 
-                (
-                    &toplevel,
-                    Popup::from_surface(
-                        Some(parent_xdg),
-                        &positioner,
-                        &self.queue_handle,
-                        wl_surface.clone(),
-                        &self.xdg_shell_state,
+                    (
+                        &parent_window.wl_surface(&self.connection),
+                        Popup::from_surface(
+                            Some(&parent_window.xdg_surface(&self.connection)),
+                            &positioner,
+                            &self.queue_handle,
+                            wl_surface.clone(),
+                            &self.xdg_shell_state,
+                        )
+                        .map_err(PopupCreationError::PopupCreationFailed)?,
                     )
-                    .map_err(PopupCreationError::PopupCreationFailed)?,
-                )
-            }
-        };
+                }
+                PopupParent::Popup(parent) => {
+                    let Some(parent_xdg) = self.popups.iter().find_map(|p| {
+                        (p.popup.wl_surface() == parent).then(|| p.popup.xdg_surface())
+                    }) else {
+                        return Err(PopupCreationError::ParentMissing);
+                    };
 
-        popup.xdg_surface().set_window_geometry(
-            0,
-            0,
-            size.0 as i32,
-            size.1 as i32,
-        );
+                    (
+                        &toplevel,
+                        Popup::from_surface(
+                            Some(parent_xdg),
+                            &positioner,
+                            &self.queue_handle,
+                            wl_surface.clone(),
+                            &self.xdg_shell_state,
+                        )
+                        .map_err(PopupCreationError::PopupCreationFailed)?,
+                    )
+                }
+            };
+
+        popup
+            .xdg_surface()
+            .set_window_geometry(0, 0, size.0 as i32, size.1 as i32);
 
         if grab {
             if let Some(s) = self.seats.first() {
@@ -860,15 +823,14 @@ impl SctkState {
         wl_surface.commit();
 
         let wp_viewport = self.viewporter_state.as_ref().map(|state| {
-            let viewport =
-                state.get_viewport(popup.wl_surface(), &self.queue_handle);
+            let viewport = state.get_viewport(popup.wl_surface(), &self.queue_handle);
             viewport.set_destination(size.0 as i32, size.1 as i32);
             viewport
         });
-        let wp_fractional_scale =
-            self.fractional_scaling_manager.as_ref().map(|fsm| {
-                fsm.fractional_scaling(popup.wl_surface(), &self.queue_handle)
-            });
+        let wp_fractional_scale = self
+            .fractional_scaling_manager
+            .as_ref()
+            .map(|fsm| fsm.fractional_scaling(popup.wl_surface(), &self.queue_handle));
         let mut common: Common = LogicalSize::new(size.0, size.1).into();
         common.wp_viewport = wp_viewport;
         let common = Arc::new(Mutex::new(common));
@@ -914,10 +876,8 @@ impl SctkState {
             exclusive_zone,
             ..
         }: SctkLayerSurfaceSettings,
-    ) -> Result<
-        (core::window::Id, CommonSurface, Arc<Mutex<Common>>),
-        LayerSurfaceCreationError,
-    > {
+    ) -> Result<(core::window::Id, CommonSurface, Arc<Mutex<Common>>), LayerSurfaceCreationError>
+    {
         let wl_output = match output {
             IcedOutput::All => None, // TODO
             IcedOutput::Active => None,
@@ -928,8 +888,7 @@ impl SctkState {
             .layer_shell
             .as_ref()
             .ok_or(LayerSurfaceCreationError::LayerShellNotSupported)?;
-        let wl_surface =
-            self.compositor_state.create_surface(&self.queue_handle);
+        let wl_surface = self.compositor_state.create_surface(&self.queue_handle);
         _ = self.id_map.insert(wl_surface.id(), id.clone());
         let mut size = size.unwrap_or((None, None));
         if anchor.contains(Anchor::BOTTOM.union(Anchor::TOP)) {
@@ -951,14 +910,8 @@ impl SctkState {
         );
         layer_surface.set_anchor(anchor);
         layer_surface.set_keyboard_interactivity(keyboard_interactivity);
-        layer_surface.set_margin(
-            margin.top,
-            margin.right,
-            margin.bottom,
-            margin.left,
-        );
-        layer_surface
-            .set_size(size.0.unwrap_or_default(), size.1.unwrap_or_default());
+        layer_surface.set_margin(margin.top, margin.right, margin.bottom, margin.left);
+        layer_surface.set_size(size.0.unwrap_or_default(), size.1.unwrap_or_default());
         layer_surface.set_exclusive_zone(exclusive_zone);
         if let Some(zone) = &input_zone {
             let region = self
@@ -978,20 +931,15 @@ impl SctkState {
         }
         layer_surface.commit();
 
-        let wp_viewport = self.viewporter_state.as_ref().map(|state| {
-            state.get_viewport(layer_surface.wl_surface(), &self.queue_handle)
-        });
-        let wp_fractional_scale =
-            self.fractional_scaling_manager.as_ref().map(|fsm| {
-                fsm.fractional_scaling(
-                    layer_surface.wl_surface(),
-                    &self.queue_handle,
-                )
-            });
-        let mut common = Common::from(LogicalSize::new(
-            size.0.unwrap_or(1),
-            size.1.unwrap_or(1),
-        ));
+        let wp_viewport = self
+            .viewporter_state
+            .as_ref()
+            .map(|state| state.get_viewport(layer_surface.wl_surface(), &self.queue_handle));
+        let wp_fractional_scale = self
+            .fractional_scaling_manager
+            .as_ref()
+            .map(|fsm| fsm.fractional_scaling(layer_surface.wl_surface(), &self.queue_handle));
+        let mut common = Common::from(LogicalSize::new(size.0.unwrap_or(1), size.1.unwrap_or(1)));
         common.requested_size = size;
         common.wp_viewport = wp_viewport;
         let common = Arc::new(Mutex::new(common));
@@ -1018,23 +966,18 @@ impl SctkState {
         output: &WlOutput,
     ) -> Option<(CommonSurface, Arc<Mutex<Common>>)> {
         if let Some(lock) = self.session_lock.as_ref() {
-            let wl_surface =
-                self.compositor_state.create_surface(&self.queue_handle);
+            let wl_surface = self.compositor_state.create_surface(&self.queue_handle);
             _ = self.id_map.insert(wl_surface.id(), id.clone());
-            let session_lock_surface = lock.create_lock_surface(
-                wl_surface.clone(),
-                output,
-                &self.queue_handle,
-            );
+            let session_lock_surface =
+                lock.create_lock_surface(wl_surface.clone(), output, &self.queue_handle);
             let wp_viewport = self.viewporter_state.as_ref().map(|state| {
-                let viewport =
-                    state.get_viewport(&wl_surface, &self.queue_handle);
+                let viewport = state.get_viewport(&wl_surface, &self.queue_handle);
                 viewport
             });
-            let wp_fractional_scale =
-                self.fractional_scaling_manager.as_ref().map(|fsm| {
-                    fsm.fractional_scaling(&wl_surface, &self.queue_handle)
-                });
+            let wp_fractional_scale = self
+                .fractional_scaling_manager
+                .as_ref()
+                .map(|fsm| fsm.fractional_scaling(&wl_surface, &self.queue_handle));
             let mut common = Common::from(LogicalSize::new(1, 1));
             common.wp_viewport = wp_viewport;
             let common = Arc::new(Mutex::new(common));
@@ -1058,152 +1001,204 @@ impl SctkState {
     ) -> Result<(), Infallible> {
         match action {
             Action::LayerSurface(action) => match action {
-                        platform_specific::wayland::layer_surface::Action::LayerSurface {
-                            builder,
-                        } => {
-                            let title = builder.namespace.clone();
-                            if let Ok((id, surface, common)) = self.get_layer_surface(builder) {
-                                // TODO Ashley: all surfaces should probably have an optional title for a11y if nothing else
-                                let wl_surface = surface.wl_surface().clone();
-                                send_event(&self.events_sender, &self.proxy,
-                                    SctkEvent::LayerSurfaceEvent {
-                                        variant: LayerSurfaceEventVariant::Created(self.queue_handle.clone(), surface, id, common, self.connection.display(), title),
-                                        id: wl_surface.clone(),
-                                    }
+                platform_specific::wayland::layer_surface::Action::LayerSurface { builder } => {
+                    let title = builder.namespace.clone();
+                    if let Ok((id, surface, common)) = self.get_layer_surface(builder) {
+                        // TODO Ashley: all surfaces should probably have an optional title for a11y if nothing else
+                        let wl_surface = surface.wl_surface().clone();
+                        send_event(
+                            &self.events_sender,
+                            &self.proxy,
+                            SctkEvent::LayerSurfaceEvent {
+                                variant: LayerSurfaceEventVariant::Created(
+                                    self.queue_handle.clone(),
+                                    surface,
+                                    id,
+                                    common,
+                                    self.connection.display(),
+                                    title,
+                                ),
+                                id: wl_surface.clone(),
+                            },
+                        );
+                    }
+                }
+                platform_specific::wayland::layer_surface::Action::Size { id, width, height } => {
+                    if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id)
+                    {
+                        layer_surface.set_size(width, height);
+                        let wl_surface = layer_surface.surface.wl_surface();
+                        receive_frame(&mut self.frame_status, &wl_surface);
+                        if let Some(mut prev_configure) = layer_surface.last_configure.clone() {
+                            prev_configure.new_size = (
+                                width.unwrap_or(prev_configure.new_size.0),
+                                width.unwrap_or(prev_configure.new_size.1),
+                            );
+                            _ = send_event(
+                                &self.events_sender,
+                                &self.proxy,
+                                SctkEvent::LayerSurfaceEvent {
+                                    variant: LayerSurfaceEventVariant::Configure(
+                                        prev_configure,
+                                        wl_surface.clone(),
+                                        false,
+                                    ),
+                                    id: wl_surface.clone(),
+                                },
+                            );
+                        }
+                    }
+                }
+                platform_specific::wayland::layer_surface::Action::Destroy(id) => {
+                    if let Some(i) = self.layer_surfaces.iter().position(|l| l.id == id) {
+                        let l = self.layer_surfaces.remove(i);
+
+                        if let Some(blurred) = self.blur_surfaces.remove(&l.id) {
+                            for s in blurred {
+                                s.destroy();
+                            }
+                        }
+
+                        let (removed, remaining): (Vec<_>, Vec<_>) = self
+                            .subsurfaces
+                            .drain(..)
+                            .partition(|s| s.instance.parent == *l.surface.wl_surface());
+
+                        self.subsurfaces = remaining;
+                        for s in removed {
+                            crate::subsurface_widget::remove_iced_subsurface(
+                                &s.instance.wl_surface,
+                            );
+                            send_event(
+                                &self.events_sender,
+                                &self.proxy,
+                                SctkEvent::SubsurfaceEvent(
+                                    crate::sctk_event::SubsurfaceEventVariant::Destroyed(
+                                        s.instance,
+                                    ),
+                                ),
+                            );
+                        }
+
+                        if let Some(destroyed) = self.id_map.remove(&l.surface.wl_surface().id()) {
+                            _ = self.destroyed.insert(destroyed);
+                        }
+                        send_event(
+                            &self.events_sender,
+                            &self.proxy,
+                            SctkEvent::LayerSurfaceEvent {
+                                variant: LayerSurfaceEventVariant::Done,
+                                id: l.surface.wl_surface().clone(),
+                            },
+                        );
+                    }
+                }
+                platform_specific::wayland::layer_surface::Action::Anchor { id, anchor } => {
+                    if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id)
+                    {
+                        layer_surface.anchor = anchor;
+                        layer_surface.surface.set_anchor(anchor);
+                        _ = self
+                            .to_commit
+                            .insert(id, layer_surface.surface.wl_surface().clone());
+                    }
+                }
+                platform_specific::wayland::layer_surface::Action::ExclusiveZone {
+                    id,
+                    exclusive_zone,
+                } => {
+                    if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id)
+                    {
+                        layer_surface.exclusive_zone = exclusive_zone;
+                        layer_surface.surface.set_exclusive_zone(exclusive_zone);
+                        _ = self
+                            .to_commit
+                            .insert(id, layer_surface.surface.wl_surface().clone());
+                    }
+                }
+                platform_specific::wayland::layer_surface::Action::Margin { id, margin } => {
+                    if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id)
+                    {
+                        layer_surface.margin = margin;
+                        layer_surface.surface.set_margin(
+                            margin.top,
+                            margin.right,
+                            margin.bottom,
+                            margin.left,
+                        );
+                        _ = self
+                            .to_commit
+                            .insert(id, layer_surface.surface.wl_surface().clone());
+                    }
+                }
+                platform_specific::wayland::layer_surface::Action::KeyboardInteractivity {
+                    id,
+                    keyboard_interactivity,
+                } => {
+                    if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id)
+                    {
+                        layer_surface.keyboard_interactivity = keyboard_interactivity;
+                        layer_surface
+                            .surface
+                            .set_keyboard_interactivity(keyboard_interactivity);
+                        _ = self
+                            .to_commit
+                            .insert(id, layer_surface.surface.wl_surface().clone());
+                    }
+                }
+                platform_specific::wayland::layer_surface::Action::InputZone { id, zone } => {
+                    if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id)
+                    {
+                        if let Some(zone) = &zone {
+                            let region = self
+                                .compositor_state
+                                .wl_compositor()
+                                .create_region(&self.queue_handle, ());
+                            for rect in zone {
+                                region.add(
+                                    rect.x.round() as i32,
+                                    rect.y.round() as i32,
+                                    rect.width.round() as i32,
+                                    rect.height.round() as i32,
                                 );
                             }
+                            layer_surface.surface.set_input_region(Some(&region));
+                            region.destroy();
+                        } else {
+                            layer_surface.surface.set_input_region(None);
                         }
-                        platform_specific::wayland::layer_surface::Action::Size {
-                            id,
-                            width,
-                            height,
-                        } => {
-                            if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id) {
-                                layer_surface.set_size(width, height);
-                                let wl_surface = layer_surface.surface.wl_surface();
-                                receive_frame(&mut self.frame_status, &wl_surface);
-                                if let Some(mut prev_configure) = layer_surface.last_configure.clone() {
-                                    prev_configure.new_size = (width.unwrap_or(prev_configure.new_size.0), width.unwrap_or(prev_configure.new_size.1));
-                                    _ = send_event(&self.events_sender, &self.proxy,
-                                        SctkEvent::LayerSurfaceEvent { variant: LayerSurfaceEventVariant::Configure(prev_configure, wl_surface.clone(), false), id: wl_surface.clone()});
-                                }
-                            }
-                        },
-                        platform_specific::wayland::layer_surface::Action::Destroy(id) => {
-                            if let Some(i) = self.layer_surfaces.iter().position(|l| l.id == id) {
-                                let l = self.layer_surfaces.remove(i);
-
-                                if let Some(blurred) = self.blur_surfaces.remove(&l.id) {
-                                    for s in blurred {
-                                        s.destroy();
-                                    }
-                                }
-
-                                let (removed, remaining): (Vec<_>, Vec<_>) =  self
-                                    .subsurfaces
-                                    .drain(..)
-                                    .partition(|s| {
-                                        s.instance.parent == *l.surface.wl_surface()
-                                    });
-
-                                self.subsurfaces = remaining;
-                                for s in removed
-                                {
-                                    crate::subsurface_widget::remove_iced_subsurface(
-                                        &s.instance.wl_surface,
-                                    );
-                                    send_event(&self.events_sender, &self.proxy,
-                                        SctkEvent::SubsurfaceEvent( crate::sctk_event::SubsurfaceEventVariant::Destroyed(s.instance) )
-                                    );
-                                }
-
-                                if let Some(destroyed) = self.id_map.remove(&l.surface.wl_surface().id()) {
-                                    _ = self.destroyed.insert(destroyed);
-                                }
-                                send_event(&self.events_sender, &self.proxy, SctkEvent::LayerSurfaceEvent {
-                                            variant: LayerSurfaceEventVariant::Done,
-                                            id: l.surface.wl_surface().clone(),
-                                    }
-                                );
-                            }
-                        },
-                        platform_specific::wayland::layer_surface::Action::Anchor { id, anchor } => {
-                            if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id) {
-                                layer_surface.anchor = anchor;
-                                layer_surface.surface.set_anchor(anchor);
-                                _ = self.to_commit.insert(id, layer_surface.surface.wl_surface().clone());
-
-                            }
-                        }
-                        platform_specific::wayland::layer_surface::Action::ExclusiveZone {
-                            id,
-                            exclusive_zone,
-                        } => {
-                            if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id) {
-                                layer_surface.exclusive_zone = exclusive_zone;
-                                layer_surface.surface.set_exclusive_zone(exclusive_zone);
-                                _ = self.to_commit.insert(id, layer_surface.surface.wl_surface().clone());
-                            }
-                        },
-                        platform_specific::wayland::layer_surface::Action::Margin {
-                            id,
-                            margin,
-                        } => {
-                            if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id) {
-                                layer_surface.margin = margin;
-                                layer_surface.surface.set_margin(margin.top, margin.right, margin.bottom, margin.left);
-                                _ = self.to_commit.insert(id, layer_surface.surface.wl_surface().clone());
-                            }
-                        },
-                        platform_specific::wayland::layer_surface::Action::KeyboardInteractivity { id, keyboard_interactivity } => {
-                            if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id) {
-                                layer_surface.keyboard_interactivity = keyboard_interactivity;
-                                layer_surface.surface.set_keyboard_interactivity(keyboard_interactivity);
-                                _ = self.to_commit.insert(id, layer_surface.surface.wl_surface().clone());
-
-                            }
-                        },
-                        platform_specific::wayland::layer_surface::Action::InputZone { id, zone } => {
-                            if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id) {
-                                if let Some(zone) = &zone {
-                                    let region = self
-                                        .compositor_state
-                                        .wl_compositor()
-                                        .create_region(&self.queue_handle, ());
-                                    for rect in zone {
-                                        region.add(
-                                            rect.x.round() as i32,
-                                            rect.y.round() as i32,
-                                            rect.width.round() as i32,
-                                            rect.height.round() as i32,
-                                        );
-                                    }
-                                    layer_surface.surface.set_input_region(Some(&region));
-                                    region.destroy();
-                                } else{
-                                    layer_surface.surface.set_input_region(None);
-                                }
-                                _ = self.to_commit.insert(id, layer_surface.surface.wl_surface().clone());
-                            }
-                        }
-                        platform_specific::wayland::layer_surface::Action::Layer { id, layer } => {
-                            if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id) {
-                                layer_surface.layer = layer;
-                                layer_surface.surface.set_layer(layer);
-                                _ = self.to_commit.insert(id, layer_surface.surface.wl_surface().clone());
-
-                            }
-                        },
-                },
+                        _ = self
+                            .to_commit
+                            .insert(id, layer_surface.surface.wl_surface().clone());
+                    }
+                }
+                platform_specific::wayland::layer_surface::Action::Layer { id, layer } => {
+                    if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id)
+                    {
+                        layer_surface.layer = layer;
+                        layer_surface.surface.set_layer(layer);
+                        _ = self
+                            .to_commit
+                            .insert(id, layer_surface.surface.wl_surface().clone());
+                    }
+                }
+            },
             Action::Popup(action) => match action {
                 platform_specific::wayland::popup::Action::Popup { popup: settings } => {
                     // first check existing popup
-                    if let Some(existing) = self.popups.iter().position(|p| p.data.id == settings.id
-                    && (
-                        self.popups.iter().any(|parent| parent.popup.wl_surface() == p.data.parent.wl_surface() && parent.data.id == settings.parent)
-                        || self.windows.iter().any(|w| w.id == settings.parent && *p.data.parent.wl_surface() == w.wl_surface(&self.connection))
-                        || self.layer_surfaces.iter().any(|l| l.id == settings.parent && p.data.parent.wl_surface() == l.surface.wl_surface()))
-                    ) {
+                    if let Some(existing) = self.popups.iter().position(|p| {
+                        p.data.id == settings.id
+                            && (self.popups.iter().any(|parent| {
+                                parent.popup.wl_surface() == p.data.parent.wl_surface()
+                                    && parent.data.id == settings.parent
+                            }) || self.windows.iter().any(|w| {
+                                w.id == settings.parent
+                                    && *p.data.parent.wl_surface() == w.wl_surface(&self.connection)
+                            }) || self.layer_surfaces.iter().any(|l| {
+                                l.id == settings.parent
+                                    && p.data.parent.wl_surface() == l.surface.wl_surface()
+                            }))
+                    }) {
                         let existing = &mut self.popups[existing];
                         let size = if settings.positioner.size.is_none() {
                             log::info!("No configured popup size");
@@ -1212,10 +1207,11 @@ impl SctkState {
                             settings.positioner.size.unwrap()
                         };
                         let Ok(positioner) = XdgPositioner::new(&self.xdg_shell_state)
-                            .map_err(PopupCreationError::PositionerCreationFailed) else {
-                                log::error!("Failed to create popup positioner");
-                                return Ok(());
-                            };
+                            .map_err(PopupCreationError::PositionerCreationFailed)
+                        else {
+                            log::error!("Failed to create popup positioner");
+                            return Ok(());
+                        };
                         positioner.set_anchor(settings.positioner.anchor);
                         positioner.set_anchor_rect(
                             settings.positioner.anchor_rect.x,
@@ -1229,18 +1225,28 @@ impl SctkState {
                             positioner.set_constraint_adjustment(constraint_adjustment);
                         }
                         positioner.set_gravity(settings.positioner.gravity);
-                        positioner.set_offset(
-                            settings.positioner.offset.0,
-                            settings.positioner.offset.1,
-                        );
+                        positioner
+                            .set_offset(settings.positioner.offset.0, settings.positioner.offset.1);
                         if settings.positioner.reactive {
                             positioner.set_reactive();
                         }
                         positioner.set_size(size.0 as i32, size.1 as i32);
                         existing.data.positioner = Arc::new(positioner);
-                        existing.set_size(size.0, size.1, TOKEN_CTR.fetch_add(1, std::sync::atomic::Ordering::Relaxed));
-                        _ = send_event(&self.events_sender, &self.proxy,
-                            SctkEvent::PopupEvent { variant: crate::sctk_event::PopupEventVariant::Size(size.0, size.1), toplevel_id: existing.data.parent.wl_surface().clone(), parent_id: existing.data.parent.wl_surface().clone(), id: existing.popup.wl_surface().clone() });
+                        existing.set_size(
+                            size.0,
+                            size.1,
+                            TOKEN_CTR.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+                        );
+                        _ = send_event(
+                            &self.events_sender,
+                            &self.proxy,
+                            SctkEvent::PopupEvent {
+                                variant: crate::sctk_event::PopupEventVariant::Size(size.0, size.1),
+                                toplevel_id: existing.data.parent.wl_surface().clone(),
+                                parent_id: existing.data.parent.wl_surface().clone(),
+                                id: existing.popup.wl_surface().clone(),
+                            },
+                        );
                         return Ok(());
                     }
                     let mut parent_mismatch = !self.popups.is_empty();
@@ -1255,15 +1261,17 @@ impl SctkState {
                                 self.popups.insert(0, p);
 
                                 found |= id == settings.parent;
-                                if !found  {
-                                    _ = self.handle_action(Action::Popup(platform_specific::wayland::popup::Action::Destroy{id}));
+                                if !found {
+                                    _ = self.handle_action(Action::Popup(
+                                        platform_specific::wayland::popup::Action::Destroy { id },
+                                    ));
                                 }
-
                             }
                         }
                         if self.pending_popup.replace((settings, 0)).is_none() {
-
-                            let timer = cctk::sctk::reexports::calloop::timer::Timer::from_duration(Duration::from_millis(30));
+                            let timer = cctk::sctk::reexports::calloop::timer::Timer::from_duration(
+                                Duration::from_millis(30),
+                            );
                             let queue_handle = self.queue_handle.clone();
                             _ = self.loop_handle.insert_source(timer, move |_, _, state| {
                                 let Some((mut popup, attempt)) = state.pending_popup.take() else {
@@ -1314,36 +1322,35 @@ impl SctkState {
                             }
                         }
                     }
-                },
+                }
                 // XXX popup destruction must be done carefully
                 // first destroy the uppermost popup, then work down to the requested popup
                 platform_specific::wayland::popup::Action::Destroy { id } => {
-                    let sctk_popup = match self
-                        .popups
-                        .iter()
-                        .position(|s| s.data.id == id)
-                    {
+                    let sctk_popup = match self.popups.iter().position(|s| s.data.id == id) {
                         Some(p) => self.popups.remove(p),
                         None => {
                             log::info!("No popup to destroy");
                             return Ok(());
-                        },
+                        }
                     };
                     let mut to_destroy = vec![sctk_popup];
                     // TODO optionally destroy parents if they request to be destroyed with children
-                    while let Some(popup_to_destroy_last) = to_destroy.last().and_then(|popup| self
-                        .popups
-                        .iter()
-                        .position(|p| popup.data.parent.wl_surface() == p.popup.wl_surface() && p.close_with_children)) {
+                    while let Some(popup_to_destroy_last) = to_destroy.last().and_then(|popup| {
+                        self.popups.iter().position(|p| {
+                            popup.data.parent.wl_surface() == p.popup.wl_surface()
+                                && p.close_with_children
+                        })
+                    }) {
                         let popup_to_destroy_last = self.popups.remove(popup_to_destroy_last);
                         to_destroy.push(popup_to_destroy_last);
                     }
                     to_destroy.reverse();
 
-                    while let Some(popup_to_destroy_first) = to_destroy.last().and_then(|popup| self
-                        .popups
-                        .iter()
-                        .position(|p| p.data.parent.wl_surface() == popup.popup.wl_surface())) {
+                    while let Some(popup_to_destroy_first) = to_destroy.last().and_then(|popup| {
+                        self.popups
+                            .iter()
+                            .position(|p| p.data.parent.wl_surface() == popup.popup.wl_surface())
+                    }) {
                         let popup_to_destroy_first = self.popups.remove(popup_to_destroy_first);
                         to_destroy.push(popup_to_destroy_first);
                     }
@@ -1358,58 +1365,103 @@ impl SctkState {
                             }
                         }
 
-                        let (removed, remaining): (Vec<_>, Vec<_>) =  self
+                        let (removed, remaining): (Vec<_>, Vec<_>) = self
                             .subsurfaces
                             .drain(..)
-                            .partition(|s| {
-                                s.instance.parent == *popup.popup.wl_surface()
-                            });
+                            .partition(|s| s.instance.parent == *popup.popup.wl_surface());
 
                         self.subsurfaces = remaining;
-                        for s in removed
-                        {
+                        for s in removed {
                             crate::subsurface_widget::remove_iced_subsurface(
                                 &s.instance.wl_surface,
                             );
-                            send_event(&self.events_sender, &self.proxy,
-                                SctkEvent::SubsurfaceEvent( crate::sctk_event::SubsurfaceEventVariant::Destroyed(s.instance) )
+                            send_event(
+                                &self.events_sender,
+                                &self.proxy,
+                                SctkEvent::SubsurfaceEvent(
+                                    crate::sctk_event::SubsurfaceEventVariant::Destroyed(
+                                        s.instance,
+                                    ),
+                                ),
                             );
                         }
-                        _ = send_event(&self.events_sender, &self.proxy,
-                            SctkEvent::PopupEvent { variant: crate::sctk_event::PopupEventVariant::Done, toplevel_id: popup.data.toplevel.clone(), parent_id: popup.data.parent.wl_surface().clone(), id: popup.popup.wl_surface().clone() });
+                        _ = send_event(
+                            &self.events_sender,
+                            &self.proxy,
+                            SctkEvent::PopupEvent {
+                                variant: crate::sctk_event::PopupEventVariant::Done,
+                                toplevel_id: popup.data.toplevel.clone(),
+                                parent_id: popup.data.parent.wl_surface().clone(),
+                                id: popup.popup.wl_surface().clone(),
+                            },
+                        );
                     }
-                },
+                }
                 platform_specific::wayland::popup::Action::Size { id, width, height } => {
-                    if let Some(sctk_popup) = self
-                        .popups
-                        .iter_mut()
-                        .find(|s| s.data.id == id)
-                    {
+                    if let Some(sctk_popup) = self.popups.iter_mut().find(|s| s.data.id == id) {
                         // update geometry
                         // update positioner
-                        sctk_popup.set_size(width, height, TOKEN_CTR.fetch_add(1, std::sync::atomic::Ordering::Relaxed));
+                        sctk_popup.set_size(
+                            width,
+                            height,
+                            TOKEN_CTR.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+                        );
                         let surface = sctk_popup.popup.wl_surface().clone();
-                        _ = send_event(&self.events_sender, &self.proxy,
-                            SctkEvent::PopupEvent { variant: crate::sctk_event::PopupEventVariant::Size(width, height), toplevel_id: sctk_popup.data.parent.wl_surface().clone(), parent_id: sctk_popup.data.parent.wl_surface().clone(), id: surface });
+                        _ = send_event(
+                            &self.events_sender,
+                            &self.proxy,
+                            SctkEvent::PopupEvent {
+                                variant: crate::sctk_event::PopupEventVariant::Size(width, height),
+                                toplevel_id: sctk_popup.data.parent.wl_surface().clone(),
+                                parent_id: sctk_popup.data.parent.wl_surface().clone(),
+                                id: surface,
+                            },
+                        );
                     }
-                },
+                }
             },
             Action::Activation(activation_event) => match activation_event {
-                platform_specific::wayland::activation::Action::RequestToken { app_id, window, channel } => {
+                platform_specific::wayland::activation::Action::RequestToken {
+                    app_id,
+                    window,
+                    channel,
+                } => {
                     if let Some(activation_state) = self.activation_state.as_ref() {
                         let (seat_and_serial, surface) = if let Some(id) = window {
-                            let surface = self.windows.iter().find(|w| w.id == id)
+                            let surface = self
+                                .windows
+                                .iter()
+                                .find(|w| w.id == id)
                                 .map(|w| w.wl_surface(&self.connection).clone())
-                                .or_else(|| self.layer_surfaces.iter().find(|l| l.id == id)
-                                    .map(|l| l.surface.wl_surface().clone())
-                                );
+                                .or_else(|| {
+                                    self.layer_surfaces
+                                        .iter()
+                                        .find(|l| l.id == id)
+                                        .map(|l| l.surface.wl_surface().clone())
+                                });
                             let seat_and_serial = surface.as_ref().and_then(|surface| {
-                                self.seats.first().and_then(|seat| if seat.kbd_focus.as_ref().map(|focus| focus == surface).unwrap_or(false) {
-                                    seat.last_kbd_press.as_ref().map(|(_, serial)| (seat.seat.clone(), *serial))
-                                } else if seat.ptr_focus.as_ref().map(|focus| focus == surface).unwrap_or(false) {
-                                    seat.last_ptr_press.as_ref().map(|(_, _, serial)| (seat.seat.clone(), *serial))
-                                } else {
-                                    None
+                                self.seats.first().and_then(|seat| {
+                                    if seat
+                                        .kbd_focus
+                                        .as_ref()
+                                        .map(|focus| focus == surface)
+                                        .unwrap_or(false)
+                                    {
+                                        seat.last_kbd_press
+                                            .as_ref()
+                                            .map(|(_, serial)| (seat.seat.clone(), *serial))
+                                    } else if seat
+                                        .ptr_focus
+                                        .as_ref()
+                                        .map(|focus| focus == surface)
+                                        .unwrap_or(false)
+                                    {
+                                        seat.last_ptr_press
+                                            .as_ref()
+                                            .map(|(_, _, serial)| (seat.seat.clone(), *serial))
+                                    } else {
+                                        None
+                                    }
                                 })
                             });
 
@@ -1418,30 +1470,38 @@ impl SctkState {
                             (None, None)
                         };
 
-
-                        activation_state.request_token_with_data(&self.queue_handle,
-                            IcedRequestData::new(RequestData {
+                        activation_state.request_token_with_data(
+                            &self.queue_handle,
+                            IcedRequestData::new(
+                                RequestData {
                                     app_id,
                                     seat_and_serial,
                                     surface,
                                 },
-                            self.activation_token_ctr
-                            )
+                                self.activation_token_ctr,
+                            ),
                         );
-                        _ = self.token_senders.insert(self.activation_token_ctr, channel);
+                        _ = self
+                            .token_senders
+                            .insert(self.activation_token_ctr, channel);
                         self.activation_token_ctr = self.activation_token_ctr.wrapping_add(1);
                     } else {
                         // if we don't have the global, we don't want to stall the app
                         _ = channel.send(None);
                     }
-                },
+                }
                 platform_specific::wayland::activation::Action::Activate { window, token } => {
                     if let Some(activation_state) = self.activation_state.as_ref() {
-                        if let Some(surface) = self.windows.iter().find(|w| w.id == window).map(|w| w.wl_surface(&self.connection)) {
+                        if let Some(surface) = self
+                            .windows
+                            .iter()
+                            .find(|w| w.id == window)
+                            .map(|w| w.wl_surface(&self.connection))
+                        {
                             activation_state.activate::<SctkState>(&surface, token)
                         }
                     }
-                },
+                }
             },
             Action::SessionLock(action) => match action {
                 platform_specific::wayland::session_lock::Action::Lock => {
@@ -1469,47 +1529,55 @@ impl SctkState {
                     // TODO how to handle this when there's no lock?
                     if let Some((surface, _)) = self.get_lock_surface(id, &output) {
                         let wl_surface = surface.wl_surface();
-                        
+
                         receive_frame(&mut self.frame_status, &wl_surface);
                     }
                 }
                 platform_specific::wayland::session_lock::Action::DestroyLockSurface { id } => {
-                    if let Some(i) =
-                        self.lock_surfaces.iter().position(|s| {
-                            s.id == id
-                        })
-                    {
+                    if let Some(i) = self.lock_surfaces.iter().position(|s| s.id == id) {
                         let surface = self.lock_surfaces.remove(i);
                         if let Some(blurred) = self.blur_surfaces.remove(&surface.id) {
                             for s in blurred {
                                 s.destroy();
                             }
                         }
-                        let (removed, remaining): (Vec<_>, Vec<_>) =  self
-                            .subsurfaces
-                            .drain(..)
-                            .partition(|s| {
+                        let (removed, remaining): (Vec<_>, Vec<_>) =
+                            self.subsurfaces.drain(..).partition(|s| {
                                 s.instance.parent == *surface.session_lock_surface.wl_surface()
                             });
 
                         self.subsurfaces = remaining;
-                        for s in removed
-                        {
+                        for s in removed {
                             crate::subsurface_widget::remove_iced_subsurface(
                                 &s.instance.wl_surface,
                             );
-                            send_event(&self.events_sender, &self.proxy,
-                                SctkEvent::SubsurfaceEvent( crate::sctk_event::SubsurfaceEventVariant::Destroyed(s.instance) )
+                            send_event(
+                                &self.events_sender,
+                                &self.proxy,
+                                SctkEvent::SubsurfaceEvent(
+                                    crate::sctk_event::SubsurfaceEventVariant::Destroyed(
+                                        s.instance,
+                                    ),
+                                ),
                             );
                         }
-                        if let Some(id) = self.id_map.remove(&surface.session_lock_surface.wl_surface().id()) {
+                        if let Some(id) = self
+                            .id_map
+                            .remove(&surface.session_lock_surface.wl_surface().id())
+                        {
                             _ = self.destroyed.insert(id);
                         }
 
-                        send_event(&self.events_sender, &self.proxy, SctkEvent::SessionLockSurfaceDone { surface: surface.session_lock_surface.wl_surface().clone() });
+                        send_event(
+                            &self.events_sender,
+                            &self.proxy,
+                            SctkEvent::SessionLockSurfaceDone {
+                                surface: surface.session_lock_surface.wl_surface().clone(),
+                            },
+                        );
                     }
                 }
-            }
+            },
             Action::OverlapNotify(id, enabled) => {
                 if let Some(layer_surface) = self.layer_surfaces.iter_mut().find(|l| l.id == id) {
                     let Some(overlap_notify_state) = self.overlap_notify.as_ref() else {
@@ -1522,46 +1590,72 @@ impl SctkState {
                             log::error!("Overlap notify is not supported for non wlr surface.");
                             return Ok(());
                         };
-                        let notification = overlap_notify_state.notify.notify_on_overlap(wlr, &self.queue_handle, OverlapNotificationV1 { surface: layer_surface.surface.wl_surface().clone() });
+                        let notification = overlap_notify_state.notify.notify_on_overlap(
+                            wlr,
+                            &self.queue_handle,
+                            OverlapNotificationV1 {
+                                surface: layer_surface.surface.wl_surface().clone(),
+                            },
+                        );
                         _ = self.overlap_notifications.insert(my_id, notification);
                     } else {
                         _ = self.overlap_notifications.remove(&my_id);
                     }
                 } else {
-                    log::error!("Overlap notify subscription cannot be created for surface. No matching layer surface found.");
+                    log::error!(
+                        "Overlap notify subscription cannot be created for surface. No matching layer surface found."
+                    );
                 }
-            },
+            }
             Action::Subsurface(action) => match action {
-                subsurface::Action::Subsurface { subsurface: subsurface_settings } => {
+                subsurface::Action::Subsurface {
+                    subsurface: subsurface_settings,
+                } => {
                     let parent_id = subsurface_settings.parent;
-                    if let Ok((_, parent, subsurface, common_surface, common)) = self.get_subsurface(subsurface_settings.clone()) {
+                    if let Ok((_, parent, subsurface, common_surface, common)) =
+                        self.get_subsurface(subsurface_settings.clone())
+                    {
                         // TODO Ashley: all surfaces should probably have an optional title for a11y if nothing else
                         receive_frame(&mut self.frame_status, &subsurface);
-                        send_event(&self.events_sender, &self.proxy,
-                            SctkEvent::SubsurfaceEvent (crate::sctk_event::SubsurfaceEventVariant::Created{
-                                parent_id,
-                                parent,
-                                surface: subsurface,
-                                qh: self.queue_handle.clone(),
-                                common_surface,
-                                surface_id: subsurface_settings.id,
-                                common,
-                                display: self.connection.display(),
-                                z: subsurface_settings.z,
-                            })
+                        send_event(
+                            &self.events_sender,
+                            &self.proxy,
+                            SctkEvent::SubsurfaceEvent(
+                                crate::sctk_event::SubsurfaceEventVariant::Created {
+                                    parent_id,
+                                    parent,
+                                    surface: subsurface,
+                                    qh: self.queue_handle.clone(),
+                                    common_surface,
+                                    surface_id: subsurface_settings.id,
+                                    common,
+                                    display: self.connection.display(),
+                                    z: subsurface_settings.z,
+                                },
+                            ),
                         );
                     }
-                },
+                }
                 subsurface::Action::Destroy { id } => {
                     let mut destroyed = vec![];
                     if let Some(subsurface) = self.subsurfaces.iter().position(|s| s.id == id) {
                         let subsurface = self.subsurfaces.remove(subsurface);
-                        destroyed.push((subsurface.instance.wl_surface.clone(), subsurface.instance.parent.clone(), subsurface.id));
+                        destroyed.push((
+                            subsurface.instance.wl_surface.clone(),
+                            subsurface.instance.parent.clone(),
+                            subsurface.id,
+                        ));
 
                         subsurface.instance.wl_surface.attach(None, 0, 0);
                         subsurface.instance.wl_surface.commit();
-                        send_event(&self.events_sender, &self.proxy,
-                            SctkEvent::SubsurfaceEvent( crate::sctk_event::SubsurfaceEventVariant::Destroyed(subsurface.instance) )
+                        send_event(
+                            &self.events_sender,
+                            &self.proxy,
+                            SctkEvent::SubsurfaceEvent(
+                                crate::sctk_event::SubsurfaceEventVariant::Destroyed(
+                                    subsurface.instance,
+                                ),
+                            ),
                         );
                     }
                     for (destroyed, parent, id) in destroyed {
@@ -1570,19 +1664,22 @@ impl SctkState {
                                 s.destroy();
                             }
                         }
-                        if let Some((wl_surface, f)) = self.seats.iter_mut().find(|f| {
-                            f.kbd_focus.as_ref().is_some_and(|f| *f == destroyed)
-                        }).and_then(|f| Some((parent, &mut f.kbd_focus))) {
+                        if let Some((wl_surface, f)) = self
+                            .seats
+                            .iter_mut()
+                            .find(|f| f.kbd_focus.as_ref().is_some_and(|f| *f == destroyed))
+                            .and_then(|f| Some((parent, &mut f.kbd_focus)))
+                        {
                             *f = Some(wl_surface);
                         }
                     }
-                },
+                }
                 subsurface::Action::Reposition { id, x, y } => {
                     if let Some(subsurface) = self.subsurfaces.iter().find(|s| s.id == id) {
                         subsurface.instance.wl_subsurface.set_position(x, y);
                         subsurface.instance.wl_surface.commit();
                     }
-                },
+                }
             },
             Action::InhibitShortcuts(v) => {
                 if let Some(manager) = self.inhibitor_manager.as_ref() {
@@ -1590,25 +1687,33 @@ impl SctkState {
                         inhibit.destroy();
                     }
                     if v {
-                        self.inhibitor = self.seats.iter().next()
-                        .and_then(|s| s.kbd_focus.as_ref().map(|surface| manager.inhibit_shortcuts(surface, &s.seat, &self.queue_handle, ())));
+                        self.inhibitor = self.seats.iter().next().and_then(|s| {
+                            s.kbd_focus.as_ref().map(|surface| {
+                                manager.inhibit_shortcuts(surface, &s.seat, &self.queue_handle, ())
+                            })
+                        });
                     }
                 }
             }
             Action::RoundedCorners(id, v) => {
                 if let Some(manager) = self.corner_radius_manager.as_ref() {
                     if let Some(w) = self.windows.iter_mut().find(|w| w.id == id) {
-                        let geo_size: LogicalSize<f64> = w.window.surface_size().cast::<f64>().to_logical(w.window.scale_factor());
+                        let geo_size: LogicalSize<f64> = w
+                            .window
+                            .surface_size()
+                            .cast::<f64>()
+                            .to_logical(w.window.scale_factor());
                         let half_min_dim = (geo_size.width as u32).min(geo_size.height as u32) / 2;
 
                         if let Some(radii) = v {
-                            let adjusted_radii  = CornerRadius {
+                            let adjusted_radii = CornerRadius {
                                 top_left: radii.top_left.min(half_min_dim),
                                 top_right: radii.top_right.min(half_min_dim),
                                 bottom_right: radii.bottom_right.min(half_min_dim),
                                 bottom_left: radii.bottom_left.min(half_min_dim),
                             };
-                            if let Some((protocol_object, corner_radii)) = w.corner_radius.as_mut() {
+                            if let Some((protocol_object, corner_radii)) = w.corner_radius.as_mut()
+                            {
                                 if *corner_radii != Some(adjusted_radii) {
                                     protocol_object.0.0.set_radius(
                                         adjusted_radii.top_left,
@@ -1621,7 +1726,8 @@ impl SctkState {
                             } else {
                                 let toplevel = w.xdg_toplevel(&self.connection);
 
-                                let protocol_object = manager.get_corner_radius(&toplevel, &self.queue_handle, ());
+                                let protocol_object =
+                                    manager.get_corner_radius(&toplevel, &self.queue_handle, ());
 
                                 protocol_object.set_radius(
                                     adjusted_radii.top_left,
@@ -1629,7 +1735,12 @@ impl SctkState {
                                     adjusted_radii.bottom_right,
                                     adjusted_radii.bottom_left,
                                 );
-                                w.corner_radius = Some((SctkCornerRadius(Arc::new(MyCosmicCornerRadiusToplevelV1( protocol_object))), Some(adjusted_radii.clone())));
+                                w.corner_radius = Some((
+                                    SctkCornerRadius(Arc::new(MyCosmicCornerRadiusToplevelV1(
+                                        protocol_object,
+                                    ))),
+                                    Some(adjusted_radii.clone()),
+                                ));
                             }
                         } else {
                             if let Some(old) = w.corner_radius.as_mut() {
@@ -1638,7 +1749,7 @@ impl SctkState {
                             }
                         }
                     } else {
-                        if let Some(v) = v{
+                        if let Some(v) = v {
                             _ = self.pending_corner_radius.insert(id, v);
                         } else {
                             _ = self.pending_corner_radius.remove(&id);
@@ -1649,11 +1760,15 @@ impl SctkState {
             Action::BlurSurface(id, rectangles) => {
                 use wayland_protocols::ext::background_effect::v1::client::ext_background_effect_manager_v1;
 
-                if let Some(bg_effect_mgr) = self.ext_background_effect_manager.as_mut() && !bg_effect_mgr.capabilities().contains(ext_background_effect_manager_v1::Capability::Blur) {
+                if let Some(bg_effect_mgr) = self.ext_background_effect_manager.as_mut()
+                    && !bg_effect_mgr
+                        .capabilities()
+                        .contains(ext_background_effect_manager_v1::Capability::Blur)
+                {
                     bg_effect_mgr.enqueue(id, rectangles.clone());
                     return Ok(());
                 }
-                
+
                 let s = if let Some(s) = self.popups.iter().find(|s| s.data.id == id) {
                     s.popup.wl_surface()
                 } else if let Some(s) = self.layer_surfaces.iter().find(|s| s.id == id) {
@@ -1673,26 +1788,33 @@ impl SctkState {
                         for region in blur_surfaces {
                             region.destroy();
                         }
-                    },
+                    }
                     (Entry::Occupied(mut occupied_entry), Some(rectangles)) => {
                         let blur_surfaces = occupied_entry.get_mut();
-                        let regions = rectangles.into_iter().map(|rect| {
-                            let region = self
-                                .compositor_state
-                                .wl_compositor()
-                                .create_region(&self.queue_handle, ());
-                            region.add(
-                                rect.x.round() as i32,
-                                rect.y.round() as i32,
-                                rect.width.round() as i32,
-                                rect.height.round() as i32,
-                            );
-                            region
-                        }).collect::<Vec<_>>();
+                        let regions = rectangles
+                            .into_iter()
+                            .map(|rect| {
+                                let region = self
+                                    .compositor_state
+                                    .wl_compositor()
+                                    .create_region(&self.queue_handle, ());
+                                region.add(
+                                    rect.x.round() as i32,
+                                    rect.y.round() as i32,
+                                    rect.width.round() as i32,
+                                    rect.height.round() as i32,
+                                );
+                                region
+                            })
+                            .collect::<Vec<_>>();
                         if regions.len() > blur_surfaces.len() {
                             // add extra blur surfaces if needed
                             for _ in blur_surfaces.len()..regions.len() {
-                                let Some(extra_region) = self.ext_background_effect_manager.as_mut().map(|mgr| mgr.blur(s, &self.queue_handle)) else {
+                                let Some(extra_region) = self
+                                    .ext_background_effect_manager
+                                    .as_mut()
+                                    .map(|mgr| mgr.blur(s, &self.queue_handle))
+                                else {
                                     log::error!("Failed to create blur effect for surface");
                                     return Ok(());
                                 };
@@ -1705,38 +1827,43 @@ impl SctkState {
                         }
 
                         // update existing blur surfaces
-                        for (blur_surface, region) in blur_surfaces.iter().zip(regions.into_iter()) {
+                        for (blur_surface, region) in blur_surfaces.iter().zip(regions.into_iter())
+                        {
                             blur_surface.set_blur_region(Some(&region));
                         }
-                    },
+                    }
                     (Entry::Vacant(..), None) => {
                         // nothing to remove
-                    },
+                    }
                     (Entry::Vacant(vacant_entry), Some(rectangles)) => {
                         if self.ext_background_effect_manager.is_none() {
                             log::error!("Blur effect is not supported.");
                             return Ok(());
                         }
-                        let blur_surfaces = rectangles.into_iter().map(|rect| {
-                            let region = self
-                                .compositor_state
-                                .wl_compositor()
-                                .create_region(&self.queue_handle, ());
-                            region.add(
-                                rect.x.round() as i32,
-                                rect.y.round() as i32,
-                                rect.width.round() as i32,
-                                rect.height.round() as i32,
-                            );
-                            let blur_manager = self.ext_background_effect_manager.as_mut().unwrap();
-                            let blur_surface = blur_manager.blur(s, &self.queue_handle);
-                            blur_surface.set_blur_region(Some(&region));
-                            blur_surface
-                        }).collect::<Vec<_>>();
+                        let blur_surfaces = rectangles
+                            .into_iter()
+                            .map(|rect| {
+                                let region = self
+                                    .compositor_state
+                                    .wl_compositor()
+                                    .create_region(&self.queue_handle, ());
+                                region.add(
+                                    rect.x.round() as i32,
+                                    rect.y.round() as i32,
+                                    rect.width.round() as i32,
+                                    rect.height.round() as i32,
+                                );
+                                let blur_manager =
+                                    self.ext_background_effect_manager.as_mut().unwrap();
+                                let blur_surface = blur_manager.blur(s, &self.queue_handle);
+                                blur_surface.set_blur_region(Some(&region));
+                                blur_surface
+                            })
+                            .collect::<Vec<_>>();
                         _ = vacant_entry.insert(blur_surfaces);
-                    },
+                    }
                 }
-            },
+            }
         };
         Ok(())
     }
@@ -1768,64 +1895,60 @@ impl SctkState {
                 // center on
                 loc.x -= half_w;
                 loc.y -= half_h;
-            },
+            }
             wayland_protocols::xdg::shell::client::xdg_positioner::Gravity::Top => {
                 loc.x -= half_w;
                 loc.y -= size.height;
-            },
+            }
             wayland_protocols::xdg::shell::client::xdg_positioner::Gravity::Bottom => {
                 loc.x -= half_w;
-            },
+            }
             wayland_protocols::xdg::shell::client::xdg_positioner::Gravity::Left => {
                 loc.y -= half_h;
                 loc.x -= size.width;
-            },
+            }
             wayland_protocols::xdg::shell::client::xdg_positioner::Gravity::Right => {
                 loc.y -= half_h;
-            },
+            }
             wayland_protocols::xdg::shell::client::xdg_positioner::Gravity::TopLeft => {
                 loc.y -= size.height;
                 loc.x -= size.width;
-            },
+            }
             wayland_protocols::xdg::shell::client::xdg_positioner::Gravity::BottomLeft => {
                 loc.x -= size.width;
-            },
+            }
             wayland_protocols::xdg::shell::client::xdg_positioner::Gravity::TopRight => {
                 loc.y -= size.height;
-            },
-            wayland_protocols::xdg::shell::client::xdg_positioner::Gravity::BottomRight => {},
+            }
+            wayland_protocols::xdg::shell::client::xdg_positioner::Gravity::BottomRight => {}
             _ => unimplemented!(),
         };
         let bounds = Rectangle::new(loc, size);
 
-        let parent = if let Some(parent) =
-            self.layer_surfaces.iter().find(|l| l.id == settings.parent)
-        {
-            PopupParent::LayerSurface(parent.surface.wl_surface().clone())
-        } else if let Some(parent) =
-            self.windows.iter().find(|w| w.id == settings.parent)
-        {
-            PopupParent::Window(parent.wl_surface(&self.connection))
-        } else if let Some(i) = self
-            .popups
-            .iter()
-            .position(|p| p.data.id == settings.parent)
-        {
-            let parent = &self.popups[i];
-            PopupParent::Popup(parent.popup.wl_surface().clone())
-        } else if let Some(i) = self
-            .lock_surfaces
-            .iter()
-            .position(|p| p.id == settings.parent)
-        {
-            let parent = &self.lock_surfaces[i];
-            PopupParent::Popup(parent.session_lock_surface.wl_surface().clone())
-        } else {
-            return Err(SubsurfaceCreationError::ParentMissing);
-        };
+        let parent =
+            if let Some(parent) = self.layer_surfaces.iter().find(|l| l.id == settings.parent) {
+                PopupParent::LayerSurface(parent.surface.wl_surface().clone())
+            } else if let Some(parent) = self.windows.iter().find(|w| w.id == settings.parent) {
+                PopupParent::Window(parent.wl_surface(&self.connection))
+            } else if let Some(i) = self
+                .popups
+                .iter()
+                .position(|p| p.data.id == settings.parent)
+            {
+                let parent = &self.popups[i];
+                PopupParent::Popup(parent.popup.wl_surface().clone())
+            } else if let Some(i) = self
+                .lock_surfaces
+                .iter()
+                .position(|p| p.id == settings.parent)
+            {
+                let parent = &self.lock_surfaces[i];
+                PopupParent::Popup(parent.session_lock_surface.wl_surface().clone())
+            } else {
+                return Err(SubsurfaceCreationError::ParentMissing);
+            };
 
-        let wl_surface =
-            self.compositor_state.create_surface(&self.queue_handle);
+        let wl_surface = self.compositor_state.create_surface(&self.queue_handle);
         _ = self.id_map.insert(wl_surface.id(), settings.id.clone());
 
         for s in self.seats.iter_mut() {
@@ -1874,20 +1997,16 @@ impl SctkState {
             .as_ref()
             .map(|fsm| fsm.fractional_scaling(&wl_surface, &self.queue_handle));
 
-        let wp_alpha_modifier_surface = subsurface_state
-            .wp_alpha_modifier
-            .as_ref()
-            .map(|wp_alpha_modifier| {
-                wp_alpha_modifier.get_surface(
-                    &wl_surface,
-                    &self.queue_handle,
-                    (),
-                )
-            });
+        let wp_alpha_modifier_surface =
+            subsurface_state
+                .wp_alpha_modifier
+                .as_ref()
+                .map(|wp_alpha_modifier| {
+                    wp_alpha_modifier.get_surface(&wl_surface, &self.queue_handle, ())
+                });
         wp_viewport.set_destination(size.width as i32, size.height as i32);
 
-        let mut common: Common =
-            LogicalSize::new(size.width as u32, size.height as u32).into();
+        let mut common: Common = LogicalSize::new(size.width as u32, size.height as u32).into();
         let instance = SubsurfaceInstance {
             wl_surface: wl_surface.clone(),
             wl_subsurface: wl_subsurface.clone(),
@@ -1897,8 +2016,7 @@ impl SctkState {
 
             wl_buffer: None,
             bounds: Some(bounds),
-            transform:
-                cctk::wayland_client::protocol::wl_output::Transform::Normal,
+            transform: cctk::wayland_client::protocol::wl_output::Transform::Normal,
             z: settings.z,
             parent: parent_wl_surface.clone(),
         };
@@ -1911,9 +2029,7 @@ impl SctkState {
                 .as_ref()
                 .is_some_and(|s| s == parent_wl_surface)
             {
-                let id = winit::window::WindowId::from_raw(
-                    wl_surface.id().as_ptr() as usize,
-                );
+                let id = winit::window::WindowId::from_raw(wl_surface.id().as_ptr() as usize);
                 self.sctk_events.push(SctkEvent::Winit(
                     id,
                     winit::event::WindowEvent::Focused(true),
@@ -1958,8 +2074,7 @@ pub(crate) fn send_event(
     proxy: &winit::event_loop::EventLoopProxy,
     sctk_event: SctkEvent,
 ) {
-    _ = sender
-        .unbounded_send(Control::PlatformSpecific(Event::Wayland(sctk_event)));
+    _ = sender.unbounded_send(Control::PlatformSpecific(Event::Wayland(sctk_event)));
     proxy.wake_up();
 }
 

--- a/winit/src/platform_specific/wayland/handlers/compositor.rs
+++ b/winit/src/platform_specific/wayland/handlers/compositor.rs
@@ -9,8 +9,7 @@ use cctk::sctk::{
 };
 
 use crate::{
-    event_loop::state::receive_frame,
-    platform_specific::wayland::event_loop::state::SctkState,
+    event_loop::state::receive_frame, platform_specific::wayland::event_loop::state::SctkState,
 };
 
 impl CompositorHandler for SctkState {

--- a/winit/src/platform_specific/wayland/handlers/ext_background_effect.rs
+++ b/winit/src/platform_specific/wayland/handlers/ext_background_effect.rs
@@ -7,7 +7,9 @@ use sctk::globals::GlobalData;
 use sctk::reexports::client::globals::{BindError, GlobalList};
 use sctk::reexports::client::protocol::wl_surface::WlSurface;
 use sctk::reexports::client::{Connection, Dispatch, Proxy, QueueHandle, delegate_dispatch};
-use wayland_protocols::ext::background_effect::v1::client::ext_background_effect_manager_v1::{Capability, Event, ExtBackgroundEffectManagerV1};
+use wayland_protocols::ext::background_effect::v1::client::ext_background_effect_manager_v1::{
+    Capability, Event, ExtBackgroundEffectManagerV1,
+};
 use wayland_protocols::ext::background_effect::v1::client::ext_background_effect_surface_v1::ExtBackgroundEffectSurfaceV1;
 
 use crate::event_loop::state::SctkState;
@@ -51,9 +53,7 @@ impl ExtBackgroundEffectManager {
     }
 }
 
-impl Dispatch<ExtBackgroundEffectManagerV1, GlobalData, SctkState>
-    for ExtBackgroundEffectManager
-{
+impl Dispatch<ExtBackgroundEffectManagerV1, GlobalData, SctkState> for ExtBackgroundEffectManager {
     fn event(
         state: &mut SctkState,
         _: &ExtBackgroundEffectManagerV1,
@@ -66,12 +66,9 @@ impl Dispatch<ExtBackgroundEffectManagerV1, GlobalData, SctkState>
             Event::Capabilities { flags } => match flags {
                 wayland_client::WEnum::Value(capability) => {
                     let mut queued_actions = Vec::new();
-                    if let Some(bg_effect_mgr) =
-                        state.ext_background_effect_manager.as_mut()
-                    {
+                    if let Some(bg_effect_mgr) = state.ext_background_effect_manager.as_mut() {
                         bg_effect_mgr.capabilities = capability;
-                        queued_actions =
-                            bg_effect_mgr.queued_blur_actions.drain().collect();
+                        queued_actions = bg_effect_mgr.queued_blur_actions.drain().collect();
                     }
                     for (id, rects) in queued_actions {
                         _ = state.handle_action(Action::BlurSurface(id, rects));
@@ -88,9 +85,7 @@ impl Dispatch<ExtBackgroundEffectManagerV1, GlobalData, SctkState>
     }
 }
 
-impl Dispatch<ExtBackgroundEffectSurfaceV1, (), SctkState>
-    for ExtBackgroundEffectManager
-{
+impl Dispatch<ExtBackgroundEffectSurfaceV1, (), SctkState> for ExtBackgroundEffectManager {
     fn event(
         _: &mut SctkState,
         _: &ExtBackgroundEffectSurfaceV1,

--- a/winit/src/platform_specific/wayland/handlers/output.rs
+++ b/winit/src/platform_specific/wayland/handlers/output.rs
@@ -1,6 +1,4 @@
-use crate::platform_specific::wayland::{
-    event_loop::state::SctkState, sctk_event::SctkEvent,
-};
+use crate::platform_specific::wayland::{event_loop::state::SctkState, sctk_event::SctkEvent};
 use cctk::sctk::{delegate_output, output::OutputHandler};
 
 impl OutputHandler for SctkState {

--- a/winit/src/platform_specific/wayland/handlers/overlap.rs
+++ b/winit/src/platform_specific/wayland/handlers/overlap.rs
@@ -1,15 +1,17 @@
+use cctk::sctk::globals::GlobalData;
 use cctk::{
     cosmic_protocols::overlap_notify::v1::client::{
         zcosmic_overlap_notification_v1::{self, ZcosmicOverlapNotificationV1},
         zcosmic_overlap_notify_v1::ZcosmicOverlapNotifyV1,
-    }, sctk::shell::wlr_layer::Layer, wayland_client::{
-        self, event_created_child,
+    },
+    sctk::shell::wlr_layer::Layer,
+    wayland_client::{
+        self, Connection, Dispatch, Proxy, QueueHandle, event_created_child,
         globals::{BindError, GlobalList},
         protocol::wl_surface::WlSurface,
-        Connection, Dispatch, Proxy, QueueHandle,
-    }, wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1
+    },
+    wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
 };
-use cctk::sctk::globals::GlobalData;
 use iced_futures::core::Rectangle;
 
 use crate::{event_loop::state::SctkState, sctk_event::SctkEvent};
@@ -29,9 +31,7 @@ impl OverlapNotifyV1 {
     }
 }
 
-impl Dispatch<ZcosmicOverlapNotifyV1, GlobalData, SctkState>
-    for OverlapNotifyV1
-{
+impl Dispatch<ZcosmicOverlapNotifyV1, GlobalData, SctkState> for OverlapNotifyV1 {
     fn event(
         _: &mut SctkState,
         _: &ZcosmicOverlapNotifyV1,

--- a/winit/src/platform_specific/wayland/handlers/seat/keyboard.rs
+++ b/winit/src/platform_specific/wayland/handlers/seat/keyboard.rs
@@ -32,10 +32,11 @@ impl KeyboardHandler for SctkState {
                     None => return,
                 };
 
-            let surface = if let Some(subsurface) =
-                self.subsurfaces.iter().find(|s| {
-                    s.steals_keyboard_focus && s.instance.parent == *surface
-                }) {
+            let surface = if let Some(subsurface) = self
+                .subsurfaces
+                .iter()
+                .find(|s| s.steals_keyboard_focus && s.instance.parent == *surface)
+            {
                 &subsurface.instance.wl_surface
             } else {
                 surface
@@ -52,14 +53,13 @@ impl KeyboardHandler for SctkState {
         }
         self.request_redraw(&surface);
 
-        let surfaces = self.subsurfaces.iter().filter_map(|s| {
-            (s.instance.parent == *surface).then(|| &s.instance.wl_surface)
-        });
+        let surfaces = self
+            .subsurfaces
+            .iter()
+            .filter_map(|s| (s.instance.parent == *surface).then(|| &s.instance.wl_surface));
         for surface in surfaces.chain(std::iter::once(surface)) {
             if is_active {
-                let id = winit::window::WindowId::from_raw(
-                    surface.id().as_ptr() as usize,
-                );
+                let id = winit::window::WindowId::from_raw(surface.id().as_ptr() as usize);
                 if self.windows.iter().any(|w| w.window.id() == id) {
                     continue;
                 }
@@ -87,25 +87,25 @@ impl KeyboardHandler for SctkState {
     ) {
         self.request_redraw(surface);
         let (is_active, seat, kbd) = {
-            let (is_active, my_seat) =
-                match self.seats.iter_mut().enumerate().find_map(|(i, s)| {
-                    if s.kbd.as_ref() == Some(keyboard) {
-                        Some((i, s))
-                    } else {
-                        None
-                    }
-                }) {
-                    Some((i, s)) => (i == 0, s),
-                    None => return,
-                };
+            let (is_active, my_seat) = match self.seats.iter_mut().enumerate().find_map(|(i, s)| {
+                if s.kbd.as_ref() == Some(keyboard) {
+                    Some((i, s))
+                } else {
+                    None
+                }
+            }) {
+                Some((i, s)) => (i == 0, s),
+                None => return,
+            };
             let seat = my_seat.seat.clone();
             let kbd = keyboard.clone();
             _ = my_seat.kbd_focus.take();
             (is_active, seat, kbd)
         };
-        let surfaces = self.subsurfaces.iter().filter_map(|s| {
-            (s.instance.parent == *surface).then(|| &s.instance.wl_surface)
-        });
+        let surfaces = self
+            .subsurfaces
+            .iter()
+            .filter_map(|s| (s.instance.parent == *surface).then(|| &s.instance.wl_surface));
         for surface in surfaces.chain(std::iter::once(surface)) {
             if is_active {
                 self.sctk_events.push(SctkEvent::KeyboardEvent {
@@ -115,14 +115,10 @@ impl KeyboardHandler for SctkState {
                     surface: surface.clone(),
                 });
                 // if there is another seat with a keyboard focused on a surface make that the new active seat
-                if let Some(i) =
-                    self.seats.iter().position(|s| s.kbd_focus.is_some())
-                {
+                if let Some(i) = self.seats.iter().position(|s| s.kbd_focus.is_some()) {
                     self.seats.swap(0, i);
                     let s = &self.seats[0];
-                    let id = winit::window::WindowId::from_raw(
-                        surface.id().as_ptr() as usize,
-                    );
+                    let id = winit::window::WindowId::from_raw(surface.id().as_ptr() as usize);
                     if self.windows.iter().any(|w| w.window.id() == id) {
                         continue;
                     }
@@ -131,9 +127,7 @@ impl KeyboardHandler for SctkState {
                         winit::event::WindowEvent::Focused(true),
                     ));
                     self.sctk_events.push(SctkEvent::KeyboardEvent {
-                        variant: KeyboardEventVariant::Enter(
-                            s.kbd_focus.clone().unwrap(),
-                        ),
+                        variant: KeyboardEventVariant::Enter(s.kbd_focus.clone().unwrap()),
                         kbd_id: s.kbd.clone().unwrap(),
                         seat_id: s.seat.clone(),
                         surface: surface.clone(),
@@ -151,27 +145,26 @@ impl KeyboardHandler for SctkState {
         serial: u32,
         event: cctk::sctk::seat::keyboard::KeyEvent,
     ) {
-        let (is_active, my_seat) =
-            match self.seats.iter_mut().enumerate().find_map(|(i, s)| {
-                if s.kbd.as_ref() == Some(keyboard) {
-                    Some((i, s))
-                } else {
-                    None
-                }
-            }) {
-                Some((i, s)) => (i == 0, s),
-                None => return,
-            };
+        let (is_active, my_seat) = match self.seats.iter_mut().enumerate().find_map(|(i, s)| {
+            if s.kbd.as_ref() == Some(keyboard) {
+                Some((i, s))
+            } else {
+                None
+            }
+        }) {
+            Some((i, s)) => (i == 0, s),
+            None => return,
+        };
         let seat_id = my_seat.seat.clone();
         let kbd_id = keyboard.clone();
         _ = my_seat.last_kbd_press.replace((event.clone(), serial));
         if is_active {
             if let Some(surface) = my_seat.kbd_focus.clone() {
                 self.request_redraw(&surface);
-                let surfaces = self.subsurfaces.iter().filter_map(|s| {
-                    (s.instance.parent == surface)
-                        .then(|| &s.instance.wl_surface)
-                });
+                let surfaces = self
+                    .subsurfaces
+                    .iter()
+                    .filter_map(|s| (s.instance.parent == surface).then(|| &s.instance.wl_surface));
                 for surface in surfaces.chain(std::iter::once(&surface)) {
                     self.sctk_events.push(SctkEvent::KeyboardEvent {
                         variant: KeyboardEventVariant::Press(event.clone()),
@@ -192,27 +185,26 @@ impl KeyboardHandler for SctkState {
         _serial: u32,
         event: cctk::sctk::seat::keyboard::KeyEvent,
     ) {
-        let (is_active, my_seat) =
-            match self.seats.iter_mut().enumerate().find_map(|(i, s)| {
-                if s.kbd.as_ref() == Some(keyboard) {
-                    Some((i, s))
-                } else {
-                    None
-                }
-            }) {
-                Some((i, s)) => (i == 0, s),
-                None => return,
-            };
+        let (is_active, my_seat) = match self.seats.iter_mut().enumerate().find_map(|(i, s)| {
+            if s.kbd.as_ref() == Some(keyboard) {
+                Some((i, s))
+            } else {
+                None
+            }
+        }) {
+            Some((i, s)) => (i == 0, s),
+            None => return,
+        };
         let seat_id = my_seat.seat.clone();
         let kbd_id = keyboard.clone();
 
         if is_active {
             if let Some(surface) = my_seat.kbd_focus.clone() {
                 self.request_redraw(&surface);
-                let surfaces = self.subsurfaces.iter().filter_map(|s| {
-                    (s.instance.parent == surface)
-                        .then(|| &s.instance.wl_surface)
-                });
+                let surfaces = self
+                    .subsurfaces
+                    .iter()
+                    .filter_map(|s| (s.instance.parent == surface).then(|| &s.instance.wl_surface));
                 for surface in surfaces.chain(std::iter::once(&surface)) {
                     self.sctk_events.push(SctkEvent::KeyboardEvent {
                         variant: KeyboardEventVariant::Release(event.clone()),
@@ -235,32 +227,29 @@ impl KeyboardHandler for SctkState {
         _raw_modifiers: RawModifiers,
         _layout: u32,
     ) {
-        let (is_active, my_seat) =
-            match self.seats.iter_mut().enumerate().find_map(|(i, s)| {
-                if s.kbd.as_ref() == Some(keyboard) {
-                    Some((i, s))
-                } else {
-                    None
-                }
-            }) {
-                Some((i, s)) => (i == 0, s),
-                None => return,
-            };
+        let (is_active, my_seat) = match self.seats.iter_mut().enumerate().find_map(|(i, s)| {
+            if s.kbd.as_ref() == Some(keyboard) {
+                Some((i, s))
+            } else {
+                None
+            }
+        }) {
+            Some((i, s)) => (i == 0, s),
+            None => return,
+        };
         let seat_id = my_seat.seat.clone();
         let kbd_id = keyboard.clone();
 
         if is_active {
             if let Some(surface) = my_seat.kbd_focus.clone() {
                 self.request_redraw(&surface);
-                let surfaces = self.subsurfaces.iter().filter_map(|s| {
-                    (s.instance.parent == surface)
-                        .then(|| &s.instance.wl_surface)
-                });
+                let surfaces = self
+                    .subsurfaces
+                    .iter()
+                    .filter_map(|s| (s.instance.parent == surface).then(|| &s.instance.wl_surface));
                 for surface in surfaces.chain(std::iter::once(&surface)) {
                     self.sctk_events.push(SctkEvent::KeyboardEvent {
-                        variant: KeyboardEventVariant::Modifiers(
-                            modifiers.clone(),
-                        ),
+                        variant: KeyboardEventVariant::Modifiers(modifiers.clone()),
                         kbd_id: kbd_id.clone(),
                         seat_id: seat_id.clone(),
                         surface: surface.clone(),

--- a/winit/src/platform_specific/wayland/handlers/seat/keyboard_shortcuts_inhibit.rs
+++ b/winit/src/platform_specific/wayland/handlers/seat/keyboard_shortcuts_inhibit.rs
@@ -20,11 +20,8 @@ impl Dispatch<keyboard_shortcuts_inhibit::zv1::client::zwp_keyboard_shortcuts_in
     ) {}
 }
 
-impl
-    Dispatch<
-        zwp_keyboard_shortcuts_inhibitor_v1::ZwpKeyboardShortcutsInhibitorV1,
-        (),
-    > for SctkState
+impl Dispatch<zwp_keyboard_shortcuts_inhibitor_v1::ZwpKeyboardShortcutsInhibitorV1, ()>
+    for SctkState
 {
     fn event(
         state: &mut Self,

--- a/winit/src/platform_specific/wayland/handlers/seat/pointer.rs
+++ b/winit/src/platform_specific/wayland/handlers/seat/pointer.rs
@@ -1,15 +1,11 @@
 use crate::{
     event_loop::state::FrameStatus,
-    platform_specific::wayland::{
-        event_loop::state::SctkState, sctk_event::SctkEvent,
-    },
+    platform_specific::wayland::{event_loop::state::SctkState, sctk_event::SctkEvent},
 };
 use cctk::sctk::{
     delegate_pointer,
     reexports::client::Proxy,
-    seat::pointer::{
-        CursorIcon, PointerEvent, PointerEventKind, PointerHandler,
-    },
+    seat::pointer::{CursorIcon, PointerEvent, PointerEventKind, PointerHandler},
 };
 
 impl PointerHandler for SctkState {
@@ -20,32 +16,26 @@ impl PointerHandler for SctkState {
         pointer: &cctk::sctk::reexports::client::protocol::wl_pointer::WlPointer,
         events: &[cctk::sctk::seat::pointer::PointerEvent],
     ) {
-        let (is_active, my_seat) =
-            match self.seats.iter_mut().enumerate().find_map(|(i, s)| {
-                if s.ptr.as_ref().map(|p| p.pointer()) == Some(pointer) {
-                    Some((i, s))
-                } else {
-                    None
-                }
-            }) {
-                Some((i, s)) => (i == 0, s),
-                None => return,
-            };
+        let (is_active, my_seat) = match self.seats.iter_mut().enumerate().find_map(|(i, s)| {
+            if s.ptr.as_ref().map(|p| p.pointer()) == Some(pointer) {
+                Some((i, s))
+            } else {
+                None
+            }
+        }) {
+            Some((i, s)) => (i == 0, s),
+            None => return,
+        };
 
         // track events, but only forward for the active seat
         for e in events {
             if my_seat.active_icon != my_seat.icon {
                 // Restore cursor that was set by appliction, or default
-                my_seat.set_cursor(
-                    conn,
-                    my_seat.icon.unwrap_or(CursorIcon::Default),
-                );
+                my_seat.set_cursor(conn, my_seat.icon.unwrap_or(CursorIcon::Default));
             }
 
             if is_active {
-                let id = winit::window::WindowId::from_raw(
-                    e.surface.id().as_ptr() as usize,
-                );
+                let id = winit::window::WindowId::from_raw(e.surface.id().as_ptr() as usize);
                 if self.windows.iter().any(|w| w.window.id() == id) {
                     continue;
                 }

--- a/winit/src/platform_specific/wayland/handlers/seat/seat.rs
+++ b/winit/src/platform_specific/wayland/handlers/seat/seat.rs
@@ -4,8 +4,8 @@ use crate::platform_specific::wayland::{
 };
 use cctk::sctk::{
     delegate_seat,
-    reexports::client::{protocol::wl_keyboard::WlKeyboard, Proxy},
-    seat::{pointer::ThemeSpec, SeatHandler},
+    reexports::client::{Proxy, protocol::wl_keyboard::WlKeyboard},
+    seat::{SeatHandler, pointer::ThemeSpec},
 };
 use iced_runtime::keyboard::Modifiers;
 use std::sync::Arc;
@@ -81,10 +81,7 @@ impl SeatHandler for SctkState {
                     None,
                     self.loop_handle.clone(),
                     Box::new(move |state, kbd: &WlKeyboard, e| {
-                        let Some(my_seat) = state
-                            .seats
-                            .iter_mut()
-                            .find(|s| s.seat == seat_clone_2)
+                        let Some(my_seat) = state.seats.iter_mut().find(|s| s.seat == seat_clone_2)
                         else {
                             return;
                         };
@@ -99,10 +96,7 @@ impl SeatHandler for SctkState {
                     }),
                 ) {
                     self.sctk_events.push(SctkEvent::SeatEvent {
-                        variant: SeatEventVariant::NewCapability(
-                            capability,
-                            kbd.id(),
-                        ),
+                        variant: SeatEventVariant::NewCapability(capability, kbd.id()),
                         id: seat.clone(),
                     });
                     _ = my_seat.kbd.replace(kbd);
@@ -119,10 +113,7 @@ impl SeatHandler for SctkState {
                     ThemeSpec::default(),
                 ) {
                     self.sctk_events.push(SctkEvent::SeatEvent {
-                        variant: SeatEventVariant::NewCapability(
-                            capability,
-                            ptr.pointer().id(),
-                        ),
+                        variant: SeatEventVariant::NewCapability(capability, ptr.pointer().id()),
                         id: seat.clone(),
                     });
                     _ = my_seat.ptr.replace(ptr);
@@ -131,10 +122,7 @@ impl SeatHandler for SctkState {
             cctk::sctk::seat::Capability::Touch => {
                 if let Some(touch) = self.seat_state.get_touch(qh, &seat).ok() {
                     self.sctk_events.push(SctkEvent::SeatEvent {
-                        variant: SeatEventVariant::NewCapability(
-                            capability,
-                            touch.id(),
-                        ),
+                        variant: SeatEventVariant::NewCapability(capability, touch.id()),
                         id: seat.clone(),
                     });
                     _ = my_seat.touch.replace(touch);
@@ -149,8 +137,7 @@ impl SeatHandler for SctkState {
             .then_some(self.text_input_manager.as_ref())
             .flatten()
         {
-            self.text_input =
-                Some(Arc::new((text_input_manager).get_text_input(&seat, &qh)));
+            self.text_input = Some(Arc::new((text_input_manager).get_text_input(&seat, &qh)));
         }
     }
 
@@ -172,10 +159,7 @@ impl SeatHandler for SctkState {
             cctk::sctk::seat::Capability::Keyboard => {
                 if let Some(kbd) = my_seat.kbd.take() {
                     self.sctk_events.push(SctkEvent::SeatEvent {
-                        variant: SeatEventVariant::RemoveCapability(
-                            capability,
-                            kbd.id(),
-                        ),
+                        variant: SeatEventVariant::RemoveCapability(capability, kbd.id()),
                         id: seat.clone(),
                     });
                 }
@@ -183,10 +167,7 @@ impl SeatHandler for SctkState {
             cctk::sctk::seat::Capability::Pointer => {
                 if let Some(ptr) = my_seat.ptr.take() {
                     self.sctk_events.push(SctkEvent::SeatEvent {
-                        variant: SeatEventVariant::RemoveCapability(
-                            capability,
-                            ptr.pointer().id(),
-                        ),
+                        variant: SeatEventVariant::RemoveCapability(capability, ptr.pointer().id()),
                         id: seat.clone(),
                     });
                 }
@@ -194,10 +175,7 @@ impl SeatHandler for SctkState {
             cctk::sctk::seat::Capability::Touch => {
                 if let Some(touch) = my_seat.touch.take() {
                     self.sctk_events.push(SctkEvent::SeatEvent {
-                        variant: SeatEventVariant::RemoveCapability(
-                            capability,
-                            touch.id(),
-                        ),
+                        variant: SeatEventVariant::RemoveCapability(capability, touch.id()),
                         id: seat.clone(),
                     });
                 }

--- a/winit/src/platform_specific/wayland/handlers/seat/touch.rs
+++ b/winit/src/platform_specific/wayland/handlers/seat/touch.rs
@@ -2,19 +2,17 @@
 
 use crate::{
     event_loop::state::FrameStatus,
-    platform_specific::wayland::{
-        event_loop::state::SctkState, sctk_event::SctkEvent,
-    },
+    platform_specific::wayland::{event_loop::state::SctkState, sctk_event::SctkEvent},
 };
 use cctk::sctk::{
     delegate_touch,
     reexports::client::{
-        protocol::{wl_surface::WlSurface, wl_touch::WlTouch},
         Connection, Proxy, QueueHandle,
+        protocol::{wl_surface::WlSurface, wl_touch::WlTouch},
     },
     seat::touch::TouchHandler,
 };
-use iced_runtime::core::{touch, Point};
+use iced_runtime::core::{Point, touch};
 
 impl TouchHandler for SctkState {
     fn down(
@@ -59,9 +57,7 @@ impl TouchHandler for SctkState {
         _time: u32,
         id: i32,
     ) {
-        let Some(my_seat) =
-            self.seats.iter().find(|s| s.touch.as_ref() == Some(touch))
-        else {
+        let Some(my_seat) = self.seats.iter().find(|s| s.touch.as_ref() == Some(touch)) else {
             return;
         };
 
@@ -84,9 +80,7 @@ impl TouchHandler for SctkState {
         id: i32,
         position: (f64, f64),
     ) {
-        let Some(my_seat) =
-            self.seats.iter().find(|s| s.touch.as_ref() == Some(touch))
-        else {
+        let Some(my_seat) = self.seats.iter().find(|s| s.touch.as_ref() == Some(touch)) else {
             return;
         };
 
@@ -121,25 +115,10 @@ impl TouchHandler for SctkState {
     ) {
     }
 
-    fn orientation(
-        &mut self,
-        _: &Connection,
-        _: &QueueHandle<Self>,
-        _: &WlTouch,
-        _: i32,
-        _: f64,
-    ) {
-    }
+    fn orientation(&mut self, _: &Connection, _: &QueueHandle<Self>, _: &WlTouch, _: i32, _: f64) {}
 
-    fn cancel(
-        &mut self,
-        _: &Connection,
-        _: &QueueHandle<Self>,
-        touch: &WlTouch,
-    ) {
-        let Some(my_seat) =
-            self.seats.iter().find(|s| s.touch.as_ref() == Some(touch))
-        else {
+    fn cancel(&mut self, _: &Connection, _: &QueueHandle<Self>, touch: &WlTouch) {
+        let Some(my_seat) = self.seats.iter().find(|s| s.touch.as_ref() == Some(touch)) else {
             return;
         };
 

--- a/winit/src/platform_specific/wayland/handlers/session_lock.rs
+++ b/winit/src/platform_specific/wayland/handlers/session_lock.rs
@@ -6,18 +6,12 @@ use cctk::sctk::{
     delegate_session_lock,
     reexports::client::{Connection, QueueHandle},
     session_lock::{
-        SessionLock, SessionLockHandler, SessionLockSurface,
-        SessionLockSurfaceConfigure,
+        SessionLock, SessionLockHandler, SessionLockSurface, SessionLockSurfaceConfigure,
     },
 };
 
 impl SessionLockHandler for SctkState {
-    fn locked(
-        &mut self,
-        _conn: &Connection,
-        _qh: &QueueHandle<Self>,
-        session_lock: SessionLock,
-    ) {
+    fn locked(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, session_lock: SessionLock) {
         self.session_lock = Some(session_lock);
         self.sctk_events.push(SctkEvent::SessionLocked);
     }
@@ -39,24 +33,22 @@ impl SessionLockHandler for SctkState {
         configure: SessionLockSurfaceConfigure,
         _serial: u32,
     ) {
-        let lock_surface = match self.lock_surfaces.iter_mut().find(|s| {
-            s.session_lock_surface.wl_surface()
-                == session_lock_surface.wl_surface()
-        }) {
+        let lock_surface = match self
+            .lock_surfaces
+            .iter_mut()
+            .find(|s| s.session_lock_surface.wl_surface() == session_lock_surface.wl_surface())
+        {
             Some(l) => l,
             None => return,
         };
-        lock_surface
-            .update_viewport(configure.new_size.0, configure.new_size.1);
+        lock_surface.update_viewport(configure.new_size.0, configure.new_size.1);
 
         let first = lock_surface.last_configure.is_none();
         _ = lock_surface.last_configure.replace(configure.clone());
 
         self.sctk_events.push(SctkEvent::SessionLockSurfaceCreated {
             queue_handle: self.queue_handle.clone(),
-            surface: CommonSurface::Lock(
-                lock_surface.session_lock_surface.clone(),
-            ),
+            surface: CommonSurface::Lock(lock_surface.session_lock_surface.clone()),
             native_id: lock_surface.id,
             common: lock_surface.common.clone(),
             display: self.connection.display(),

--- a/winit/src/platform_specific/wayland/handlers/shell/corner_radius.rs
+++ b/winit/src/platform_specific/wayland/handlers/shell/corner_radius.rs
@@ -1,14 +1,14 @@
-use cctk::{sctk, cosmic_protocols::{
-    corner_radius::v1::client::{
-        cosmic_corner_radius_manager_v1::CosmicCornerRadiusManagerV1,
-        cosmic_corner_radius_toplevel_v1::CosmicCornerRadiusToplevelV1,
+use cctk::{
+    cosmic_protocols::{
+        corner_radius::v1::client::{
+            cosmic_corner_radius_manager_v1::CosmicCornerRadiusManagerV1,
+            cosmic_corner_radius_toplevel_v1::CosmicCornerRadiusToplevelV1,
+        },
+        overlap_notify::v1::client::zcosmic_overlap_notification_v1::ZcosmicOverlapNotificationV1,
     },
-    overlap_notify::v1::client::zcosmic_overlap_notification_v1::ZcosmicOverlapNotificationV1,
-}};
-use sctk::reexports::{
-    client::{Connection, Dispatch, Proxy},
-
+    sctk,
 };
+use sctk::reexports::client::{Connection, Dispatch, Proxy};
 
 use crate::event_loop::state::SctkState;
 use crate::platform_specific::wayland::SctkEvent;
@@ -21,15 +21,11 @@ impl Dispatch<CosmicCornerRadiusManagerV1, ()> for SctkState {
         _data: &(),
         _conn: &Connection,
         _qhandle: &sctk::reexports::client::QueueHandle<Self>,
-    ) {}
+    ) {
+    }
 }
 
-impl
-    Dispatch<
-        CosmicCornerRadiusToplevelV1,
-        (),
-    > for SctkState
-{
+impl Dispatch<CosmicCornerRadiusToplevelV1, ()> for SctkState {
     fn event(
         state: &mut Self,
         _proxy: &CosmicCornerRadiusToplevelV1,
@@ -39,7 +35,7 @@ impl
         _qhandle: &sctk::reexports::client::QueueHandle<Self>,
     ) {
         match event {
-            _ => unimplemented!()
+            _ => unimplemented!(),
         }
     }
 }

--- a/winit/src/platform_specific/wayland/handlers/shell/layer.rs
+++ b/winit/src/platform_specific/wayland/handlers/shell/layer.rs
@@ -1,13 +1,13 @@
 use crate::platform_specific::wayland::{
-    event_loop::state::{receive_frame, SctkState},
+    event_loop::state::{SctkState, receive_frame},
     sctk_event::{LayerSurfaceEventVariant, SctkEvent},
 };
 use cctk::sctk::{
     delegate_layer,
     reexports::client::Proxy,
     shell::{
-        wlr_layer::{Anchor, KeyboardInteractivity, LayerShellHandler},
         WaylandSurface,
+        wlr_layer::{Anchor, KeyboardInteractivity, LayerShellHandler},
     },
 };
 use std::fmt::Debug;
@@ -20,9 +20,11 @@ impl LayerShellHandler for SctkState {
         _qh: &cctk::sctk::reexports::client::QueueHandle<Self>,
         layer: &cctk::sctk::shell::wlr_layer::LayerSurface,
     ) {
-        let layer = match self.layer_surfaces.iter().position(|s| {
-            s.surface.wl_surface().id() == layer.wl_surface().id()
-        }) {
+        let layer = match self
+            .layer_surfaces
+            .iter()
+            .position(|s| s.surface.wl_surface().id() == layer.wl_surface().id())
+        {
             Some(w) => self.layer_surfaces.remove(w),
             None => return,
         };
@@ -42,13 +44,14 @@ impl LayerShellHandler for SctkState {
         mut configure: cctk::sctk::shell::wlr_layer::LayerSurfaceConfigure,
         _serial: u32,
     ) {
-        let layer =
-            match self.layer_surfaces.iter_mut().find(|s| {
-                s.surface.wl_surface().id() == layer.wl_surface().id()
-            }) {
-                Some(l) => l,
-                None => return,
-            };
+        let layer = match self
+            .layer_surfaces
+            .iter_mut()
+            .find(|s| s.surface.wl_surface().id() == layer.wl_surface().id())
+        {
+            Some(l) => l,
+            None => return,
+        };
         let first = layer.last_configure.is_none();
         let common = layer.common.lock().unwrap();
         let requested_size = common.requested_size;
@@ -67,19 +70,14 @@ impl LayerShellHandler for SctkState {
         layer.update_viewport(configure.new_size.0, configure.new_size.1);
         _ = layer.last_configure.replace(configure.clone());
         let mut common = layer.common.lock().unwrap();
-        common.size =
-            LogicalSize::new(configure.new_size.0, configure.new_size.1);
+        common.size = LogicalSize::new(configure.new_size.0, configure.new_size.1);
         drop(common);
         let wl_surface = layer.surface.wl_surface().clone();
         receive_frame(&mut self.frame_status, &wl_surface);
         self.request_redraw(&wl_surface);
 
         self.sctk_events.push(SctkEvent::LayerSurfaceEvent {
-            variant: LayerSurfaceEventVariant::Configure(
-                configure,
-                wl_surface.clone(),
-                first,
-            ),
+            variant: LayerSurfaceEventVariant::Configure(configure, wl_surface.clone(), first),
             id: wl_surface,
         });
     }

--- a/winit/src/platform_specific/wayland/handlers/shell/mod.rs
+++ b/winit/src/platform_specific/wayland/handlers/shell/mod.rs
@@ -1,4 +1,4 @@
+pub mod corner_radius;
 pub mod layer;
 pub mod xdg_popup;
 pub mod xdg_window;
-pub mod corner_radius;

--- a/winit/src/platform_specific/wayland/handlers/shell/xdg_popup.rs
+++ b/winit/src/platform_specific/wayland/handlers/shell/xdg_popup.rs
@@ -3,10 +3,7 @@ use crate::platform_specific::wayland::{
     event_loop::state::{self, PopupParent, SctkState},
     sctk_event::{PopupEventVariant, SctkEvent},
 };
-use cctk::sctk::{
-    delegate_xdg_popup, reexports::client::Proxy,
-    shell::xdg::popup::PopupHandler,
-};
+use cctk::sctk::{delegate_xdg_popup, reexports::client::Proxy, shell::xdg::popup::PopupHandler};
 use winit::dpi::LogicalSize;
 
 impl PopupHandler for SctkState {
@@ -18,25 +15,22 @@ impl PopupHandler for SctkState {
         configure: cctk::sctk::shell::xdg::popup::PopupConfigure,
     ) {
         self.request_redraw(popup.wl_surface());
-        let sctk_popup = match self.popups.iter_mut().find(|s| {
-            s.popup.wl_surface().clone() == popup.wl_surface().clone()
-        }) {
+        let sctk_popup = match self
+            .popups
+            .iter_mut()
+            .find(|s| s.popup.wl_surface().clone() == popup.wl_surface().clone())
+        {
             Some(p) => p,
             None => return,
         };
         let first = sctk_popup.last_configure.is_none();
         _ = sctk_popup.last_configure.replace(configure.clone());
         let mut guard = sctk_popup.common.lock().unwrap();
-        guard.size =
-            LogicalSize::new(configure.width as u32, configure.height as u32);
+        guard.size = LogicalSize::new(configure.width as u32, configure.height as u32);
         receive_frame(&mut self.frame_status, popup.wl_surface());
 
         self.sctk_events.push(SctkEvent::PopupEvent {
-            variant: PopupEventVariant::Configure(
-                configure,
-                popup.wl_surface().clone(),
-                first,
-            ),
+            variant: PopupEventVariant::Configure(configure, popup.wl_surface().clone(), first),
             id: popup.wl_surface().clone(),
             toplevel_id: sctk_popup.data.toplevel.clone(),
             parent_id: match &sctk_popup.data.parent {
@@ -53,37 +47,36 @@ impl PopupHandler for SctkState {
         _qh: &cctk::sctk::reexports::client::QueueHandle<Self>,
         popup: &cctk::sctk::shell::xdg::popup::Popup,
     ) {
-        let sctk_popup = match self.popups.iter().position(|s| {
-            s.popup.wl_surface().clone() == popup.wl_surface().clone()
-        }) {
+        let sctk_popup = match self
+            .popups
+            .iter()
+            .position(|s| s.popup.wl_surface().clone() == popup.wl_surface().clone())
+        {
             Some(p) => self.popups.remove(p),
             None => return,
         };
         let mut to_destroy = vec![sctk_popup];
         while let Some(popup_to_destroy) = to_destroy.last() {
             match popup_to_destroy.data.parent.clone() {
-                state::PopupParent::LayerSurface(_)
-                | state::PopupParent::Window(_) => {
+                state::PopupParent::LayerSurface(_) | state::PopupParent::Window(_) => {
                     break;
                 }
                 state::PopupParent::Popup(popup_to_destroy_first) => {
-                    let Some(popup_to_destroy_first) =
-                        self.popups.iter().position(|p| {
-                            p.popup.wl_surface() == &popup_to_destroy_first
-                        })
+                    let Some(popup_to_destroy_first) = self
+                        .popups
+                        .iter()
+                        .position(|p| p.popup.wl_surface() == &popup_to_destroy_first)
                     else {
                         log::warn!("could not find popup to destroy first.");
                         return;
                     };
-                    let popup_to_destroy_first =
-                        self.popups.remove(popup_to_destroy_first);
+                    let popup_to_destroy_first = self.popups.remove(popup_to_destroy_first);
                     to_destroy.push(popup_to_destroy_first);
                 }
             }
         }
         for popup in to_destroy.into_iter().rev() {
-            if let Some(id) = self.id_map.remove(&popup.popup.wl_surface().id())
-            {
+            if let Some(id) = self.id_map.remove(&popup.popup.wl_surface().id()) {
                 _ = self.destroyed.insert(id);
             }
 

--- a/winit/src/platform_specific/wayland/handlers/shell/xdg_window.rs
+++ b/winit/src/platform_specific/wayland/handlers/shell/xdg_window.rs
@@ -1,7 +1,5 @@
 use crate::platform_specific::wayland::event_loop::state::SctkState;
-use cctk::sctk::{
-    delegate_xdg_shell, delegate_xdg_window, shell::xdg::window::WindowHandler,
-};
+use cctk::sctk::{delegate_xdg_shell, delegate_xdg_window, shell::xdg::window::WindowHandler};
 
 impl WindowHandler for SctkState {
     fn request_close(

--- a/winit/src/platform_specific/wayland/handlers/text_input.rs
+++ b/winit/src/platform_specific/wayland/handlers/text_input.rs
@@ -1,8 +1,8 @@
 use cctk::sctk::globals::GlobalData;
 use cctk::sctk::reexports::client::{Connection, Proxy, QueueHandle};
 
-use cctk::sctk::reexports::client::delegate_dispatch;
 use cctk::sctk::reexports::client::Dispatch;
+use cctk::sctk::reexports::client::delegate_dispatch;
 use cctk::sctk::reexports::protocols::wp::text_input::zv3::client::zwp_text_input_manager_v3::ZwpTextInputManagerV3;
 use cctk::sctk::reexports::protocols::wp::text_input::zv3::client::zwp_text_input_v3::Event as TextInputEvent;
 use cctk::sctk::reexports::protocols::wp::text_input::zv3::client::zwp_text_input_v3::ZwpTextInputV3;
@@ -24,10 +24,7 @@ pub struct TextInputManager {
 }
 
 impl TextInputManager {
-    pub fn try_new<D>(
-        registry: &RegistryState,
-        qh: &QueueHandle<D>,
-    ) -> Option<Self>
+    pub fn try_new<D>(registry: &RegistryState, qh: &QueueHandle<D>) -> Option<Self>
     where
         D: Dispatch<ZwpTextInputManagerV3, GlobalData> + 'static,
     {
@@ -37,18 +34,12 @@ impl TextInputManager {
         Some(Self { manager })
     }
 
-    pub fn get_text_input(
-        &self,
-        seat: &WlSeat,
-        qh: &QueueHandle<SctkState>,
-    ) -> ZwpTextInputV3 {
+    pub fn get_text_input(&self, seat: &WlSeat, qh: &QueueHandle<SctkState>) -> ZwpTextInputV3 {
         self.manager.get_text_input(&seat, &qh, ())
     }
 }
 
-impl Dispatch<ZwpTextInputManagerV3, GlobalData, SctkState>
-    for TextInputManager
-{
+impl Dispatch<ZwpTextInputManagerV3, GlobalData, SctkState> for TextInputManager {
     fn event(
         _state: &mut SctkState,
         _proxy: &ZwpTextInputManagerV3,
@@ -73,11 +64,10 @@ impl Dispatch<ZwpTextInputV3, (), SctkState> for TextInputManager {
             return;
         }
 
-        let kbd_focus =
-            match state.seats.iter_mut().find_map(|s| s.kbd_focus.clone()) {
-                Some(surface) => surface,
-                None => return,
-            };
+        let kbd_focus = match state.seats.iter_mut().find_map(|s| s.kbd_focus.clone()) {
+            Some(surface) => surface,
+            None => return,
+        };
         match event {
             TextInputEvent::PreeditString {
                 text,
@@ -91,8 +81,7 @@ impl Dispatch<ZwpTextInputV3, (), SctkState> for TextInputManager {
                 let cursor_end = usize::try_from(cursor_end)
                     .ok()
                     .and_then(|idx| text.is_char_boundary(idx).then_some(idx));
-                let cursor_range =
-                    cursor_begin.map(|b| (b, cursor_end.unwrap_or(b)));
+                let cursor_range = cursor_begin.map(|b| (b, cursor_end.unwrap_or(b)));
                 state.preedit = Some(Preedit { text, cursor_range });
             }
             TextInputEvent::DeleteSurroundingText {
@@ -123,9 +112,7 @@ impl Dispatch<ZwpTextInputV3, (), SctkState> for TextInputManager {
                 ));
 
                 // 2. Delete requested surrounding text.
-                if let Some((before_bytes, after_bytes)) =
-                    state.pending_delete.take()
-                {
+                if let Some((before_bytes, after_bytes)) = state.pending_delete.take() {
                     state.sctk_events.push(SctkEvent::Winit(
                         id,
                         WindowEvent::Ime(Ime::DeleteSurrounding {
@@ -137,10 +124,9 @@ impl Dispatch<ZwpTextInputV3, (), SctkState> for TextInputManager {
 
                 // 3. Insert commit string with the cursor at its end.
                 if let Some(text) = state.pending_commit.take() {
-                    state.sctk_events.push(SctkEvent::Winit(
-                        id,
-                        WindowEvent::Ime(Ime::Commit(text)),
-                    ));
+                    state
+                        .sctk_events
+                        .push(SctkEvent::Winit(id, WindowEvent::Ime(Ime::Commit(text))));
                 }
 
                 // 4. Calculate surrounding text to send.
@@ -149,10 +135,7 @@ impl Dispatch<ZwpTextInputV3, (), SctkState> for TextInputManager {
                 if let Some(preedit) = state.preedit.take() {
                     state.sctk_events.push(SctkEvent::Winit(
                         id,
-                        WindowEvent::Ime(Ime::Preedit(
-                            preedit.text,
-                            preedit.cursor_range,
-                        )),
+                        WindowEvent::Ime(Ime::Preedit(preedit.text, preedit.cursor_range)),
                     ));
                 }
             }

--- a/winit/src/platform_specific/wayland/handlers/toplevel.rs
+++ b/winit/src/platform_specific/wayland/handlers/toplevel.rs
@@ -10,9 +10,7 @@ use wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_tople
 use crate::event_loop::state::SctkState;
 
 impl ToplevelManagerHandler for SctkState {
-    fn toplevel_manager_state(
-        &mut self,
-    ) -> &mut cctk::toplevel_management::ToplevelManagerState {
+    fn toplevel_manager_state(&mut self) -> &mut cctk::toplevel_management::ToplevelManagerState {
         self.toplevel_manager.as_mut().unwrap()
     }
 

--- a/winit/src/platform_specific/wayland/handlers/wp_fractional_scaling.rs
+++ b/winit/src/platform_specific/wayland/handlers/wp_fractional_scaling.rs
@@ -50,9 +50,7 @@ impl FractionalScalingManager {
     }
 }
 
-impl Dispatch<WpFractionalScaleManagerV1, GlobalData, SctkState>
-    for FractionalScalingManager
-{
+impl Dispatch<WpFractionalScaleManagerV1, GlobalData, SctkState> for FractionalScalingManager {
     fn event(
         _: &mut SctkState,
         _: &WpFractionalScaleManagerV1,
@@ -65,9 +63,7 @@ impl Dispatch<WpFractionalScaleManagerV1, GlobalData, SctkState>
     }
 }
 
-impl Dispatch<WpFractionalScaleV1, FractionalScaling, SctkState>
-    for FractionalScalingManager
-{
+impl Dispatch<WpFractionalScaleV1, FractionalScaling, SctkState> for FractionalScalingManager {
     fn event(
         state: &mut SctkState,
         _: &WpFractionalScaleV1,
@@ -77,11 +73,7 @@ impl Dispatch<WpFractionalScaleV1, FractionalScaling, SctkState>
         _: &QueueHandle<SctkState>,
     ) {
         if let FractionalScalingEvent::PreferredScale { scale } = event {
-            state.scale_factor_changed(
-                &data.surface,
-                scale as f64 / SCALE_DENOMINATOR,
-                false,
-            );
+            state.scale_factor_changed(&data.surface, scale as f64 / SCALE_DENOMINATOR, false);
         }
     }
 }

--- a/winit/src/platform_specific/wayland/handlers/wp_viewporter.rs
+++ b/winit/src/platform_specific/wayland/handlers/wp_viewporter.rs
@@ -1,11 +1,9 @@
 //! Handling of the wp-viewporter.
 
+use cctk::sctk::reexports::client::Dispatch;
 use cctk::sctk::reexports::client::globals::{BindError, GlobalList};
 use cctk::sctk::reexports::client::protocol::wl_surface::WlSurface;
-use cctk::sctk::reexports::client::Dispatch;
-use cctk::sctk::reexports::client::{
-    delegate_dispatch, Connection, Proxy, QueueHandle,
-};
+use cctk::sctk::reexports::client::{Connection, Proxy, QueueHandle, delegate_dispatch};
 use cctk::sctk::reexports::protocols::wp::viewporter::client::wp_viewport::WpViewport;
 use cctk::sctk::reexports::protocols::wp::viewporter::client::wp_viewporter::WpViewporter;
 

--- a/winit/src/platform_specific/wayland/keymap.rs
+++ b/winit/src/platform_specific/wayland/keymap.rs
@@ -896,10 +896,7 @@ pub fn keysym_location(keysym: u32) -> Location {
     }
 }
 
-pub fn key_to_keysym(
-    unmodified_key: Key,
-    location: Location,
-) -> Option<xkeysym::Keysym> {
+pub fn key_to_keysym(unmodified_key: Key, location: Location) -> Option<xkeysym::Keysym> {
     use xkbcommon_dl::keysyms;
 
     let raw = match unmodified_key {
@@ -1051,37 +1048,34 @@ pub fn key_to_keysym(
 
             _ => return None,
         }),
-        Key::Character(c) if c.chars().count() == 1 => {
-            Some(match (c.chars().next(), location) {
-                (Some('0'), Location::Numpad) => keysyms::KP_0,
-                (Some('1'), Location::Numpad) => keysyms::KP_1,
-                (Some('2'), Location::Numpad) => keysyms::KP_2,
-                (Some('3'), Location::Numpad) => keysyms::KP_3,
-                (Some('4'), Location::Numpad) => keysyms::KP_4,
-                (Some('5'), Location::Numpad) => keysyms::KP_5,
-                (Some('6'), Location::Numpad) => keysyms::KP_6,
-                (Some('7'), Location::Numpad) => keysyms::KP_7,
-                (Some('8'), Location::Numpad) => keysyms::KP_8,
-                (Some('9'), Location::Numpad) => keysyms::KP_9,
-                (Some('.'), Location::Numpad) => keysyms::KP_Decimal,
-                (Some('+'), Location::Numpad) => keysyms::KP_Add,
-                (Some('-'), Location::Numpad) => keysyms::KP_Subtract,
-                (Some('*'), Location::Numpad) => keysyms::KP_Multiply,
-                (Some('/'), Location::Numpad) => keysyms::KP_Divide,
-                (Some('='), Location::Numpad) => keysyms::KP_Equal,
-                (Some(' '), _) => keysyms::space,
+        Key::Character(c) if c.chars().count() == 1 => Some(match (c.chars().next(), location) {
+            (Some('0'), Location::Numpad) => keysyms::KP_0,
+            (Some('1'), Location::Numpad) => keysyms::KP_1,
+            (Some('2'), Location::Numpad) => keysyms::KP_2,
+            (Some('3'), Location::Numpad) => keysyms::KP_3,
+            (Some('4'), Location::Numpad) => keysyms::KP_4,
+            (Some('5'), Location::Numpad) => keysyms::KP_5,
+            (Some('6'), Location::Numpad) => keysyms::KP_6,
+            (Some('7'), Location::Numpad) => keysyms::KP_7,
+            (Some('8'), Location::Numpad) => keysyms::KP_8,
+            (Some('9'), Location::Numpad) => keysyms::KP_9,
+            (Some('.'), Location::Numpad) => keysyms::KP_Decimal,
+            (Some('+'), Location::Numpad) => keysyms::KP_Add,
+            (Some('-'), Location::Numpad) => keysyms::KP_Subtract,
+            (Some('*'), Location::Numpad) => keysyms::KP_Multiply,
+            (Some('/'), Location::Numpad) => keysyms::KP_Divide,
+            (Some('='), Location::Numpad) => keysyms::KP_Equal,
+            (Some(' '), _) => keysyms::space,
 
-                (Some(c), _) => unsafe {
-                    let keysym =
-                        xkbcommon::xkb::ffi::xkb_utf32_to_keysym(c as u32);
-                    if keysym == keysyms::NoSymbol {
-                        return None;
-                    }
-                    keysym
-                },
-                _ => return None,
-            })
-        }
+            (Some(c), _) => unsafe {
+                let keysym = xkbcommon::xkb::ffi::xkb_utf32_to_keysym(c as u32);
+                if keysym == keysyms::NoSymbol {
+                    return None;
+                }
+                keysym
+            },
+            _ => return None,
+        }),
         _ => None,
     };
     raw.map(|k| xkeysym::Keysym::new(k))

--- a/winit/src/platform_specific/wayland/mod.rs
+++ b/winit/src/platform_specific/wayland/mod.rs
@@ -47,30 +47,18 @@ impl std::fmt::Debug for Action {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Action(arg0) => f.debug_tuple("Action").field(arg0).finish(),
-            Self::SetCursor(arg0) => {
-                f.debug_tuple("SetCursor").field(arg0).finish()
-            }
-            Self::RequestRedraw(arg0) => {
-                f.debug_tuple("RequestRedraw").field(arg0).finish()
-            }
-            Self::TrackWindow(_arg0, arg1) => {
-                f.debug_tuple("TrackWindow").field(arg1).finish()
-            }
-            Self::RemoveWindow(arg0) => {
-                f.debug_tuple("RemoveWindow").field(arg0).finish()
-            }
+            Self::SetCursor(arg0) => f.debug_tuple("SetCursor").field(arg0).finish(),
+            Self::RequestRedraw(arg0) => f.debug_tuple("RequestRedraw").field(arg0).finish(),
+            Self::TrackWindow(_arg0, arg1) => f.debug_tuple("TrackWindow").field(arg1).finish(),
+            Self::RemoveWindow(arg0) => f.debug_tuple("RemoveWindow").field(arg0).finish(),
             Self::Dropped(_surface_id_wrapper) => write!(f, "Dropped"),
             Self::SubsurfaceResize(id, size) => f
                 .debug_tuple("SubsurfaceResize")
                 .field(id)
                 .field(size)
                 .finish(),
-            Self::ResizeWindow(arg0) => {
-                f.debug_tuple("ResizeWindow").field(arg0).finish()
-            }
-            Self::SetImeAllowed(allowed) => {
-                f.debug_tuple("SetImeAllowed").field(allowed).finish()
-            }
+            Self::ResizeWindow(arg0) => f.debug_tuple("ResizeWindow").field(arg0).finish(),
+            Self::SetImeAllowed(allowed) => f.debug_tuple("SetImeAllowed").field(allowed).finish(),
             Self::SetImeCursorArea(x, y, width, height) => f
                 .debug_tuple("SetImeCursorArea")
                 .field(x)
@@ -78,9 +66,7 @@ impl std::fmt::Debug for Action {
                 .field(width)
                 .field(height)
                 .finish(),
-            Self::SetImePurpose(purpose) => {
-                f.debug_tuple("SetImePurpose").field(purpose).finish()
-            }
+            Self::SetImePurpose(purpose) => f.debug_tuple("SetImePurpose").field(purpose).finish(),
         }
     }
 }
@@ -107,9 +93,7 @@ impl PlatformSpecific {
     ) -> Self {
         self.wayland.winit_event_sender = Some(tx);
         self.wayland.conn = match display.raw_display_handle() {
-            Ok(raw_window_handle::RawDisplayHandle::Wayland(
-                wayland_display_handle,
-            )) => {
+            Ok(raw_window_handle::RawDisplayHandle::Wayland(wayland_display_handle)) => {
                 let backend = unsafe {
                     wayland_backend::client::Backend::from_foreign_display(
                         wayland_display_handle.display.as_ptr().cast(),
@@ -129,13 +113,12 @@ impl PlatformSpecific {
         self.wayland.display_handle = Some(display);
         self.wayland.proxy = Some(raw);
         // TODO remove this
-        self.wayland.sender =
-            crate::platform_specific::event_loop::SctkEventLoop::new(
-                self.wayland.winit_event_sender.clone().unwrap(),
-                self.wayland.proxy.clone().unwrap(),
-                self.wayland.display_handle.clone().unwrap(),
-            )
-            .ok();
+        self.wayland.sender = crate::platform_specific::event_loop::SctkEventLoop::new(
+            self.wayland.winit_event_sender.clone().unwrap(),
+            self.wayland.proxy.clone().unwrap(),
+            self.wayland.display_handle.clone().unwrap(),
+        )
+        .ok();
         self
     }
 
@@ -145,13 +128,12 @@ impl PlatformSpecific {
             && self.wayland.display_handle.is_some()
             && self.wayland.proxy.is_some()
         {
-            self.wayland.sender =
-                crate::platform_specific::event_loop::SctkEventLoop::new(
-                    self.wayland.winit_event_sender.clone().unwrap(),
-                    self.wayland.proxy.clone().unwrap(),
-                    self.wayland.display_handle.clone().unwrap(),
-                )
-                .ok();
+            self.wayland.sender = crate::platform_specific::event_loop::SctkEventLoop::new(
+                self.wayland.winit_event_sender.clone().unwrap(),
+                self.wayland.proxy.clone().unwrap(),
+                self.wayland.display_handle.clone().unwrap(),
+            )
+            .ok();
         }
 
         if let Some(tx) = self.wayland.sender.as_ref() {
@@ -172,9 +154,7 @@ impl WaylandSpecific {
         e: SctkEvent,
         events: &mut Vec<(Option<window::Id>, iced_runtime::core::Event)>,
         program: &'a crate::program::Instance<P>,
-        compositor: &mut Option<
-            <<P as Program>::Renderer as compositor::Default>::Compositor,
-        >,
+        compositor: &mut Option<<<P as Program>::Renderer as compositor::Default>::Compositor>,
         window_manager: &mut WindowManager<
             P,
             <<P as Program>::Renderer as compositor::Default>::Compositor,
@@ -233,10 +213,7 @@ impl WaylandSpecific {
         };
     }
 
-    pub(crate) fn retain_subsurfaces<F: Fn(window::Id) -> bool>(
-        &mut self,
-        keep: F,
-    ) {
+    pub(crate) fn retain_subsurfaces<F: Fn(window::Id) -> bool>(&mut self, keep: F) {
         self.surface_subsurfaces.retain(|k, v| keep(*k))
     }
 
@@ -244,11 +221,7 @@ impl WaylandSpecific {
         let _ = crate::subsurface_widget::take_subsurfaces();
     }
 
-    pub(crate) fn update_subsurfaces(
-        &mut self,
-        id: window::Id,
-        wl_surface: &WlSurface,
-    ) {
+    pub(crate) fn update_subsurfaces(&mut self, id: window::Id, wl_surface: &WlSurface) {
         let subsurfaces = crate::subsurface_widget::take_subsurfaces();
         let mut entry = self.surface_subsurfaces.entry(id);
         let surface_subsurfaces = entry.or_default();
@@ -256,11 +229,7 @@ impl WaylandSpecific {
             return;
         };
 
-        subsurface_state.update_subsurfaces(
-            wl_surface,
-            surface_subsurfaces,
-            &subsurfaces,
-        );
+        subsurface_state.update_subsurfaces(wl_surface, surface_subsurfaces, &subsurfaces);
     }
 
     pub(crate) fn create_surface(
@@ -284,22 +253,13 @@ impl WaylandSpecific {
         offset: Vector,
     ) {
         if let Some(subsurface_state) = self.subsurface_state.as_mut() {
-            if let RawWindowHandle::Wayland(window) =
-                window.window_handle().unwrap().as_raw()
-            {
+            if let RawWindowHandle::Wayland(window) = window.window_handle().unwrap().as_raw() {
                 let id = unsafe {
-                    ObjectId::from_ptr(
-                        WlSurface::interface(),
-                        window.surface.as_ptr().cast(),
-                    )
-                    .unwrap()
+                    ObjectId::from_ptr(WlSurface::interface(), window.surface.as_ptr().cast())
+                        .unwrap()
                 };
-                let surface =
-                    WlSurface::from_id(self.conn.as_ref().unwrap(), id)
-                        .unwrap();
-                subsurface_state.update_surface_shm(
-                    &surface, width, height, scale, data, offset,
-                );
+                let surface = WlSurface::from_id(self.conn.as_ref().unwrap(), id).unwrap();
+                subsurface_state.update_surface_shm(&surface, width, height, scale, data, offset);
             }
         }
     }
@@ -310,16 +270,12 @@ struct Window(WlSurface);
 impl HasWindowHandle for Window {
     fn window_handle(
         &self,
-    ) -> Result<
-        raw_window_handle::WindowHandle<'_>,
-        raw_window_handle::HandleError,
-    > {
+    ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
         Ok(unsafe {
             raw_window_handle::WindowHandle::borrow_raw(
                 raw_window_handle::RawWindowHandle::Wayland(
                     raw_window_handle::WaylandWindowHandle::new(
-                        std::ptr::NonNull::new(self.0.id().as_ptr() as *mut _)
-                            .unwrap(),
+                        std::ptr::NonNull::new(self.0.id().as_ptr() as *mut _).unwrap(),
                     ),
                 ),
             )

--- a/winit/src/platform_specific/wayland/sctk_event.rs
+++ b/winit/src/platform_specific/wayland/sctk_event.rs
@@ -3,10 +3,7 @@ use crate::{
     platform_specific::{
         SurfaceIdWrapper, UserInterfaces,
         wayland::{
-            conversion::{
-                modifiers_to_native, pointer_axis_to_native,
-                pointer_button_to_native,
-            },
+            conversion::{modifiers_to_native, pointer_axis_to_native, pointer_button_to_native},
             keymap::{self, keysym_to_key},
             subsurface_widget::SubsurfaceState,
         },
@@ -20,9 +17,7 @@ use iced_futures::{
         Size,
         event::{
             PlatformSpecific,
-            wayland::{
-                LayerEvent, OverlapNotifyEvent, PopupEvent, SessionLockEvent,
-            },
+            wayland::{LayerEvent, OverlapNotifyEvent, PopupEvent, SessionLockEvent},
         },
     },
     event,
@@ -50,9 +45,9 @@ use cctk::{
                 Proxy, QueueHandle,
                 backend::ObjectId,
                 protocol::{
-                    wl_display::WlDisplay, wl_keyboard::WlKeyboard,
-                    wl_output::WlOutput, wl_pointer::WlPointer,
-                    wl_seat::WlSeat, wl_surface::WlSurface, wl_touch::WlTouch,
+                    wl_display::WlDisplay, wl_keyboard::WlKeyboard, wl_output::WlOutput,
+                    wl_pointer::WlPointer, wl_seat::WlSeat, wl_surface::WlSurface,
+                    wl_touch::WlTouch,
                 },
             },
             csd_frame::WindowManagerCapabilities,
@@ -346,9 +341,7 @@ impl SctkEvent {
         self,
         modifiers: &mut Modifiers,
         program: &'a crate::program::Instance<P>,
-        compositor: &mut Option<
-            <<P as Program>::Renderer as compositor::Default>::Compositor,
-        >,
+        compositor: &mut Option<<<P as Program>::Renderer as compositor::Default>::Compositor>,
         window_manager: &mut crate::WindowManager<
             P,
             <<P as Program>::Renderer as compositor::Default>::Compositor,
@@ -370,32 +363,23 @@ impl SctkEvent {
             SctkEvent::SeatEvent { .. } => Default::default(),
             SctkEvent::PointerEvent { variant, .. } => match variant.kind {
                 PointerEventKind::Enter { .. } => {
-                    let id = surface_ids
-                        .get(&variant.surface.id())
-                        .map(|id| id.inner());
-                    if let Some(w) =
-                        id.clone().and_then(|id| window_manager.get_mut(id))
-                    {
-                        w.state.set_logical_cursor_pos(
-                            (variant.position.0, variant.position.1).into(),
-                        )
+                    let id = surface_ids.get(&variant.surface.id()).map(|id| id.inner());
+                    if let Some(w) = id.clone().and_then(|id| window_manager.get_mut(id)) {
+                        w.state
+                            .set_logical_cursor_pos((variant.position.0, variant.position.1).into())
                     }
                     events.push((
                         id.clone(),
-                        iced_runtime::core::Event::Mouse(
-                            mouse::Event::CursorEntered,
-                        ),
+                        iced_runtime::core::Event::Mouse(mouse::Event::CursorEntered),
                     ));
                     events.push((
                         id,
-                        iced_runtime::core::Event::Mouse(
-                            mouse::Event::CursorMoved {
-                                position: Point::new(
-                                    variant.position.0 as f32,
-                                    variant.position.1 as f32,
-                                ),
-                            },
-                        ),
+                        iced_runtime::core::Event::Mouse(mouse::Event::CursorMoved {
+                            position: Point::new(
+                                variant.position.0 as f32,
+                                variant.position.1 as f32,
+                            ),
+                        }),
                     ));
                 }
                 PointerEventKind::Leave { .. } => events.push((
@@ -403,26 +387,19 @@ impl SctkEvent {
                     iced_runtime::core::Event::Mouse(mouse::Event::CursorLeft),
                 )),
                 PointerEventKind::Motion { .. } => {
-                    let id = surface_ids
-                        .get(&variant.surface.id())
-                        .map(|id| id.inner());
-                    if let Some(w) =
-                        id.clone().and_then(|id| window_manager.get_mut(id))
-                    {
-                        w.state.set_logical_cursor_pos(
-                            (variant.position.0, variant.position.1).into(),
-                        )
+                    let id = surface_ids.get(&variant.surface.id()).map(|id| id.inner());
+                    if let Some(w) = id.clone().and_then(|id| window_manager.get_mut(id)) {
+                        w.state
+                            .set_logical_cursor_pos((variant.position.0, variant.position.1).into())
                     }
                     events.push((
                         id,
-                        iced_runtime::core::Event::Mouse(
-                            mouse::Event::CursorMoved {
-                                position: Point::new(
-                                    variant.position.0 as f32,
-                                    variant.position.1 as f32,
-                                ),
-                            },
-                        ),
+                        iced_runtime::core::Event::Mouse(mouse::Event::CursorMoved {
+                            position: Point::new(
+                                variant.position.0 as f32,
+                                variant.position.1 as f32,
+                            ),
+                        }),
                     ));
                 }
                 PointerEventKind::Press {
@@ -430,15 +407,11 @@ impl SctkEvent {
                     button,
                     serial: _,
                 } => {
-                    if let Some(e) = pointer_button_to_native(button).map(|b| {
-                        iced_runtime::core::Event::Mouse(
-                            mouse::Event::ButtonPressed(b),
-                        )
-                    }) {
+                    if let Some(e) = pointer_button_to_native(button)
+                        .map(|b| iced_runtime::core::Event::Mouse(mouse::Event::ButtonPressed(b)))
+                    {
                         events.push((
-                            surface_ids
-                                .get(&variant.surface.id())
-                                .map(|id| id.inner()),
+                            surface_ids.get(&variant.surface.id()).map(|id| id.inner()),
                             e,
                         ));
                     }
@@ -448,15 +421,11 @@ impl SctkEvent {
                     button,
                     serial: _,
                 } => {
-                    if let Some(e) = pointer_button_to_native(button).map(|b| {
-                        iced_runtime::core::Event::Mouse(
-                            mouse::Event::ButtonReleased(b),
-                        )
-                    }) {
+                    if let Some(e) = pointer_button_to_native(button)
+                        .map(|b| iced_runtime::core::Event::Mouse(mouse::Event::ButtonReleased(b)))
+                    {
                         events.push((
-                            surface_ids
-                                .get(&variant.surface.id())
-                                .map(|id| id.inner()),
+                            surface_ids.get(&variant.surface.id()).map(|id| id.inner()),
                             e,
                         ));
                     }
@@ -467,15 +436,12 @@ impl SctkEvent {
                     vertical,
                     source: _,
                 } => {
-                    let delta = if horizontal.value120 != 0
-                        || vertical.value120 != 0
-                    {
+                    let delta = if horizontal.value120 != 0 || vertical.value120 != 0 {
                         mouse::ScrollDelta::Lines {
                             x: -horizontal.value120 as f32 / 120.,
                             y: -vertical.value120 as f32 / 120.,
                         }
-                    } else if horizontal.discrete != 0 || vertical.discrete != 0
-                    {
+                    } else if horizontal.discrete != 0 || vertical.discrete != 0 {
                         mouse::ScrollDelta::Lines {
                             x: -horizontal.discrete as f32,
                             y: -vertical.discrete as f32,
@@ -487,12 +453,8 @@ impl SctkEvent {
                         }
                     };
                     events.push((
-                        surface_ids
-                            .get(&variant.surface.id())
-                            .map(|id| id.inner()),
-                        iced_runtime::core::Event::Mouse(
-                            mouse::Event::WheelScrolled { delta },
-                        ),
+                        surface_ids.get(&variant.surface.id()).map(|id| id.inner()),
+                        iced_runtime::core::Event::Mouse(mouse::Event::WheelScrolled { delta }),
                     ));
                 }
             },
@@ -503,145 +465,107 @@ impl SctkEvent {
                 surface,
             } => match variant {
                 KeyboardEventVariant::Leave(surface) => {
-                    if let Some(e) =
-                        surface_ids.get(&surface.id()).and_then(|id| match id {
-                            SurfaceIdWrapper::LayerSurface(_id) => Some(
-                                iced_runtime::core::Event::PlatformSpecific(
-                                    PlatformSpecific::Wayland(
-                                        wayland::Event::Layer(
-                                            LayerEvent::Unfocused,
-                                            surface.clone(),
-                                            id.inner(),
-                                        ),
-                                    ),
-                                ),
-                            ),
-                            SurfaceIdWrapper::Window(id) => {
-                                Some(iced_runtime::core::Event::Window(
-                                    window::Event::Unfocused,
-                                ))
-                            }
-                            SurfaceIdWrapper::Popup(_id) => Some(
-                                iced_runtime::core::Event::PlatformSpecific(
-                                    PlatformSpecific::Wayland(
-                                        wayland::Event::Popup(
-                                            PopupEvent::Unfocused,
-                                            surface.clone(),
-                                            id.inner(),
-                                        ),
-                                    ),
-                                ),
-                            ),
-                            SurfaceIdWrapper::SessionLock(_) => Some(
-                                iced_runtime::core::Event::PlatformSpecific(
-                                    PlatformSpecific::Wayland(
-                                        wayland::Event::SessionLock(
-                                            SessionLockEvent::Unfocused(
-                                                surface.clone(),
-                                                id.inner(),
-                                            ),
-                                        ),
-                                    ),
-                                ),
-                            ),
-                            SurfaceIdWrapper::Subsurface(id) => None,
-                        })
-                    {
-                        events.push((
-                            surface_ids.get(&surface.id()).map(|id| id.inner()),
-                            e,
-                        ));
+                    if let Some(e) = surface_ids.get(&surface.id()).and_then(|id| match id {
+                        SurfaceIdWrapper::LayerSurface(_id) => {
+                            Some(iced_runtime::core::Event::PlatformSpecific(
+                                PlatformSpecific::Wayland(wayland::Event::Layer(
+                                    LayerEvent::Unfocused,
+                                    surface.clone(),
+                                    id.inner(),
+                                )),
+                            ))
+                        }
+                        SurfaceIdWrapper::Window(id) => {
+                            Some(iced_runtime::core::Event::Window(window::Event::Unfocused))
+                        }
+                        SurfaceIdWrapper::Popup(_id) => {
+                            Some(iced_runtime::core::Event::PlatformSpecific(
+                                PlatformSpecific::Wayland(wayland::Event::Popup(
+                                    PopupEvent::Unfocused,
+                                    surface.clone(),
+                                    id.inner(),
+                                )),
+                            ))
+                        }
+                        SurfaceIdWrapper::SessionLock(_) => {
+                            Some(iced_runtime::core::Event::PlatformSpecific(
+                                PlatformSpecific::Wayland(wayland::Event::SessionLock(
+                                    SessionLockEvent::Unfocused(surface.clone(), id.inner()),
+                                )),
+                            ))
+                        }
+                        SurfaceIdWrapper::Subsurface(id) => None,
+                    }) {
+                        events.push((surface_ids.get(&surface.id()).map(|id| id.inner()), e));
                     }
 
                     events.push((
                         surface_ids.get(&surface.id()).map(|id| id.inner()),
-                        iced_runtime::core::Event::PlatformSpecific(
-                            PlatformSpecific::Wayland(wayland::Event::Seat(
-                                wayland::SeatEvent::Leave,
-                                seat_id,
-                            )),
-                        ),
+                        iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                            wayland::Event::Seat(wayland::SeatEvent::Leave, seat_id),
+                        )),
                     ))
                 }
                 KeyboardEventVariant::Enter(surface) => {
-                    if let Some(e) =
-                        surface_ids.get(&surface.id()).and_then(|id| {
-                            match id {
-                                SurfaceIdWrapper::LayerSurface(_id) => Some(
-                                    iced_runtime::core::Event::PlatformSpecific(
-                                        PlatformSpecific::Wayland(
-                                            wayland::Event::Layer(
-                                                LayerEvent::Focused,
-                                                surface.clone(),
-                                                id.inner(),
-                                            ),
-                                        ),
-                                    ),
-                                ),
-                                SurfaceIdWrapper::Window(id) => {
-                                    Some(iced_runtime::core::Event::Window(
-                                        window::Event::Focused,
-                                    ))
-                                }
-                                SurfaceIdWrapper::Popup(_id) => Some(
-                                    iced_runtime::core::Event::PlatformSpecific(
-                                        PlatformSpecific::Wayland(
-                                            wayland::Event::Popup(
-                                                PopupEvent::Focused,
-                                                surface.clone(),
-                                                id.inner(),
-                                            ),
-                                        ),
-                                    ),
-                                ),
-                                SurfaceIdWrapper::SessionLock(_) => Some(
-                                    iced_runtime::core::Event::PlatformSpecific(
-                                        PlatformSpecific::Wayland(
-                                            wayland::Event::SessionLock(
-                                                SessionLockEvent::Focused(
-                                                    surface.clone(),
-                                                    id.inner(),
-                                                ),
-                                            ),
-                                        ),
-                                    ),
-                                ),
-                                SurfaceIdWrapper::Subsurface(_) => None,
+                    if let Some(e) = surface_ids.get(&surface.id()).and_then(|id| {
+                        match id {
+                            SurfaceIdWrapper::LayerSurface(_id) => {
+                                Some(iced_runtime::core::Event::PlatformSpecific(
+                                    PlatformSpecific::Wayland(wayland::Event::Layer(
+                                        LayerEvent::Focused,
+                                        surface.clone(),
+                                        id.inner(),
+                                    )),
+                                ))
                             }
-                            .map(|e| (Some(id.inner()), e))
-                        })
-                    {
+                            SurfaceIdWrapper::Window(id) => {
+                                Some(iced_runtime::core::Event::Window(window::Event::Focused))
+                            }
+                            SurfaceIdWrapper::Popup(_id) => {
+                                Some(iced_runtime::core::Event::PlatformSpecific(
+                                    PlatformSpecific::Wayland(wayland::Event::Popup(
+                                        PopupEvent::Focused,
+                                        surface.clone(),
+                                        id.inner(),
+                                    )),
+                                ))
+                            }
+                            SurfaceIdWrapper::SessionLock(_) => {
+                                Some(iced_runtime::core::Event::PlatformSpecific(
+                                    PlatformSpecific::Wayland(wayland::Event::SessionLock(
+                                        SessionLockEvent::Focused(surface.clone(), id.inner()),
+                                    )),
+                                ))
+                            }
+                            SurfaceIdWrapper::Subsurface(_) => None,
+                        }
+                        .map(|e| (Some(id.inner()), e))
+                    }) {
                         events.push(e);
                     }
 
                     events.push((
                         surface_ids.get(&surface.id()).map(|id| id.inner()),
-                        iced_runtime::core::Event::PlatformSpecific(
-                            PlatformSpecific::Wayland(wayland::Event::Seat(
-                                wayland::SeatEvent::Enter,
-                                seat_id,
-                            )),
-                        ),
+                        iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                            wayland::Event::Seat(wayland::SeatEvent::Enter, seat_id),
+                        )),
                     ));
                 }
                 KeyboardEventVariant::Press(ke) => {
                     let (key, location) = keysym_to_vkey_location(ke.keysym);
                     let physical_key = raw_keycode_to_physicalkey(ke.raw_code);
-                    let physical_key =
-                        crate::conversion::physical_key(physical_key);
+                    let physical_key = crate::conversion::physical_key(physical_key);
                     events.push((
                         surface_ids.get(&surface.id()).map(|id| id.inner()),
-                        iced_runtime::core::Event::Keyboard(
-                            keyboard::Event::KeyPressed {
-                                key: key.clone(),
-                                location: location,
-                                text: ke.utf8.map(|s| s.into()),
-                                modifiers: modifiers_to_native(*modifiers),
-                                physical_key,
-                                repeat: false,
-                                modified_key: key, // TODO calculate without Ctrl?
-                            },
-                        ),
+                        iced_runtime::core::Event::Keyboard(keyboard::Event::KeyPressed {
+                            key: key.clone(),
+                            location: location,
+                            text: ke.utf8.map(|s| s.into()),
+                            modifiers: modifiers_to_native(*modifiers),
+                            physical_key,
+                            repeat: false,
+                            modified_key: key, // TODO calculate without Ctrl?
+                        }),
                     ))
                 }
                 KeyboardEventVariant::Repeat(KeyEvent {
@@ -652,51 +576,43 @@ impl SctkEvent {
                 }) => {
                     let (key, location) = keysym_to_vkey_location(keysym);
                     let physical_key = raw_keycode_to_physicalkey(raw_code);
-                    let physical_key =
-                        crate::conversion::physical_key(physical_key);
+                    let physical_key = crate::conversion::physical_key(physical_key);
 
                     events.push((
                         surface_ids.get(&surface.id()).map(|id| id.inner()),
-                        iced_runtime::core::Event::Keyboard(
-                            keyboard::Event::KeyPressed {
-                                key: key.clone(),
-                                location: location,
-                                text: utf8.map(|s| s.into()),
-                                modifiers: modifiers_to_native(*modifiers),
-                                physical_key,
-                                repeat: true,
-                                modified_key: key, // TODO calculate without Ctrl?
-                            },
-                        ),
+                        iced_runtime::core::Event::Keyboard(keyboard::Event::KeyPressed {
+                            key: key.clone(),
+                            location: location,
+                            text: utf8.map(|s| s.into()),
+                            modifiers: modifiers_to_native(*modifiers),
+                            physical_key,
+                            repeat: true,
+                            modified_key: key, // TODO calculate without Ctrl?
+                        }),
                     ))
                 }
                 KeyboardEventVariant::Release(ke) => {
                     let (k, location) = keysym_to_vkey_location(ke.keysym);
                     let physical_key = raw_keycode_to_physicalkey(ke.raw_code);
-                    let physical_key =
-                        crate::conversion::physical_key(physical_key);
+                    let physical_key = crate::conversion::physical_key(physical_key);
                     events.push((
                         surface_ids.get(&surface.id()).map(|id| id.inner()),
-                        iced_runtime::core::Event::Keyboard(
-                            keyboard::Event::KeyReleased {
-                                key: k.clone(),
-                                location,
-                                modifiers: modifiers_to_native(*modifiers),
-                                modified_key: k,
-                                physical_key: physical_key,
-                            },
-                        ),
+                        iced_runtime::core::Event::Keyboard(keyboard::Event::KeyReleased {
+                            key: k.clone(),
+                            location,
+                            modifiers: modifiers_to_native(*modifiers),
+                            modified_key: k,
+                            physical_key: physical_key,
+                        }),
                     ))
                 }
                 KeyboardEventVariant::Modifiers(new_mods) => {
                     *modifiers = new_mods;
                     events.push((
                         surface_ids.get(&surface.id()).map(|id| id.inner()),
-                        iced_runtime::core::Event::Keyboard(
-                            keyboard::Event::ModifiersChanged(
-                                modifiers_to_native(new_mods),
-                            ),
-                        ),
+                        iced_runtime::core::Event::Keyboard(keyboard::Event::ModifiersChanged(
+                            modifiers_to_native(new_mods),
+                        )),
                     ))
                 }
             },
@@ -713,12 +629,9 @@ impl SctkEvent {
                     touch::Event::FingerLost { position, .. } => position,
                 };
                 let id = surface_ids.get(&surface.id()).map(|id| id.inner());
-                if let Some(w) =
-                    id.clone().and_then(|id| window_manager.get_mut(id))
-                {
-                    w.state.set_logical_cursor_pos(
-                        (position.x, position.y).into(),
-                    );
+                if let Some(w) = id.clone().and_then(|id| window_manager.get_mut(id)) {
+                    w.state
+                        .set_logical_cursor_pos((position.x, position.y).into());
                 }
                 events.push((id, iced_runtime::core::Event::Touch(variant)))
             }
@@ -734,24 +647,15 @@ impl SctkEvent {
                                 DndSurface(Arc::new(Box::new(w.raw.clone()))),
                                 Vec::new(),
                             );
-                            if clipboard
-                                .window_id()
-                                .is_some_and(|id| w.raw.id() == id)
-                            {
+                            if clipboard.window_id().is_some_and(|id| w.raw.id() == id) {
                                 *clipboard = Clipboard::unconnected();
                             }
                         }
                         events.push((
                             Some(id.inner()),
-                            iced_runtime::core::Event::PlatformSpecific(
-                                PlatformSpecific::Wayland(
-                                    wayland::Event::Layer(
-                                        LayerEvent::Done,
-                                        surface,
-                                        id.inner(),
-                                    ),
-                                ),
-                            ),
+                            iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                                wayland::Event::Layer(LayerEvent::Done, surface, id.inner()),
+                            )),
                         ));
                     }
                 }
@@ -765,8 +669,7 @@ impl SctkEvent {
                 ) => {
                     let wl_surface = surface.wl_surface();
                     let object_id = wl_surface.id();
-                    let wrapper =
-                        SurfaceIdWrapper::LayerSurface(surface_id.clone());
+                    let wrapper = SurfaceIdWrapper::LayerSurface(surface_id.clone());
                     _ = surface_ids.insert(object_id.clone(), wrapper.clone());
                     let sctk_winit = SctkWinitWindow::new(
                         sctk_tx.clone(),
@@ -778,24 +681,16 @@ impl SctkEvent {
                     );
                     #[cfg(feature = "a11y")]
                     control_sender
-                        .start_send(Control::InitAdapter(
-                            surface_id,
-                            sctk_winit.clone(),
-                        ))
+                        .start_send(Control::InitAdapter(surface_id, sctk_winit.clone()))
                         .expect("Send control message");
                     if compositor.is_none() {
-                        match create_compositor(
-                            sctk_winit.clone(),
-                            create_compositor_data,
-                        )
-                        .await
-                        {
+                        match create_compositor(sctk_winit.clone(), create_compositor_data).await {
                             Ok(c) => *compositor = Some(c),
                             Err(error) => {
                                 control_sender
-                                    .start_send(Control::Crash(
-                                        Error::GraphicsCreationFailed(error),
-                                    ))
+                                    .start_send(Control::Crash(Error::GraphicsCreationFailed(
+                                        error,
+                                    )))
                                     .expect("Send control message");
                                 return;
                             }
@@ -807,7 +702,7 @@ impl SctkEvent {
                         sctk_winit,
                         program,
                         compositor,
-                        false, // TODO do we want to get this value here?
+                        false,             // TODO do we want to get this value here?
                         theme::Mode::None, // TODO do we really need to track the system theme here?
                         0,
                     );
@@ -850,83 +745,60 @@ impl SctkEvent {
                     if let Some(requested_size) =
                         clipboard.requested_logical_size.lock().unwrap().take()
                     {
-                        let requested_physical_size =
-                            winit::dpi::PhysicalSize::new(
-                                (requested_size.width as f64
-                                    * window.state.scale_factor())
-                                .ceil() as u32,
-                                (requested_size.height as f64
-                                    * window.state.scale_factor())
-                                .ceil() as u32,
-                            );
+                        let requested_physical_size = winit::dpi::PhysicalSize::new(
+                            (requested_size.width as f64 * window.state.scale_factor()).ceil()
+                                as u32,
+                            (requested_size.height as f64 * window.state.scale_factor()).ceil()
+                                as u32,
+                        );
                         let physical_size = window.state.physical_size();
                         if requested_physical_size.width != physical_size.width
-                            || requested_physical_size.height
-                                != physical_size.height
+                            || requested_physical_size.height != physical_size.height
                         {
                             // FIXME what to do when we are stuck in a configure event/resize request loop
                             // We don't have control over how winit handles this.
                             window.resize_enabled = true;
 
-                            let s = winit::dpi::Size::Physical(
-                                requested_physical_size,
-                            );
+                            let s = winit::dpi::Size::Physical(requested_physical_size);
                             _ = window.raw.request_surface_size(s);
                             window.raw.set_min_surface_size(Some(s));
                             window.raw.set_max_surface_size(Some(s));
-                            window.state.synchronize(
-                                &program,
-                                surface_id,
-                                window.raw.as_ref(),
-                            );
+                            window
+                                .state
+                                .synchronize(&program, surface_id, window.raw.as_ref());
                         }
                     }
 
                     let _ = user_interfaces.insert(surface_id, ui);
                 }
                 LayerSurfaceEventVariant::ScaleFactorChanged(..) => {}
-                LayerSurfaceEventVariant::Configure(
-                    configure,
-                    surface,
-                    first,
-                ) => {
-                    if let Some((id, w)) =
-                        surface_ids.get(&surface.id()).and_then(|id| {
-                            window_manager
-                                .get_mut(id.inner())
-                                .map(|v| (id.inner(), v))
-                        })
+                LayerSurfaceEventVariant::Configure(configure, surface, first) => {
+                    if let Some((id, w)) = surface_ids
+                        .get(&surface.id())
+                        .and_then(|id| window_manager.get_mut(id.inner()).map(|v| (id.inner(), v)))
                     {
                         let scale = w.state.scale_factor();
-                        let p_w = (configure.new_size.0.max(1) as f64 * scale)
-                            .ceil() as u32;
-                        let p_h = (configure.new_size.1.max(1) as f64 * scale)
-                            .ceil() as u32;
+                        let p_w = (configure.new_size.0.max(1) as f64 * scale).ceil() as u32;
+                        let p_h = (configure.new_size.1.max(1) as f64 * scale).ceil() as u32;
                         w.state.update(
                             program,
                             w.raw.as_ref(),
-                            &WindowEvent::SurfaceResized(PhysicalSize::new(
-                                p_w, p_h,
-                            )),
+                            &WindowEvent::SurfaceResized(PhysicalSize::new(p_w, p_h)),
                         );
                         if first {
                             events.push((
                                 Some(id),
-                                iced_runtime::core::Event::Window(
-                                    window::Event::Opened {
-                                        size: w.state.logical_size(),
-                                        position: Default::default(),
-                                    },
-                                ),
+                                iced_runtime::core::Event::Window(window::Event::Opened {
+                                    size: w.state.logical_size(),
+                                    position: Default::default(),
+                                }),
                             ))
                         } else {
                             events.push((
                                 Some(id),
-                                iced_runtime::core::Event::Window(
-                                    window::Event::Resized(
-                                        w.state.logical_size(),
-                                    ),
-                                ),
+                                iced_runtime::core::Event::Window(window::Event::Resized(
+                                    w.state.logical_size(),
+                                )),
                             ))
                         }
                     }
@@ -939,40 +811,29 @@ impl SctkEvent {
             } => {
                 match variant {
                     PopupEventVariant::Done => {
-                        if let Some(e) =
-                            surface_ids.remove(&surface.id()).map(|id| {
-                                if let Some(w) =
-                                    window_manager.remove(id.inner())
-                                {
-                                    clipboard.register_dnd_destination(
-                                        DndSurface(Arc::new(Box::new(
-                                            w.raw.clone(),
-                                        ))),
-                                        Vec::new(),
-                                    );
-                                    if clipboard
-                                        .window_id()
-                                        .is_some_and(|id| w.raw.id() == id)
-                                    {
-                                        *clipboard = Clipboard::unconnected();
-                                    }
+                        if let Some(e) = surface_ids.remove(&surface.id()).map(|id| {
+                            if let Some(w) = window_manager.remove(id.inner()) {
+                                clipboard.register_dnd_destination(
+                                    DndSurface(Arc::new(Box::new(w.raw.clone()))),
+                                    Vec::new(),
+                                );
+                                if clipboard.window_id().is_some_and(|id| w.raw.id() == id) {
+                                    *clipboard = Clipboard::unconnected();
                                 }
-                                _ = user_interfaces.remove(&id.inner());
+                            }
+                            _ = user_interfaces.remove(&id.inner());
 
-                                (
-                                    Some(id.inner()),
-                                    iced_runtime::core::Event::PlatformSpecific(
-                                        PlatformSpecific::Wayland(
-                                            wayland::Event::Popup(
-                                                PopupEvent::Done,
-                                                surface,
-                                                id.inner(),
-                                            ),
-                                        ),
-                                    ),
-                                )
-                            })
-                        {
+                            (
+                                Some(id.inner()),
+                                iced_runtime::core::Event::PlatformSpecific(
+                                    PlatformSpecific::Wayland(wayland::Event::Popup(
+                                        PopupEvent::Done,
+                                        surface,
+                                        id.inner(),
+                                    )),
+                                ),
+                            )
+                        }) {
                             events.push(e)
                         }
                     }
@@ -985,8 +846,7 @@ impl SctkEvent {
                     ) => {
                         let wl_surface = surface.wl_surface();
                         let wrapper = SurfaceIdWrapper::Popup(surface_id);
-                        _ = surface_ids
-                            .insert(wl_surface.id(), wrapper.clone());
+                        _ = surface_ids.insert(wl_surface.id(), wrapper.clone());
                         let sctk_winit = SctkWinitWindow::new(
                             sctk_tx.clone(),
                             common,
@@ -997,10 +857,7 @@ impl SctkEvent {
                         );
                         #[cfg(feature = "a11y")]
                         control_sender
-                            .start_send(Control::InitAdapter(
-                                surface_id,
-                                sctk_winit.clone(),
-                            ))
+                            .start_send(Control::InitAdapter(surface_id, sctk_winit.clone()))
                             .expect("Send control message");
 
                         if clipboard.window_id().is_none() {
@@ -1022,7 +879,7 @@ impl SctkEvent {
                             sctk_winit,
                             program,
                             compositor,
-                            false, // TODO do we want to get this value here?
+                            false,             // TODO do we want to get this value here?
                             theme::Mode::None, // TODO do we really need to track the system theme here?
                             0,
                         );
@@ -1052,109 +909,81 @@ impl SctkEvent {
                             &mut Vec::new(),
                         );
 
-                        if let Some(requested_size) = clipboard
-                            .requested_logical_size
-                            .lock()
-                            .unwrap()
-                            .take()
+                        if let Some(requested_size) =
+                            clipboard.requested_logical_size.lock().unwrap().take()
                         {
-                            let requested_physical_size =
-                                winit::dpi::PhysicalSize::new(
-                                    (requested_size.width as f64
-                                        * window.state.scale_factor())
-                                    .ceil()
-                                        as u32,
-                                    (requested_size.height as f64
-                                        * window.state.scale_factor())
-                                    .ceil()
-                                        as u32,
-                                );
+                            let requested_physical_size = winit::dpi::PhysicalSize::new(
+                                (requested_size.width as f64 * window.state.scale_factor()).ceil()
+                                    as u32,
+                                (requested_size.height as f64 * window.state.scale_factor()).ceil()
+                                    as u32,
+                            );
                             let physical_size = window.state.physical_size();
-                            if requested_physical_size.width
-                                != physical_size.width
-                                || requested_physical_size.height
-                                    != physical_size.height
+                            if requested_physical_size.width != physical_size.width
+                                || requested_physical_size.height != physical_size.height
                             {
                                 // FIXME what to do when we are stuck in a configure event/resize request loop
                                 // We don't have control over how winit handles this.
                                 window.resize_enabled = true;
 
-                                let s = winit::dpi::Size::Physical(
-                                    requested_physical_size,
-                                );
+                                let s = winit::dpi::Size::Physical(requested_physical_size);
                                 _ = window.raw.request_surface_size(s);
                                 window.raw.set_min_surface_size(Some(s));
                                 window.raw.set_max_surface_size(Some(s));
-                                window.state.synchronize(
-                                    &program,
-                                    surface_id,
-                                    window.raw.as_ref(),
-                                );
+                                window
+                                    .state
+                                    .synchronize(&program, surface_id, window.raw.as_ref());
                             }
                         }
 
                         let _ = user_interfaces.insert(surface_id, ui);
                     }
                     PopupEventVariant::Configure(configure, surface, first) => {
-                        if let Some((id, w)) =
-                            surface_ids.get(&surface.id()).and_then(|id| {
-                                window_manager
-                                    .get_mut(id.inner())
-                                    .map(|v| (id.inner(), v))
-                            })
-                        {
+                        if let Some((id, w)) = surface_ids.get(&surface.id()).and_then(|id| {
+                            window_manager.get_mut(id.inner()).map(|v| (id.inner(), v))
+                        }) {
                             w.state.set_ready(true);
                             if first {
                                 control_sender
                                     .send(Control::Winit(
                                         w.raw.id(),
                                         winit::event::WindowEvent::RedrawRequested,
-                                    )).await
+                                    ))
+                                    .await
                                     .expect("Send control message");
                                 proxy.wake_up();
                             }
                             let physical = w.raw.surface_size();
-                            let (p_w, p_h) =
-                                if physical.width > 0 && physical.height > 0 {
-                                    (physical.width, physical.height)
-                                } else {
-                                    // Fallback if backend has not reported an updated
-                                    // surface size yet for this configure.
-                                    let scale = w.state.scale_factor();
-                                    (
-                                        (configure.width.max(1) as f64 * scale)
-                                            .ceil()
-                                            as u32,
-                                        (configure.height.max(1) as f64 * scale)
-                                            .ceil()
-                                            as u32,
-                                    )
-                                };
+                            let (p_w, p_h) = if physical.width > 0 && physical.height > 0 {
+                                (physical.width, physical.height)
+                            } else {
+                                // Fallback if backend has not reported an updated
+                                // surface size yet for this configure.
+                                let scale = w.state.scale_factor();
+                                (
+                                    (configure.width.max(1) as f64 * scale).ceil() as u32,
+                                    (configure.height.max(1) as f64 * scale).ceil() as u32,
+                                )
+                            };
 
                             w.state.update(
                                 program,
                                 w.raw.as_ref(),
-                                &WindowEvent::SurfaceResized(
-                                    PhysicalSize::new(p_w, p_h),
-                                ),
+                                &WindowEvent::SurfaceResized(PhysicalSize::new(p_w, p_h)),
                             );
                             let size = w.state.logical_size();
                             if first {
                                 events.push((
                                     Some(id),
-                                    iced_runtime::core::Event::Window(
-                                        window::Event::Opened {
-                                            size: size,
-                                            position: Default::default(),
-                                        },
-                                    ),
+                                    iced_runtime::core::Event::Window(window::Event::Opened {
+                                        size: size,
+                                        position: Default::default(),
+                                    }),
                                 ))
                             } else {
                                 events.push((
                                     Some(id),
-                                    iced_runtime::core::Event::Window(
-                                        window::Event::Resized(size),
-                                    ),
+                                    iced_runtime::core::Event::Window(window::Event::Resized(size)),
                                 ))
                             }
                         }
@@ -1166,30 +995,21 @@ impl SctkEvent {
             }
             SctkEvent::NewOutput { id, info } => events.push((
                 None,
-                iced_runtime::core::Event::PlatformSpecific(
-                    PlatformSpecific::Wayland(wayland::Event::Output(
-                        wayland::OutputEvent::Created(info),
-                        id,
-                    )),
-                ),
+                iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                    wayland::Event::Output(wayland::OutputEvent::Created(info), id),
+                )),
             )),
             SctkEvent::UpdateOutput { id, info } => events.push((
                 None,
-                iced_runtime::core::Event::PlatformSpecific(
-                    PlatformSpecific::Wayland(wayland::Event::Output(
-                        wayland::OutputEvent::InfoUpdate(info),
-                        id,
-                    )),
-                ),
+                iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                    wayland::Event::Output(wayland::OutputEvent::InfoUpdate(info), id),
+                )),
             )),
             SctkEvent::RemovedOutput(id) => events.push((
                 None,
-                iced_runtime::core::Event::PlatformSpecific(
-                    PlatformSpecific::Wayland(wayland::Event::Output(
-                        wayland::OutputEvent::Removed,
-                        id,
-                    )),
-                ),
+                iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                    wayland::Event::Output(wayland::OutputEvent::Removed, id),
+                )),
             )),
             SctkEvent::ScaleFactorChanged {
                 factor: _,
@@ -1198,19 +1018,15 @@ impl SctkEvent {
             } => Default::default(),
             SctkEvent::SessionLocked => events.push((
                 None,
-                iced_runtime::core::Event::PlatformSpecific(
-                    PlatformSpecific::Wayland(wayland::Event::SessionLock(
-                        wayland::SessionLockEvent::Locked,
-                    )),
-                ),
+                iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                    wayland::Event::SessionLock(wayland::SessionLockEvent::Locked),
+                )),
             )),
             SctkEvent::SessionLockFinished => events.push((
                 None,
-                iced_runtime::core::Event::PlatformSpecific(
-                    PlatformSpecific::Wayland(wayland::Event::SessionLock(
-                        wayland::SessionLockEvent::Finished,
-                    )),
-                ),
+                iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                    wayland::Event::SessionLock(wayland::SessionLockEvent::Finished),
+                )),
             )),
             SctkEvent::SessionLockSurfaceCreated {
                 queue_handle,
@@ -1234,10 +1050,7 @@ impl SctkEvent {
                 #[cfg(feature = "a11y")]
                 {
                     control_sender
-                        .start_send(Control::InitAdapter(
-                            surface_id,
-                            sctk_winit.clone(),
-                        ))
+                        .start_send(Control::InitAdapter(surface_id, sctk_winit.clone()))
                         .expect("Send control message");
                     proxy.wake_up();
                 }
@@ -1252,18 +1065,11 @@ impl SctkEvent {
                     );
                 }
                 if compositor.is_none() {
-                    match create_compositor(
-                        sctk_winit.clone(),
-                        create_compositor_data,
-                    )
-                    .await
-                    {
+                    match create_compositor(sctk_winit.clone(), create_compositor_data).await {
                         Ok(c) => *compositor = Some(c),
                         Err(error) => {
                             control_sender
-                                .start_send(Control::Crash(
-                                    Error::GraphicsCreationFailed(error),
-                                ))
+                                .start_send(Control::Crash(Error::GraphicsCreationFailed(error)))
                                 .expect("Send control message");
                             return;
                         }
@@ -1276,7 +1082,7 @@ impl SctkEvent {
                     sctk_winit,
                     program,
                     compositor,
-                    false, // TODO do we want to get this value here?
+                    false,             // TODO do we want to get this value here?
                     theme::Mode::None, // TODO do we really need to track the system theme here?
                     0,
                 );
@@ -1294,56 +1100,46 @@ impl SctkEvent {
                 );
 
                 _ = ui.update(
-                            &vec![iced_runtime::core::Event::PlatformSpecific(
-                                iced_runtime::core::event::PlatformSpecific::Wayland(
-                                    iced_runtime::core::event::wayland::Event::RequestResize,
-                                ),
-                            )],
-                            window.state.cursor(),
-                            &mut window.renderer,
-                            clipboard,
-                            &mut Vec::new(),
-                        );
+                    &vec![iced_runtime::core::Event::PlatformSpecific(
+                        iced_runtime::core::event::PlatformSpecific::Wayland(
+                            iced_runtime::core::event::wayland::Event::RequestResize,
+                        ),
+                    )],
+                    window.state.cursor(),
+                    &mut window.renderer,
+                    clipboard,
+                    &mut Vec::new(),
+                );
 
                 if let Some(requested_size) =
                     clipboard.requested_logical_size.lock().unwrap().take()
                 {
                     let requested_physical_size = winit::dpi::PhysicalSize::new(
-                        (requested_size.width as f64
-                            * window.state.scale_factor())
-                        .ceil() as u32,
-                        (requested_size.height as f64
-                            * window.state.scale_factor())
-                        .ceil() as u32,
+                        (requested_size.width as f64 * window.state.scale_factor()).ceil() as u32,
+                        (requested_size.height as f64 * window.state.scale_factor()).ceil() as u32,
                     );
                     let physical_size = window.state.physical_size();
                     if requested_physical_size.width != physical_size.width
-                        || requested_physical_size.height
-                            != physical_size.height
+                        || requested_physical_size.height != physical_size.height
                     {
                         // FIXME what to do when we are stuck in a configure event/resize request loop
                         // We don't have control over how winit handles this.
                         window.resize_enabled = true;
 
-                        let s =
-                            winit::dpi::Size::Physical(requested_physical_size);
+                        let s = winit::dpi::Size::Physical(requested_physical_size);
                         _ = window.raw.request_surface_size(s);
                         window.raw.set_min_surface_size(Some(s));
                         window.raw.set_max_surface_size(Some(s));
-                        window.state.synchronize(
-                            &program,
-                            surface_id,
-                            window.raw.as_ref(),
-                        );
+                        window
+                            .state
+                            .synchronize(&program, surface_id, window.raw.as_ref());
                     }
                 }
                 events.push((
                     Some(surface_id),
-                    iced_runtime::core::Event::PlatformSpecific(
-                        PlatformSpecific::Wayland(wayland::Event::Subsurface(
-                            wayland::SubsurfaceEvent::Created,
-                        )),
-                    ),
+                    iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                        wayland::Event::Subsurface(wayland::SubsurfaceEvent::Created),
+                    )),
                 ));
                 _ = user_interfaces.insert(surface_id, ui);
             }
@@ -1352,45 +1148,31 @@ impl SctkEvent {
                 configure,
                 first,
             } => {
-                let size = Size::new(
-                    configure.new_size.0 as f32,
-                    configure.new_size.1 as f32,
-                );
-                if let Some((id, w)) =
-                    surface_ids.get(&surface.id()).and_then(|id| {
-                        window_manager
-                            .get_mut(id.inner())
-                            .map(|v| (id.inner(), v))
-                    })
+                let size = Size::new(configure.new_size.0 as f32, configure.new_size.1 as f32);
+                if let Some((id, w)) = surface_ids
+                    .get(&surface.id())
+                    .and_then(|id| window_manager.get_mut(id.inner()).map(|v| (id.inner(), v)))
                 {
                     let scale = w.state.scale_factor();
-                    let p_w = (configure.new_size.0.max(1) as f64 * scale)
-                        .round() as u32;
-                    let p_h = (configure.new_size.1.max(1) as f64 * scale)
-                        .round() as u32;
+                    let p_w = (configure.new_size.0.max(1) as f64 * scale).round() as u32;
+                    let p_h = (configure.new_size.1.max(1) as f64 * scale).round() as u32;
                     w.state.update(
                         program,
                         w.raw.as_ref(),
-                        &WindowEvent::SurfaceResized(PhysicalSize::new(
-                            p_w, p_h,
-                        )),
+                        &WindowEvent::SurfaceResized(PhysicalSize::new(p_w, p_h)),
                     );
                     if first {
                         events.push((
                             Some(id),
-                            iced_runtime::core::Event::Window(
-                                window::Event::Opened {
-                                    size: size,
-                                    position: Default::default(),
-                                },
-                            ),
+                            iced_runtime::core::Event::Window(window::Event::Opened {
+                                size: size,
+                                position: Default::default(),
+                            }),
                         ))
                     } else {
                         events.push((
                             Some(id),
-                            iced_runtime::core::Event::Window(
-                                window::Event::Resized(size),
-                            ),
+                            iced_runtime::core::Event::Window(window::Event::Resized(size)),
                         ))
                     }
                 }
@@ -1402,11 +1184,9 @@ impl SctkEvent {
             }
             SctkEvent::SessionUnlocked => events.push((
                 None,
-                iced_runtime::core::Event::PlatformSpecific(
-                    PlatformSpecific::Wayland(wayland::Event::SessionLock(
-                        wayland::SessionLockEvent::Unlocked,
-                    )),
-                ),
+                iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                    wayland::Event::SessionLock(wayland::SessionLockEvent::Unlocked),
+                )),
             )),
             SctkEvent::Winit(_, _) => {}
             SctkEvent::SurfaceScaleFactorChanged(scale, _, id) => {
@@ -1425,18 +1205,16 @@ impl SctkEvent {
                 if let Some(id) = surface_ids.get(&surface.id()) {
                     events.push((
                         Some(id.inner()),
-                        iced_runtime::core::Event::PlatformSpecific(
-                            PlatformSpecific::Wayland(
-                                wayland::Event::OverlapNotify(
-                                    OverlapNotifyEvent::OverlapToplevelAdd {
-                                        toplevel,
-                                        logical_rect,
-                                    },
-                                    surface,
-                                    id.inner(),
-                                ),
+                        iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                            wayland::Event::OverlapNotify(
+                                OverlapNotifyEvent::OverlapToplevelAdd {
+                                    toplevel,
+                                    logical_rect,
+                                },
+                                surface,
+                                id.inner(),
                             ),
-                        ),
+                        )),
                     ))
                 }
             }
@@ -1444,17 +1222,13 @@ impl SctkEvent {
                 if let Some(id) = surface_ids.get(&surface.id()) {
                     events.push((
                         Some(id.inner()),
-                        iced_runtime::core::Event::PlatformSpecific(
-                            PlatformSpecific::Wayland(
-                                wayland::Event::OverlapNotify(
-                                    OverlapNotifyEvent::OverlapToplevelRemove {
-                                        toplevel,
-                                    },
-                                    surface,
-                                    id.inner(),
-                                ),
+                        iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                            wayland::Event::OverlapNotify(
+                                OverlapNotifyEvent::OverlapToplevelRemove { toplevel },
+                                surface,
+                                id.inner(),
                             ),
-                        ),
+                        )),
                     ))
                 }
             }
@@ -1469,21 +1243,19 @@ impl SctkEvent {
                 if let Some(id) = surface_ids.get(&surface.id()) {
                     events.push((
                         Some(id.inner()),
-                        iced_runtime::core::Event::PlatformSpecific(
-                            PlatformSpecific::Wayland(
-                                wayland::Event::OverlapNotify(
-                                    OverlapNotifyEvent::OverlapLayerAdd {
-                                        identifier,
-                                        namespace,
-                                        exclusive,
-                                        layer,
-                                        logical_rect,
-                                    },
-                                    surface,
-                                    id.inner(),
-                                ),
+                        iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                            wayland::Event::OverlapNotify(
+                                OverlapNotifyEvent::OverlapLayerAdd {
+                                    identifier,
+                                    namespace,
+                                    exclusive,
+                                    layer,
+                                    logical_rect,
+                                },
+                                surface,
+                                id.inner(),
                             ),
-                        ),
+                        )),
                     ))
                 }
             }
@@ -1494,17 +1266,13 @@ impl SctkEvent {
                 if let Some(id) = surface_ids.get(&surface.id()) {
                     events.push((
                         Some(id.inner()),
-                        iced_runtime::core::Event::PlatformSpecific(
-                            PlatformSpecific::Wayland(
-                                wayland::Event::OverlapNotify(
-                                    OverlapNotifyEvent::OverlapLayerRemove {
-                                        identifier,
-                                    },
-                                    surface,
-                                    id.inner(),
-                                ),
+                        iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                            wayland::Event::OverlapNotify(
+                                OverlapNotifyEvent::OverlapLayerRemove { identifier },
+                                surface,
+                                id.inner(),
                             ),
-                        ),
+                        )),
                     ))
                 }
             }
@@ -1551,10 +1319,7 @@ impl SctkEvent {
                     );
                     #[cfg(feature = "a11y")]
                     control_sender
-                        .start_send(Control::InitAdapter(
-                            surface_id,
-                            sctk_winit.clone(),
-                        ))
+                        .start_send(Control::InitAdapter(surface_id, sctk_winit.clone()))
                         .expect("Send control message");
 
                     if clipboard.window_id().is_none() {
@@ -1567,18 +1332,13 @@ impl SctkEvent {
                         );
                     }
                     if compositor.is_none() {
-                        match create_compositor(
-                            sctk_winit.clone(),
-                            create_compositor_data,
-                        )
-                        .await
-                        {
+                        match create_compositor(sctk_winit.clone(), create_compositor_data).await {
                             Ok(c) => *compositor = Some(c),
                             Err(error) => {
                                 control_sender
-                                    .start_send(Control::Crash(
-                                        Error::GraphicsCreationFailed(error),
-                                    ))
+                                    .start_send(Control::Crash(Error::GraphicsCreationFailed(
+                                        error,
+                                    )))
                                     .expect("Send control message");
                                 return;
                             }
@@ -1609,94 +1369,71 @@ impl SctkEvent {
                     );
 
                     _ = ui.update(
-                            &vec![iced_runtime::core::Event::PlatformSpecific(
-                                iced_runtime::core::event::PlatformSpecific::Wayland(
-                                    iced_runtime::core::event::wayland::Event::RequestResize,
-                                ),
-                            )],
-                            window.state.cursor(),
-                            &mut window.renderer,
-                            clipboard,
-                            &mut Vec::new(),
-                        );
+                        &vec![iced_runtime::core::Event::PlatformSpecific(
+                            iced_runtime::core::event::PlatformSpecific::Wayland(
+                                iced_runtime::core::event::wayland::Event::RequestResize,
+                            ),
+                        )],
+                        window.state.cursor(),
+                        &mut window.renderer,
+                        clipboard,
+                        &mut Vec::new(),
+                    );
 
                     if let Some(requested_size) =
                         clipboard.requested_logical_size.lock().unwrap().take()
                     {
-                        let requested_physical_size =
-                            winit::dpi::PhysicalSize::new(
-                                (requested_size.width as f64
-                                    * window.state.scale_factor())
-                                .ceil() as u32,
-                                (requested_size.height as f64
-                                    * window.state.scale_factor())
-                                .ceil() as u32,
-                            );
+                        let requested_physical_size = winit::dpi::PhysicalSize::new(
+                            (requested_size.width as f64 * window.state.scale_factor()).ceil()
+                                as u32,
+                            (requested_size.height as f64 * window.state.scale_factor()).ceil()
+                                as u32,
+                        );
                         let physical_size = window.state.physical_size();
                         if requested_physical_size.width != physical_size.width
-                            || requested_physical_size.height
-                                != physical_size.height
+                            || requested_physical_size.height != physical_size.height
                         {
                             // FIXME what to do when we are stuck in a configure event/resize request loop
                             // We don't have control over how winit handles this.
                             window.resize_enabled = true;
 
-                            let s = winit::dpi::Size::Physical(
-                                requested_physical_size,
-                            );
+                            let s = winit::dpi::Size::Physical(requested_physical_size);
                             _ = window.raw.request_surface_size(s);
                             window.raw.set_min_surface_size(Some(s));
                             window.raw.set_max_surface_size(Some(s));
-                            window.state.synchronize(
-                                &program,
-                                surface_id,
-                                window.raw.as_ref(),
-                            );
+                            window
+                                .state
+                                .synchronize(&program, surface_id, window.raw.as_ref());
                         }
                     }
                     events.push((
                         Some(surface_id),
-                        iced_runtime::core::Event::PlatformSpecific(
-                            PlatformSpecific::Wayland(
-                                wayland::Event::Subsurface(
-                                    wayland::SubsurfaceEvent::Created,
-                                ),
-                            ),
-                        ),
+                        iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                            wayland::Event::Subsurface(wayland::SubsurfaceEvent::Created),
+                        )),
                     ));
                     let _ = user_interfaces.insert(surface_id, ui);
                 }
                 SubsurfaceEventVariant::Destroyed(instance) => {
                     remove_iced_subsurface(&instance.wl_surface);
 
-                    if let Some(id_wrapper) =
-                        surface_ids.remove(&instance.wl_surface.id())
-                    {
+                    if let Some(id_wrapper) = surface_ids.remove(&instance.wl_surface.id()) {
                         _ = user_interfaces.remove(&id_wrapper.inner());
 
-                        if let Some(w) =
-                            window_manager.remove(id_wrapper.inner())
-                        {
+                        if let Some(w) = window_manager.remove(id_wrapper.inner()) {
                             clipboard.register_dnd_destination(
                                 DndSurface(Arc::new(Box::new(w.raw.clone()))),
                                 Vec::new(),
                             );
-                            if clipboard
-                                .window_id()
-                                .is_some_and(|id| w.raw.id() == id)
-                            {
+                            if clipboard.window_id().is_some_and(|id| w.raw.id() == id) {
                                 *clipboard = Clipboard::unconnected();
                             }
                         }
                         events.push((
                             Some(id_wrapper.inner()),
-                            iced_runtime::core::Event::PlatformSpecific(
-                                PlatformSpecific::Wayland(
-                                    wayland::Event::Subsurface(
-                                        wayland::SubsurfaceEvent::Destroyed,
-                                    ),
-                                ),
-                            ),
+                            iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                                wayland::Event::Subsurface(wayland::SubsurfaceEvent::Destroyed),
+                            )),
                         ));
                     }
                     if let Some(subsurface_state) = subsurface_state.as_mut() {
@@ -1704,9 +1441,7 @@ impl SctkEvent {
                     }
                 }
                 SubsurfaceEventVariant::Resized(id, size) => {
-                    if let Some((id, w)) =
-                        window_manager.get_mut(id).map(|v| (id, v))
-                    {
+                    if let Some((id, w)) = window_manager.get_mut(id).map(|v| (id, v)) {
                         let scale = w.state.scale_factor();
                         let physical_size = size.to_physical(scale);
                         w.state.update(
@@ -1720,23 +1455,19 @@ impl SctkEvent {
 
                         events.push((
                             Some(id),
-                            iced_runtime::core::Event::Window(
-                                window::Event::Opened {
-                                    size: w.state.logical_size(),
-                                    position: Default::default(),
-                                },
-                            ),
+                            iced_runtime::core::Event::Window(window::Event::Opened {
+                                size: w.state.logical_size(),
+                                position: Default::default(),
+                            }),
                         ))
                     }
                 }
             },
             SctkEvent::ShortcutsInhibited(v) => events.push((
                 None,
-                iced_runtime::core::Event::PlatformSpecific(
-                    PlatformSpecific::Wayland(
-                        wayland::Event::ShortcutsInhibited(v),
-                    ),
-                ),
+                iced_runtime::core::Event::PlatformSpecific(PlatformSpecific::Wayland(
+                    wayland::Event::ShortcutsInhibited(v),
+                )),
             )),
         }
     }

--- a/winit/src/platform_specific/wayland/subsurface_widget.rs
+++ b/winit/src/platform_specific/wayland/subsurface_widget.rs
@@ -51,15 +51,11 @@ use wayland_protocols::wp::{
         zwp_linux_buffer_params_v1::{self, ZwpLinuxBufferParamsV1},
         zwp_linux_dmabuf_v1::{self, ZwpLinuxDmabufV1},
     },
-    viewporter::client::{
-        wp_viewport::WpViewport, wp_viewporter::WpViewporter,
-    },
+    viewporter::client::{wp_viewport::WpViewport, wp_viewporter::WpViewporter},
 };
 use winit::window::WindowId;
 
-use crate::platform_specific::{
-    SurfaceIdWrapper, event_loop::state::SctkState,
-};
+use crate::platform_specific::{SurfaceIdWrapper, event_loop::state::SctkState};
 
 #[derive(Debug)]
 pub struct Plane {
@@ -143,10 +139,7 @@ impl SubsurfaceBufferRelease {
 impl Future for SubsurfaceBufferRelease {
     type Output = ();
 
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-    ) -> task::Poll<()> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> task::Poll<()> {
         Pin::new(&mut self.0).poll(cx).map(|_| ())
     }
 }
@@ -155,10 +148,7 @@ impl SubsurfaceBuffer {
     pub fn new(source: Arc<BufferSource>) -> (Self, SubsurfaceBufferRelease) {
         let (_sender, receiver) = oneshot::channel();
         let subsurface_buffer =
-            SubsurfaceBuffer(Arc::new(SubsurfaceBufferInner {
-                source,
-                _sender,
-            }));
+            SubsurfaceBuffer(Arc::new(SubsurfaceBufferInner { source, _sender }));
         (subsurface_buffer, SubsurfaceBufferRelease(receiver))
     }
 
@@ -201,9 +191,7 @@ impl SubsurfaceBuffer {
                     buf.format,
                     qh,
                     BufferData {
-                        source: WeakBufferSource(Arc::downgrade(
-                            &self.0.source,
-                        )),
+                        source: WeakBufferSource(Arc::downgrade(&self.0.source)),
                         subsurface_buffer: Mutex::new(Some(self.clone())),
                     },
                 );
@@ -233,9 +221,7 @@ impl SubsurfaceBuffer {
                         zwp_linux_buffer_params_v1::Flags::empty(),
                         qh,
                         BufferData {
-                            source: WeakBufferSource(Arc::downgrade(
-                                &self.0.source,
-                            )),
+                            source: WeakBufferSource(Arc::downgrade(&self.0.source)),
                             subsurface_buffer: Mutex::new(Some(self.clone())),
                         },
                     ))
@@ -391,14 +377,11 @@ impl SubsurfaceState {
         data: &[u8],
         offset: Vector,
     ) {
-        let wp_viewport = self.wp_viewporter.get_viewport(
-            &surface,
-            &self.qh,
-            cctk::sctk::globals::GlobalData,
-        );
+        let wp_viewport =
+            self.wp_viewporter
+                .get_viewport(&surface, &self.qh, cctk::sctk::globals::GlobalData);
         let shm = ShmGlobal(&self.wl_shm);
-        let mut pool =
-            SlotPool::new(width as usize * height as usize * 4, &shm).unwrap();
+        let mut pool = SlotPool::new(width as usize * height as usize * 4, &shm).unwrap();
         let (buffer, canvas) = pool
             .create_buffer(
                 width as i32,
@@ -429,23 +412,18 @@ impl SubsurfaceState {
         wl_surface.set_input_region(Some(&region));
         region.destroy();
 
-        let wl_subsurface = self.wl_subcompositor.get_subsurface(
-            &wl_surface,
-            parent,
-            &self.qh,
-            (),
-        );
+        let wl_subsurface = self
+            .wl_subcompositor
+            .get_subsurface(&wl_surface, parent, &self.qh, ());
 
-        let wp_viewport = self.wp_viewporter.get_viewport(
-            &wl_surface,
-            &self.qh,
-            cctk::sctk::globals::GlobalData,
-        );
+        let wp_viewport =
+            self.wp_viewporter
+                .get_viewport(&wl_surface, &self.qh, cctk::sctk::globals::GlobalData);
 
-        let wp_alpha_modifier_surface =
-            self.wp_alpha_modifier.as_ref().map(|wp_alpha_modifier| {
-                wp_alpha_modifier.get_surface(&wl_surface, &self.qh, ())
-            });
+        let wp_alpha_modifier_surface = self
+            .wp_alpha_modifier
+            .as_ref()
+            .map(|wp_alpha_modifier| wp_alpha_modifier.get_surface(&wl_surface, &self.qh, ()));
 
         SubsurfaceInstance {
             wl_surface,
@@ -499,8 +477,8 @@ impl SubsurfaceState {
             subsurface.unmap();
             self.unmapped_subsurfaces.push(subsurface);
         }
-        let needs_sorting = subsurfaces.len() < view_subsurfaces.len()
-            || !self.new_iced_subsurfaces.is_empty();
+        let needs_sorting =
+            subsurfaces.len() < view_subsurfaces.len() || !self.new_iced_subsurfaces.is_empty();
 
         // Create new subsurfaces if there aren't enough.
         while subsurfaces.len() < view_subsurfaces.len() {
@@ -529,9 +507,7 @@ impl SubsurfaceState {
                     let b = surfaces.borrow();
                     let v: Vec<_> = b
                         .iter()
-                        .map(move |s| {
-                            (s.1.clone(), s.3.clone(), s.4.clone(), s.5)
-                        })
+                        .map(move |s| (s.1.clone(), s.3.clone(), s.4.clone(), s.5))
                         .collect();
                     v.into_iter()
                 }))
@@ -540,8 +516,7 @@ impl SubsurfaceState {
             sorted_subsurfaces.sort_by(|a, b| a.3.cmp(&b.3));
 
             // Attach buffers to subsurfaces, set viewports, and commit.
-            'outer: for (i, subsurface) in sorted_subsurfaces.iter().enumerate()
-            {
+            'outer: for (i, subsurface) in sorted_subsurfaces.iter().enumerate() {
                 for prev in sorted_subsurfaces[0..i].iter().rev() {
                     if prev.0 == subsurface.0 {
                         // Fist surface that has `z` greater than 0, so place above parent,
@@ -568,9 +543,7 @@ impl SubsurfaceState {
                 surfaces.borrow_mut().append(&mut self.new_iced_subsurfaces);
             })
         };
-        for (subsurface_data, subsurface) in
-            view_subsurfaces.iter().zip(subsurfaces.iter_mut())
-        {
+        for (subsurface_data, subsurface) in view_subsurfaces.iter().zip(subsurfaces.iter_mut()) {
             subsurface.attach_and_commit(subsurface_data, self);
         }
     }
@@ -586,13 +559,10 @@ impl SubsurfaceState {
     // reference to be releated on `wl_buffer` release.
     //
     // If `wl_buffer` isn't released, it is destroyed instead.
-    fn get_cached_wl_buffer(
-        &mut self,
-        subsurface_buffer: &SubsurfaceBuffer,
-    ) -> Option<WlBuffer> {
-        let buffers = self.buffers.get_mut(&WeakBufferSource(
-            Arc::downgrade(&subsurface_buffer.0.source),
-        ))?;
+    fn get_cached_wl_buffer(&mut self, subsurface_buffer: &SubsurfaceBuffer) -> Option<WlBuffer> {
+        let buffers = self.buffers.get_mut(&WeakBufferSource(Arc::downgrade(
+            &subsurface_buffer.0.source,
+        )))?;
         while let Some(buffer) = buffers.pop() {
             let mut subsurface_buffer_ref = buffer
                 .data::<BufferData>()
@@ -637,19 +607,14 @@ pub(crate) struct SubsurfaceInstance {
 
 impl SubsurfaceInstance {
     // TODO correct damage? no damage/commit if unchanged?
-    fn attach_and_commit(
-        &mut self,
-        info: &SubsurfaceInfo,
-        state: &mut SubsurfaceState,
-    ) {
+    fn attach_and_commit(&mut self, info: &SubsurfaceInfo, state: &mut SubsurfaceState) {
         let buffer_changed;
 
         let old_buffer = self.wl_buffer.take();
-        let old_buffer_data =
-            old_buffer.as_ref().and_then(|b| BufferData::for_buffer(&b));
-        let buffer = if old_buffer_data.is_some_and(|b| {
-            b.subsurface_buffer.lock().unwrap().as_ref() == Some(&info.buffer)
-        }) {
+        let old_buffer_data = old_buffer.as_ref().and_then(|b| BufferData::for_buffer(&b));
+        let buffer = if old_buffer_data
+            .is_some_and(|b| b.subsurface_buffer.lock().unwrap().as_ref() == Some(&info.buffer))
+        {
             // Same "BufferSource" is already attached to this subsurface. Don't create new `wl_buffer`.
             buffer_changed = false;
             old_buffer.unwrap()
@@ -662,11 +627,10 @@ impl SubsurfaceInstance {
 
             if let Some(buffer) = state.get_cached_wl_buffer(&info.buffer) {
                 buffer
-            } else if let Some(buffer) = info.buffer.create_buffer(
-                &state.wl_shm,
-                state.wp_dmabuf.as_ref(),
-                &state.qh,
-            ) {
+            } else if let Some(buffer) =
+                info.buffer
+                    .create_buffer(&state.wl_shm, state.wp_dmabuf.as_ref(), &state.qh)
+            {
                 buffer
             } else {
                 // TODO log error
@@ -681,10 +645,8 @@ impl SubsurfaceInstance {
         if bounds_changed || buffer_changed {
             self.wl_subsurface
                 .set_position(info.bounds.x as i32, info.bounds.y as i32);
-            self.wp_viewport.set_destination(
-                info.bounds.width as i32,
-                info.bounds.height as i32,
-            );
+            self.wp_viewport
+                .set_destination(info.bounds.width as i32, info.bounds.height as i32);
         }
         let transform_changed = self.transform != info.transform;
         if transform_changed {
@@ -699,8 +661,7 @@ impl SubsurfaceInstance {
             self.wl_surface.commit();
         }
 
-        if let Some(wp_alpha_modifier_surface) = &self.wp_alpha_modifier_surface
-        {
+        if let Some(wp_alpha_modifier_surface) = &self.wp_alpha_modifier_surface {
             let alpha = (info.alpha.clamp(0.0, 1.0) * u32::MAX as f32) as u32;
             wp_alpha_modifier_surface.set_multiplier(alpha);
         }
@@ -748,9 +709,10 @@ pub(crate) fn take_subsurfaces() -> Vec<SubsurfaceInfo> {
 
 pub(crate) fn is_subsurface(id: WindowId) -> bool {
     ICED_SUBSURFACES.with(|subsurfaces| {
-        subsurfaces.borrow_mut().iter().any(|s| {
-            winit::window::WindowId::from_raw(s.4.id().as_ptr() as usize) == id
-        })
+        subsurfaces
+            .borrow_mut()
+            .iter()
+            .any(|s| winit::window::WindowId::from_raw(s.4.id().as_ptr() as usize) == id)
     })
 }
 
@@ -760,12 +722,8 @@ pub(crate) fn subsurface_ids(parent: WindowId) -> Vec<WindowId> {
             .borrow_mut()
             .iter()
             .filter_map(|s| {
-                if winit::window::WindowId::from_raw(s.1.id().as_ptr() as usize)
-                    == parent
-                {
-                    Some(winit::window::WindowId::from_raw(
-                        s.4.id().as_ptr() as usize
-                    ))
+                if winit::window::WindowId::from_raw(s.1.id().as_ptr() as usize) == parent {
+                    Some(winit::window::WindowId::from_raw(s.4.id().as_ptr() as usize))
                 } else {
                     None
                 }
@@ -812,9 +770,7 @@ where
             wl_output::Transform::_90
             | wl_output::Transform::_270
             | wl_output::Transform::Flipped90
-            | wl_output::Transform::Flipped270 => {
-                (self.buffer.height(), self.buffer.width())
-            }
+            | wl_output::Transform::Flipped270 => (self.buffer.height(), self.buffer.width()),
             _ => (self.buffer.width(), self.buffer.height()),
         };
         let buffer_size = Size::new(width as f32, height as f32);
@@ -908,8 +864,7 @@ impl Subsurface {
     }
 }
 
-impl<Message, Theme, Renderer> From<Subsurface>
-    for Element<'static, Message, Theme, Renderer>
+impl<Message, Theme, Renderer> From<Subsurface> for Element<'static, Message, Theme, Renderer>
 where
     Message: Clone,
     Renderer: renderer::Renderer,

--- a/winit/src/platform_specific/wayland/winit_window.rs
+++ b/winit/src/platform_specific/wayland/winit_window.rs
@@ -56,9 +56,7 @@ impl SctkWinitWindow {
 
 impl winit::window::Window for SctkWinitWindow {
     fn id(&self) -> winit::window::WindowId {
-        winit::window::WindowId::from_raw(
-            self.surface.wl_surface().id().as_ptr() as usize,
-        )
+        winit::window::WindowId::from_raw(self.surface.wl_surface().id().as_ptr() as usize)
     }
 
     fn scale_factor(&self) -> f64 {
@@ -107,8 +105,7 @@ impl winit::window::Window for SctkWinitWindow {
     ) -> Option<winit::dpi::PhysicalSize<u32>> {
         let mut guard = self.common.lock().unwrap();
         self.request_redraw();
-        let logical_size: LogicalSize<u32> =
-            size.to_logical(guard.fractional_scale.unwrap_or(1.));
+        let logical_size: LogicalSize<u32> = size.to_logical(guard.fractional_scale.unwrap_or(1.));
         match &self.surface {
             CommonSurface::Popup(popup, positioner) => {
                 if logical_size.width == 0 || logical_size.height == 0 {
@@ -123,10 +120,7 @@ impl winit::window::Window for SctkWinitWindow {
                 guard.size = logical_size;
                 guard.requested_size.0 = Some(guard.size.width);
                 guard.requested_size.1 = Some(guard.size.height);
-                positioner.set_size(
-                    guard.size.width as i32,
-                    guard.size.height as i32,
-                );
+                positioner.set_size(guard.size.width as i32, guard.size.height as i32);
                 popup.xdg_surface().set_window_geometry(
                     0,
                     0,
@@ -135,15 +129,11 @@ impl winit::window::Window for SctkWinitWindow {
                 );
                 popup.xdg_popup().reposition(
                     positioner,
-                    TOKEN_CTR
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+                    TOKEN_CTR.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
                 );
                 if let Some(viewport) = guard.wp_viewport.as_ref() {
                     // Set inner size without the borders.
-                    viewport.set_destination(
-                        guard.size.width as i32,
-                        guard.size.height as i32,
-                    );
+                    viewport.set_destination(guard.size.width as i32, guard.size.height as i32);
                 }
             }
             CommonSurface::Layer(layer_surface) => {
@@ -166,10 +156,7 @@ impl winit::window::Window for SctkWinitWindow {
                 layer_surface.set_size(logical_size.width, logical_size.height);
                 if let Some(viewport) = guard.wp_viewport.as_ref() {
                     // Set inner size without the borders.
-                    viewport.set_destination(
-                        guard.size.width as i32,
-                        guard.size.height as i32,
-                    );
+                    viewport.set_destination(guard.size.width as i32, guard.size.height as i32);
                 }
             }
             CommonSurface::Lock(_) => {}
@@ -186,10 +173,7 @@ impl winit::window::Window for SctkWinitWindow {
                 guard.size = logical_size;
                 if let Some(viewport) = guard.wp_viewport.as_ref() {
                     // Set inner size without the borders.
-                    viewport.set_destination(
-                        guard.size.width as i32,
-                        guard.size.height as i32,
-                    );
+                    viewport.set_destination(guard.size.width as i32, guard.size.height as i32);
                 }
                 _ = self
                     .tx
@@ -218,13 +202,8 @@ impl winit::window::Window for SctkWinitWindow {
         // XXX not applicable to wrapped surfaces
     }
 
-    fn set_surface_resize_increments(
-        &self,
-        increments: Option<winit::dpi::Size>,
-    ) {
-        log::warn!(
-            "`set_surface_resize_increments` is not implemented for Wayland"
-        )
+    fn set_surface_resize_increments(&self, increments: Option<winit::dpi::Size>) {
+        log::warn!("`set_surface_resize_increments` is not implemented for Wayland")
     }
 
     fn set_title(&self, title: &str) {
@@ -235,9 +214,7 @@ impl winit::window::Window for SctkWinitWindow {
         todo!()
     }
 
-    fn rwh_06_display_handle(
-        &self,
-    ) -> &dyn raw_window_handle::HasDisplayHandle {
+    fn rwh_06_display_handle(&self) -> &dyn raw_window_handle::HasDisplayHandle {
         self
     }
 
@@ -250,9 +227,7 @@ impl winit::window::Window for SctkWinitWindow {
         None
     }
 
-    fn available_monitors(
-        &self,
-    ) -> Box<dyn Iterator<Item = winit::monitor::MonitorHandle>> {
+    fn available_monitors(&self) -> Box<dyn Iterator<Item = winit::monitor::MonitorHandle>> {
         Box::new(None.into_iter())
     }
 
@@ -261,11 +236,7 @@ impl winit::window::Window for SctkWinitWindow {
         false
     }
 
-    fn set_ime_cursor_area(
-        &self,
-        position: winit::dpi::Position,
-        size: winit::dpi::Size,
-    ) {
+    fn set_ime_cursor_area(&self, position: winit::dpi::Position, size: winit::dpi::Size) {
         let guard = self.common.lock().unwrap();
         let scale_factor = guard.fractional_scale.unwrap_or(1.);
         let position = position.to_logical(scale_factor);
@@ -342,10 +313,7 @@ impl winit::window::Window for SctkWinitWindow {
         false
     }
 
-    fn set_fullscreen(
-        &self,
-        fullscreen: Option<winit_core::monitor::Fullscreen>,
-    ) {
+    fn set_fullscreen(&self, fullscreen: Option<winit_core::monitor::Fullscreen>) {
         // XXX can't fullscreen the wrapped surfaces
     }
 
@@ -368,10 +336,7 @@ impl winit::window::Window for SctkWinitWindow {
 
     fn focus_window(&self) {}
 
-    fn request_user_attention(
-        &self,
-        request_type: Option<winit::window::UserAttentionType>,
-    ) {
+    fn request_user_attention(&self, request_type: Option<winit::window::UserAttentionType>) {
         // XXX can't request attention on wrapped surfaces
     }
 
@@ -395,9 +360,7 @@ impl winit::window::Window for SctkWinitWindow {
         None
     }
 
-    fn surface_resize_increments(
-        &self,
-    ) -> Option<winit::dpi::PhysicalSize<u32>> {
+    fn surface_resize_increments(&self) -> Option<winit::dpi::PhysicalSize<u32>> {
         None
     }
 
@@ -412,10 +375,7 @@ impl winit::window::Window for SctkWinitWindow {
         Ok(())
     }
 
-    fn set_cursor_hittest(
-        &self,
-        _hittest: bool,
-    ) -> Result<(), winit::error::RequestError> {
+    fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), winit::error::RequestError> {
         todo!()
     }
 
@@ -425,8 +385,7 @@ impl winit::window::Window for SctkWinitWindow {
 
     fn outer_position(
         &self,
-    ) -> Result<winit::dpi::PhysicalPosition<i32>, winit::error::RequestError>
-    {
+    ) -> Result<winit::dpi::PhysicalPosition<i32>, winit::error::RequestError> {
         Err(RequestError::NotSupported(NotSupportedError::new(
             "Not supported on wayland.",
         )))
@@ -465,10 +424,7 @@ impl winit::window::Window for SctkWinitWindow {
 impl raw_window_handle::HasWindowHandle for SctkWinitWindow {
     fn window_handle(
         &self,
-    ) -> Result<
-        raw_window_handle::WindowHandle<'_>,
-        raw_window_handle::HandleError,
-    > {
+    ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
         let raw = raw_window_handle::WaylandWindowHandle::new({
             let ptr = self.surface.wl_surface().id().as_ptr();
             let Some(ptr) = std::ptr::NonNull::new(ptr as *mut _) else {
@@ -484,14 +440,10 @@ impl raw_window_handle::HasWindowHandle for SctkWinitWindow {
 impl raw_window_handle::HasDisplayHandle for SctkWinitWindow {
     fn display_handle(
         &self,
-    ) -> Result<
-        raw_window_handle::DisplayHandle<'_>,
-        raw_window_handle::HandleError,
-    > {
+    ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
         let raw = raw_window_handle::WaylandDisplayHandle::new({
             let ptr = self.display.id().as_ptr();
-            std::ptr::NonNull::new(ptr as *mut _)
-                .expect("wl_proxy should never be null")
+            std::ptr::NonNull::new(ptr as *mut _).expect("wl_proxy should never be null")
         });
 
         unsafe { Ok(raw_window_handle::DisplayHandle::borrow_raw(raw.into())) }

--- a/winit/src/proxy.rs
+++ b/winit/src/proxy.rs
@@ -39,8 +39,7 @@ impl<T: 'static> Proxy<T> {
         event_sender: mpsc::UnboundedSender<Event<T>>,
     ) -> (Self, impl Future<Output = ()>) {
         let (notifier, mut processed) = mpsc::channel(Self::MAX_SIZE);
-        let (sender, mut receiver): (mpsc::Sender<Action<T>>, _) =
-            mpsc::channel(Self::MAX_SIZE);
+        let (sender, mut receiver): (mpsc::Sender<Action<T>>, _) = mpsc::channel(Self::MAX_SIZE);
         let proxy = raw.clone();
         let event_sender_clone = event_sender.clone();
 
@@ -111,24 +110,15 @@ impl<T: 'static> Proxy<T> {
 impl<T: 'static> Sink<Action<T>> for Proxy<T> {
     type Error = mpsc::SendError;
 
-    fn poll_ready(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.sender.poll_ready(cx)
     }
 
-    fn start_send(
-        mut self: Pin<&mut Self>,
-        action: Action<T>,
-    ) -> Result<(), Self::Error> {
+    fn start_send(mut self: Pin<&mut Self>, action: Action<T>) -> Result<(), Self::Error> {
         self.sender.start_send(action)
     }
 
-    fn poll_flush(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match self.sender.poll_ready(cx) {
             Poll::Ready(Err(ref e)) if e.is_disconnected() => {
                 // If the receiver disconnected, we consider the sink to be flushed.

--- a/winit/src/window.rs
+++ b/winit/src/window.rs
@@ -13,9 +13,7 @@ use crate::core::renderer;
 use crate::core::text;
 use crate::core::theme::{self, Base};
 use crate::core::time::Instant;
-use crate::core::{
-    Color, Element, InputMethod, Padding, Point, Rectangle, Size, Text, Vector,
-};
+use crate::core::{Color, Element, InputMethod, Padding, Point, Rectangle, Size, Text, Vector};
 use crate::graphics::Compositor;
 use crate::program::{self, Program};
 use crate::runtime::window::raw_window_handle;
@@ -26,9 +24,8 @@ use winit::monitor::MonitorHandle;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-pub(crate) type ViewFn<M, T, R> = Arc<
-    Box<dyn Fn() -> Option<Element<'static, M, T, R>> + Send + Sync + 'static>,
->;
+pub(crate) type ViewFn<M, T, R> =
+    Arc<Box<dyn Fn() -> Option<Element<'static, M, T, R>> + Send + Sync + 'static>>;
 
 pub struct WindowManager<P, C>
 where
@@ -66,11 +63,8 @@ where
         let state = State::new(program, id, system_theme, window.as_ref());
         let surface_size = state.physical_size();
         let surface_version = state.surface_version();
-        let surface = compositor.create_surface(
-            window.clone(),
-            surface_size.width,
-            surface_size.height,
-        );
+        let surface =
+            compositor.create_surface(window.clone(), surface_size.width, surface_size.height);
         let renderer = compositor.create_renderer();
 
         self.aliases.retain(|w, i| *w != window.id() && *i != id);
@@ -127,9 +121,7 @@ where
         self.entries.first_key_value().map(|(_id, window)| window)
     }
 
-    pub fn iter_mut(
-        &mut self,
-    ) -> impl Iterator<Item = (Id, &mut Window<P, C>)> {
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (Id, &mut Window<P, C>)> {
         self.entries.iter_mut().map(|(k, v)| (*k, v))
     }
 
@@ -186,14 +178,8 @@ where
     pub raw: Arc<dyn winit::window::Window>,
     pub state: State<P>,
     pub viewport_version: u64,
-    pub drag_resize_window_func: Option<
-        Box<
-            dyn FnMut(
-                &dyn winit::window::Window,
-                &winit::event::WindowEvent,
-            ) -> bool,
-        >,
-    >,
+    pub drag_resize_window_func:
+        Option<Box<dyn FnMut(&dyn winit::window::Window, &winit::event::WindowEvent) -> bool>>,
     pub prev_dnd_destination_rectangles_count: usize,
     pub exit_on_close_request: bool,
     pub mouse_interaction: mouse::Interaction,
@@ -217,9 +203,7 @@ where
         self.raw
             .outer_position()
             .ok()
-            .map(|position: PhysicalPosition<i32>| {
-                position.to_logical(self.raw.scale_factor())
-            })
+            .map(|position: PhysicalPosition<i32>| position.to_logical(self.raw.scale_factor()))
             .map(|position: LogicalPosition<f32>| Point {
                 x: position.x as f32,
                 y: position.y as f32,
@@ -263,21 +247,14 @@ where
                     if preedit.content.is_empty() {
                         self.preedit = None;
                     } else {
-                        let mut overlay =
-                            self.preedit.take().unwrap_or_else(Preedit::new);
+                        let mut overlay = self.preedit.take().unwrap_or_else(Preedit::new);
 
-                        let mut background_color =
-                            self.state.background_color();
+                        let mut background_color = self.state.background_color();
                         if background_color.a < 1.0 {
                             let style = self.state.theme().base();
                             background_color = style.background_color;
                         }
-                        overlay.update(
-                            cursor,
-                            &preedit,
-                            background_color,
-                            &self.renderer,
-                        );
+                        overlay.update(cursor, &preedit, background_color, &self.renderer);
 
                         self.preedit = Some(overlay);
                     }
@@ -317,19 +294,12 @@ where
                 &mut self.renderer,
                 text_color,
                 background_color,
-                &Rectangle::new(
-                    Point::ORIGIN,
-                    self.state.viewport().logical_size(),
-                ),
+                &Rectangle::new(Point::ORIGIN, self.state.viewport().logical_size()),
             );
         }
     }
 
-    fn enable_ime(
-        &mut self,
-        cursor: Rectangle,
-        purpose: input_method::Purpose,
-    ) {
+    fn enable_ime(&mut self, cursor: Rectangle, purpose: input_method::Purpose) {
         if self.ime_state.is_none() {
             self.raw.set_ime_allowed(true);
         }
@@ -372,10 +342,7 @@ where
 {
     fn window_handle(
         &self,
-    ) -> Result<
-        raw_window_handle::WindowHandle<'_>,
-        raw_window_handle::HandleError,
-    > {
+    ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
         self.raw.window_handle()
     }
 }
@@ -387,10 +354,7 @@ where
 {
     fn display_handle(
         &self,
-    ) -> Result<
-        raw_window_handle::DisplayHandle<'_>,
-        raw_window_handle::HandleError,
-    > {
+    ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
         self.raw.display_handle()
     }
 }
@@ -452,9 +416,7 @@ where
             self.content = Renderer::Paragraph::with_spans(Text {
                 content: &spans,
                 bounds: Size::INFINITE,
-                size: preedit
-                    .text_size
-                    .unwrap_or_else(|| renderer.default_size()),
+                size: preedit.text_size.unwrap_or_else(|| renderer.default_size()),
                 line_height: text::LineHeight::default(),
                 font: renderer.default_font(),
                 align_x: text::Alignment::Default,
@@ -470,13 +432,7 @@ where
         }
     }
 
-    fn draw(
-        &self,
-        renderer: &mut Renderer,
-        color: Color,
-        background: Color,
-        viewport: &Rectangle,
-    ) {
+    fn draw(&self, renderer: &mut Renderer, color: Color, background: Color, viewport: &Rectangle) {
         use text::Paragraph as _;
 
         if self.content.min_width() < 1.0 {
@@ -512,12 +468,7 @@ where
                 background,
             );
 
-            renderer.fill_paragraph(
-                &self.content,
-                bounds.position(),
-                color,
-                bounds,
-            );
+            renderer.fill_paragraph(&self.content, bounds.position(), color, bounds);
 
             const UNDERLINE: f32 = 2.0;
 
@@ -535,8 +486,7 @@ where
             for span_bounds in self.content.span_bounds(1) {
                 renderer.fill_quad(
                     renderer::Quad {
-                        bounds: span_bounds
-                            + (bounds.position() - Point::ORIGIN),
+                        bounds: span_bounds + (bounds.position() - Point::ORIGIN),
                         ..Default::default()
                     },
                     color,

--- a/winit/src/window/state.rs
+++ b/winit/src/window/state.rs
@@ -58,8 +58,7 @@ where
         let title = program.title(window_id);
         let scale_factor = program.scale_factor(window_id);
         let theme = program.theme(window_id);
-        let theme_mode =
-            theme.as_ref().map(theme::Base::mode).unwrap_or_default();
+        let theme_mode = theme.as_ref().map(theme::Base::mode).unwrap_or_default();
         let default_theme = <P::Theme as theme::Base>::default(system_theme);
         let style = program.style(theme.as_ref().unwrap_or(&default_theme));
 
@@ -130,10 +129,7 @@ where
     pub fn cursor(&self) -> mouse::Cursor {
         self.cursor_position
             .map(|cursor_position| {
-                conversion::cursor_position(
-                    cursor_position,
-                    self.viewport.scale_factor(),
-                )
+                conversion::cursor_position(cursor_position, self.viewport.scale_factor())
             })
             .map(mouse::Cursor::Available)
             .unwrap_or(mouse::Cursor::Unavailable)
@@ -168,10 +164,7 @@ where
     pub(crate) fn update_scale_factor(&mut self, new_scale_factor: f64) {
         let size = self.viewport.logical_size();
 
-        self.viewport = Viewport::with_logical_size(
-            size,
-            new_scale_factor * self.scale_factor,
-        );
+        self.viewport = Viewport::with_logical_size(size, new_scale_factor * self.scale_factor);
 
         self.surface_version = self.surface_version.wrapping_add(1);
     }
@@ -187,10 +180,8 @@ where
             WindowEvent::SurfaceResized(new_size) => {
                 let size = Size::new(new_size.width, new_size.height);
 
-                self.viewport = Viewport::with_physical_size(
-                    size,
-                    window.scale_factor() * self.scale_factor,
-                );
+                self.viewport =
+                    Viewport::with_physical_size(size, window.scale_factor() * self.scale_factor);
                 self.surface_version += 1;
             }
             WindowEvent::ScaleFactorChanged {
@@ -216,9 +207,8 @@ where
                 self.modifiers = new_modifiers.state();
             }
             WindowEvent::ThemeChanged(theme) => {
-                self.default_theme = <P::Theme as theme::Base>::default(
-                    conversion::theme_mode(*theme),
-                );
+                self.default_theme =
+                    <P::Theme as theme::Base>::default(conversion::theme_mode(*theme));
 
                 if self.theme.is_none() {
                     self.style = program.style(&self.default_theme);
@@ -250,8 +240,7 @@ where
         let current_size = self.viewport.physical_size();
 
         if self.scale_factor != new_scale_factor
-            || (current_size.width, current_size.height)
-                != (new_size.width, new_size.height)
+            || (current_size.width, current_size.height) != (new_size.width, new_size.height)
                 && !(new_size.width == 0 && new_size.height == 0)
         {
             if new_size.width == 0 {
@@ -287,8 +276,7 @@ where
                 // Assume the old mode matches the system one
                 // We will be notified otherwise
                 if new_mode == theme::Mode::None {
-                    self.default_theme =
-                        <P::Theme as theme::Base>::default(self.theme_mode);
+                    self.default_theme = <P::Theme as theme::Base>::default(self.theme_mode);
 
                     if self.theme.is_none() {
                         self.style = program.style(&self.default_theme);


### PR DESCRIPTION
Since upstream did the same, this makes getting diffs and applying upstream fixes easier: https://github.com/iced-rs/iced/pull/3142

- deleted `rustfmt.toml`
- ran `cargo fmt`
- fixed `example/sctk_subsurface_img` complaining about `" ".into() not a pattern`