### PR TITLE
fix(text): don't reload cache every redraw

### DIFF
--- a/tiny_skia/src/text.rs
+++ b/tiny_skia/src/text.rs
@@ -15,6 +15,7 @@ use std::collections::hash_map;
 pub struct Pipeline {
     glyph_cache: GlyphCache,
     cache: RefCell<Cache>,
+    swash_cache: cosmic_text::SwashCache,
 }
 
 impl Pipeline {
@@ -22,6 +23,7 @@ impl Pipeline {
         Pipeline {
             glyph_cache: GlyphCache::new(),
             cache: RefCell::new(Cache::new()),
+            swash_cache: cosmic_text::SwashCache::new(),
         }
     }
 
@@ -54,6 +56,7 @@ impl Pipeline {
         draw(
             font_system.raw(),
             &mut self.glyph_cache,
+            &mut self.swash_cache,
             paragraph.buffer(),
             position,
             color,
@@ -81,6 +84,7 @@ impl Pipeline {
         draw(
             font_system.raw(),
             &mut self.glyph_cache,
+            &mut self.swash_cache,
             editor.buffer(),
             position,
             color,
@@ -142,6 +146,7 @@ impl Pipeline {
         draw(
             font_system,
             &mut self.glyph_cache,
+            &mut self.swash_cache,
             &entry.buffer,
             Point::new(x, y),
             color,
@@ -165,6 +170,7 @@ impl Pipeline {
         draw(
             font_system.raw(),
             &mut self.glyph_cache,
+            &mut self.swash_cache,
             buffer,
             position,
             color,
@@ -183,6 +189,7 @@ impl Pipeline {
 fn draw(
     font_system: &mut cosmic_text::FontSystem,
     glyph_cache: &mut GlyphCache,
+    swash_cache: &mut cosmic_text::SwashCache,
     buffer: &cosmic_text::Buffer,
     position: Point,
     color: Color,
@@ -191,8 +198,6 @@ fn draw(
     transformation: Transformation,
 ) {
     let position = position * transformation;
-
-    let mut swash = cosmic_text::SwashCache::new();
 
     for run in buffer.layout_runs() {
         for glyph in run.glyphs {
@@ -205,7 +210,7 @@ fn draw(
                 physical_glyph.cache_key,
                 glyph.color_opt.map(from_color).unwrap_or(color),
                 font_system,
-                &mut swash,
+                swash_cache,
             ) {
                 let pixmap = tiny_skia::PixmapRef::from_bytes(
                     buffer,

--- a/wgpu/src/text.rs
+++ b/wgpu/src/text.rs
@@ -308,6 +308,7 @@ pub struct State {
     prepare_layer: usize,
     cache: BufferCache,
     storage: Storage,
+    swash_cache: cryoglyph::SwashCache,
 }
 
 impl State {
@@ -352,6 +353,7 @@ impl State {
                         renderer,
                         &mut atlas,
                         &mut self.cache,
+                        &mut self.swash_cache,
                         text,
                         layer_bounds * layer_transformation,
                         layer_transformation * *transformation,
@@ -448,6 +450,7 @@ fn prepare(
     renderer: &mut cryoglyph::TextRenderer,
     atlas: &mut cryoglyph::TextAtlas,
     buffer_cache: &mut BufferCache,
+    swash_cache: &mut cryoglyph::SwashCache,
     sections: &[Text],
     layer_bounds: Rectangle,
     layer_transformation: Transformation,
@@ -643,6 +646,6 @@ fn prepare(
         atlas,
         viewport,
         text_areas,
-        &mut cryoglyph::SwashCache::new(),
+        swash_cache,
     )
 }


### PR DESCRIPTION
I have >1000 fonts installed. COSMIC has always been somewhat laggy for me, but I had assumed it was just like that for everyone, or was the fault of my T480s. Eventually, when trying to diagnose some hitching, I ended up discovering that cosmic-launcher was consuming on average ~5% total CPU over time, which led me to discover that it was fetching all the fonts from disk and software rendering the fonts, every redraw, causing the high cpu usage *and* the stutters (as a result of hammering disk I/O). Oops.

The fix is simple: just persist the cache across redraws.

<!-- The core team is busy and does not have time to mentor nor babysit new contributors. If a member of the core team thinks that reviewing and understanding your work will take more time and effort than writing it from scratch by themselves, your contribution will be dismissed. It is your responsibility to communicate and figure out how to reduce the likelihood of this!

Read the contributing guidelines for more details: https://github.com/iced-rs/iced/blob/master/CONTRIBUTING.md -->
