### PR TITLE
fix: crash while resizing on x11

### DIFF
--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -361,6 +361,13 @@ pub fn present(
 ) -> Result<(), compositor::SurfaceError> {
     match surface.get_current_texture() {
         Ok(frame) => {
+            if frame.suboptimal
+                || frame.texture.width() != viewport.physical_width()
+                || frame.texture.height() != viewport.physical_height()
+            {
+                return Err(compositor::SurfaceError::Outdated);
+            }
+
             let view = &frame
                 .texture
                 .create_view(&wgpu::TextureViewDescriptor::default());


### PR DESCRIPTION
You can replicate the error using `WAYLAND_DISPLAY= RUST_BACKTRACE=1 cargo run -p application` in libcosmic and resize the window.
