### PR TITLE
fix(ime): Don't panic if some IME sends DeleteSurrounding events

### DIFF
--- a/winit/src/conversion.rs
+++ b/winit/src/conversion.rs
@@ -387,19 +387,19 @@ pub fn window_event(
                 self::modifiers(new_modifiers.state()),
             )))
         }
-        WindowEvent::Ime(event) => Some(Event::InputMethod(match event {
-            Ime::Enabled => input_method::Event::Opened,
-            Ime::Preedit(content, size) => input_method::Event::Preedit(
+        WindowEvent::Ime(event) => match event {
+            Ime::Enabled => Some(input_method::Event::Opened),
+            Ime::Preedit(content, size) => Some(input_method::Event::Preedit(
                 content,
                 size.map(|(start, end)| start..end),
-            ),
-            Ime::Commit(content) => input_method::Event::Commit(content),
-            Ime::Disabled => input_method::Event::Closed,
-            Ime::DeleteSurrounding {
-                before_bytes,
-                after_bytes,
-            } => todo!(),
-        })),
+            )),
+            Ime::Commit(content) => Some(input_method::Event::Commit(content)),
+            Ime::Disabled => Some(input_method::Event::Closed),
+            // Upstream iced depends on the winit version which doesn't support
+            // this kind of ime event.
+            Ime::DeleteSurrounding { .. } => None,
+        }
+        .map(Event::InputMethod),
         WindowEvent::Focused(focused) => Some(Event::Window(if focused {
             window::Event::Focused
         } else {


### PR DESCRIPTION
Fixes https://github.com/pop-os/libcosmic/issues/1273

The upstream iced doesn't support for this kind of winit Ime event, when we rebased with newer winit, we have `todo!()` for this arm.

As our (and iced) IME support is over-the-spot style and we don't support sending surrounding text information around the text input cursor, so useful ImeDeleteSurrounding events are not sent to COSMIC apps.

Actually, in the case of https://github.com/pop-os/libcosmic/issues/1273, fictx5-mozc sends us `DeleteSurrounding { after_bytes: 0, before_bytes: 0 }`, this means delete nothing. So ignoring this is safe for us, and I don't find misbehavior about this.

---

The core team is busy and does not have time to mentor nor babysit new contributors. If a member of the core team thinks that reviewing and understanding your work will take more time and effort than writing it from scratch by themselves, your contribution will be dismissed. It is your responsibility to communicate and figure out how to reduce the likelihood of this!

Read the contributing guidelines for more details: https://github.com/iced-rs/iced/blob/master/CONTRIBUTING.md
