### PR TITLE
wgpu: request SHADER_F16 only when adapter advertises it

### DIFF
--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -289,6 +289,13 @@ impl Compositor {
             ..limits
         });
 
+        // Request SHADER_F16 only if the adapter supports it (e.g., not available in WebGL2)
+        let required_features = if adapter.features().contains(wgpu::Features::SHADER_F16) {
+            wgpu::Features::SHADER_F16
+        } else {
+            wgpu::Features::empty()
+        };
+
         let mut errors = Vec::new();
 
         for required_limits in limits {
@@ -297,7 +304,7 @@ impl Compositor {
                     label: Some(
                         "iced_wgpu::window::compositor device descriptor",
                     ),
-                    required_features: wgpu::Features::SHADER_F16,
+                    required_features,
                     required_limits: required_limits.clone(),
                     memory_hints: wgpu::MemoryHints::MemoryUsage,
                     trace: wgpu::Trace::Off,


### PR DESCRIPTION
This is a backport of https://github.com/iced-rs/iced/pull/3183 and fixes a regression in libcosmic since the iced rebase that affects many Linux phones.

Compositor::request unconditionally calls request_device with required_features: Features::SHADER_F16. Adapters that don't advertise SHADER_F16 (notably Mesa's Turnip on Adreno 6xx and other older mobile GPUs ) fail the
call, and iced_renderer silently falls back to iced_tiny_skia, which drops every custom-shader primitive. End users see a working app with a sluggish UI due to missing GPU acceleration and blank custom-shader regions (for example the camera and filter previews of the COSMIC Utils "Camera" app).

This PR masks the requested features against the adapter's actual feature set, preserving the original intent (enable SHADER_F16 where supported) without failing request_device on adapters that lack it.

Verified on:
- Mesa Turnip / Adreno 6xx (Pixel 3a, Alpine Linux with Posh, Wayland)
- Nvidia proprietary driver / RTX 3090 (CachyOS with COSMIC, Wayland)