### PR TITLE
fix: bootstrap FrameStatus on session lock surface configure

### DIFF
--- a/winit/src/platform_specific/wayland/handlers/session_lock.rs
+++ b/winit/src/platform_specific/wayland/handlers/session_lock.rs
@@ -1,6 +1,10 @@
 use crate::{
     event_loop::state::CommonSurface,
-    platform_specific::wayland::{handlers::SctkState, sctk_event::SctkEvent},
+    platform_specific::wayland::{
+        event_loop::state::receive_frame,
+        handlers::SctkState,
+        sctk_event::SctkEvent,
+    },
 };
 use cctk::sctk::{
     delegate_session_lock,
@@ -67,6 +71,10 @@ impl SessionLockHandler for SctkState {
                 configure,
                 first,
             });
+
+        let wl_surface = session_lock_surface.wl_surface().clone();
+        receive_frame(&mut self.frame_status, &wl_surface);
+        self.request_redraw(&wl_surface);
     }
 }
 


### PR DESCRIPTION


The session lock configure handler was missing receive_frame() and request_redraw() calls that the layer surface configure handler has. Without these, after S3 resume or DPMS wake, the FrameStatus entry for lock surfaces could be missing, causing the rendering gate to never reach Ready state — resulting in permanently grey lock screens.
