### PR TITLE
fix: avoid deadlock in context menu rendering

### DIFF
--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -368,12 +368,13 @@ pub fn present(
 ) -> Result<(), compositor::SurfaceError> {
     match surface.get_current_texture() {
         Ok(frame) => {
-            if frame.suboptimal
-                || frame.texture.width() != viewport.physical_width()
+            if frame.texture.width() != viewport.physical_width()
                 || frame.texture.height() != viewport.physical_height()
             {
                 return Err(compositor::SurfaceError::Outdated);
             }
+
+            let suboptimal = frame.suboptimal;
 
             let view = &frame
                 .texture
@@ -389,6 +390,10 @@ pub fn present(
             // Present the frame
             on_pre_present();
             frame.present();
+
+            if suboptimal {
+                return Err(compositor::SurfaceError::Outdated);
+            }
 
             Ok(())
         }

--- a/winit/src/platform_specific/wayland/event_loop/mod.rs
+++ b/winit/src/platform_specific/wayland/event_loop/mod.rs
@@ -538,7 +538,6 @@ impl SctkEventLoop {
                         wake_up = true;
 
                         _ = s.frame(&state.state.queue_handle, s.clone());
-                        _ = state.state.frame_status.remove(&id);
                         _ = state.state.events_sender.unbounded_send(
                             Control::Winit(
                                 winit::window::WindowId::from_raw(
@@ -547,6 +546,7 @@ impl SctkEventLoop {
                                 winit::event::WindowEvent::RedrawRequested,
                             ),
                         );
+                        _ = state.state.frame_status.insert(id, state::FrameStatus::Received);
                     }
 
                     if wake_up {


### PR DESCRIPTION
This was part of my fixes for https://github.com/pop-os/libcosmic/pull/1288. I think it's worth merging it separately while I work on that PR.

Looks like since https://github.com/pop-os/iced/pull/336 we remove the frame status entry after dispatching a redraw. A hover would register a request redraw but the entry is vacant so it's gonna wait forever to receive a frame callback which will never come.