### PR TITLE
fix: reuse wgpu compositor

### DIFF
--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -838,6 +838,28 @@ async fn run_instance<P>(
 
     log::info!("System theme: {system_theme:?}");
 
+    macro_rules! run_action {
+        ($action:expr) => {
+            run_action(
+                $action,
+                &program,
+                &mut runtime,
+                &mut compositor,
+                &mut events,
+                &mut messages,
+                &mut clipboard,
+                &mut control_sender,
+                &mut user_interfaces,
+                &mut window_manager,
+                &mut ui_caches,
+                &mut is_window_opening,
+                &mut system_theme,
+                &mut platform_specific_handler,
+                is_daemon,
+            )
+        };
+    }
+
     'next_event: loop {
         // Empty the queue if possible
         let event = if let Ok(event) = event_receiver.try_recv() {
@@ -1001,23 +1023,7 @@ async fn run_instance<P>(
                 }
             }
             Event::UserEvent(action) => {
-                let exited = run_action(
-                    action,
-                    &program,
-                    &mut runtime,
-                    &mut compositor,
-                    &mut events,
-                    &mut messages,
-                    &mut clipboard,
-                    &mut control_sender,
-                    &mut user_interfaces,
-                    &mut window_manager,
-                    &mut ui_caches,
-                    &mut is_window_opening,
-                    &mut system_theme,
-                    &mut platform_specific_handler,
-                    is_daemon,
-                );
+                let exited = run_action!(action);
                 if exited {
                     runtime.track(None.into_iter());
                 }
@@ -1159,23 +1165,7 @@ async fn run_instance<P>(
                                 continue;
                             }
 
-                            _ = run_action(
-                                action,
-                                &program,
-                                &mut runtime,
-                                &mut compositor,
-                                &mut events,
-                                &mut messages,
-                                &mut clipboard,
-                                &mut control_sender,
-                                &mut user_interfaces,
-                                &mut window_manager,
-                                &mut ui_caches,
-                                &mut is_window_opening,
-                                &mut system_theme,
-                                &mut platform_specific_handler,
-                                is_daemon,
-                            );
+                            _ = run_action!(action);
                         }
 
                         for (window_id, window) in window_manager.iter_mut() {
@@ -1358,23 +1348,7 @@ async fn run_instance<P>(
                 if matches!(event, winit::event::WindowEvent::CloseRequested)
                     && window.exit_on_close_request
                 {
-                    _ = run_action(
-                        Action::Window(runtime::window::Action::Close(id)),
-                        &program,
-                        &mut runtime,
-                        &mut compositor,
-                        &mut events,
-                        &mut messages,
-                        &mut clipboard,
-                        &mut control_sender,
-                        &mut user_interfaces,
-                        &mut window_manager,
-                        &mut ui_caches,
-                        &mut is_window_opening,
-                        &mut system_theme,
-                        &mut platform_specific_handler,
-                        is_daemon,
-                    );
+                    _ = run_action!(Action::Window(runtime::window::Action::Close(id)));
                 } else {
                     window.state.update(&program, window.raw.as_ref(), &event);
 
@@ -1552,23 +1526,7 @@ async fn run_instance<P>(
                     ));
 
                     for action in actions {
-                        let exited = run_action(
-                            action,
-                            &program,
-                            &mut runtime,
-                            &mut compositor,
-                            &mut events,
-                            &mut messages,
-                            &mut clipboard,
-                            &mut control_sender,
-                            &mut user_interfaces,
-                            &mut window_manager,
-                            &mut ui_caches,
-                            &mut is_window_opening,
-                            &mut system_theme,
-                            &mut platform_specific_handler,
-                            is_daemon,
-                        );
+                        let exited = run_action!(action);
                         if exited {
                             runtime.track(None.into_iter());
                         }

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -864,28 +864,30 @@ async fn run_instance<P>(
                 platform_specific_handler.send_wayland(
                     platform_specific::Action::TrackWindow(window.clone(), id),
                 );
-                match create_compositor::<P>(
-                    window.clone(),
-                    CreateCompositor {
-                        proxy: &proxy,
-                        runtime: &mut runtime,
-                        display_handle: &display_handle,
-                        graphics_settings: &graphics_settings,
-                        default_fonts: &default_fonts,
-                    },
-                )
-                .await
-                {
-                    Ok(comp) => {
-                        compositor = Some(comp);
-                    }
-                    Err(error) => {
-                        control_sender
-                            .start_send(Control::Crash(
-                                Error::GraphicsCreationFailed(error),
-                            ))
-                            .expect("Send control message");
-                        continue;
+                if compositor.is_none() {
+                    match create_compositor::<P>(
+                        window.clone(),
+                        CreateCompositor {
+                            proxy: &proxy,
+                            runtime: &mut runtime,
+                            display_handle: &display_handle,
+                            graphics_settings: &graphics_settings,
+                            default_fonts: &default_fonts,
+                        },
+                    )
+                    .await
+                    {
+                        Ok(comp) => {
+                            compositor = Some(comp);
+                        }
+                        Err(error) => {
+                            control_sender
+                                .start_send(Control::Crash(
+                                    Error::GraphicsCreationFailed(error),
+                                ))
+                                .expect("Send control message");
+                            continue;
+                        }
                     }
                 }
 
@@ -1014,6 +1016,7 @@ async fn run_instance<P>(
                     &mut is_window_opening,
                     &mut system_theme,
                     &mut platform_specific_handler,
+                    is_daemon,
                 );
                 if exited {
                     runtime.track(None.into_iter());
@@ -1171,6 +1174,7 @@ async fn run_instance<P>(
                                 &mut is_window_opening,
                                 &mut system_theme,
                                 &mut platform_specific_handler,
+                                is_daemon,
                             );
                         }
 
@@ -1369,6 +1373,7 @@ async fn run_instance<P>(
                         &mut is_window_opening,
                         &mut system_theme,
                         &mut platform_specific_handler,
+                        is_daemon,
                     );
                 } else {
                     window.state.update(&program, window.raw.as_ref(), &event);
@@ -1562,6 +1567,7 @@ async fn run_instance<P>(
                             &mut is_window_opening,
                             &mut system_theme,
                             &mut platform_specific_handler,
+                            is_daemon,
                         );
                         if exited {
                             runtime.track(None.into_iter());
@@ -2106,6 +2112,7 @@ fn run_action<'a, P, C>(
     is_window_opening: &mut bool,
     system_theme: &mut theme::Mode,
     platform_specific: &mut crate::platform_specific::PlatformSpecific,
+    is_daemon: bool,
 ) -> bool
 where
     P: Program,
@@ -2190,7 +2197,7 @@ where
                     ));
                 }
 
-                if window_manager.is_empty() {
+                if window_manager.is_empty() && !is_daemon {
                     *compositor = None;
                 }
             }


### PR DESCRIPTION
Fixes: 
- https://github.com/pop-os/cosmic-epoch/issues/3605
- https://github.com/pop-os/cosmic-epoch/issues/1489
- https://github.com/pop-os/cosmic-epoch/issues/1432
- https://github.com/pop-os/xdg-desktop-portal-cosmic/issues/301
- https://github.com/pop-os/cosmic-files/issues/1385
- https://github.com/pop-os/xdg-desktop-portal-cosmic/issues/293

I might have missed some. Unfortunately, many similar issues have been reported across different projects.

**Issue repro**
On NVIDIA, under Wayland, `xdg-desktop-portal-cosmic` frequently crashes (SIGSEGV) when its file-chooser dialog is opened (e.g., from a browser when you download a file with the choose option, or when trying to upload a file). The dialog appears only after 2–3 clicks because the portal process dies and is restarted, causing the in-flight request to be lost.

**Root cause**
So, the portal is a daemon with no persistent window. In `run_instance`:

- Every `Event::WindowCreated` unconditionally calls `create_compositor()` and replaces the `compositor`, meaning a fresh `wgpu::Instance` is built for every new window.
- When the last window closes, `if window_manager.is_empty() { *compositor = None; }` drops it.

For a daemon that opens one dialog window at a time, this means a full `wgpu::Instance` create-on-open / destroy-on-close cycle per dialog. Rapidly creating and destroying Vulkan instances triggers a global-state/teardown bug in NVIDIA's proprietary driver (https://github.com/gfx-rs/wgpu/issues/5930, https://github.com/gfx-rs/wgpu/issues/8365), which causes the process to segfault.

**Fix explanation**
Create the compositor once and reuse it (just like that):

1. Only build it if there isn't one yet, like `if compositor.is_none() { create_compositor }` in the `WindowCreated` branch, and reuse the existing compositor for other new windows. 
   This also helps prevent tearing a live compositor and the surfaces of already open windows when a new window appears while the previous one is still active.
3. Don't drop the compositor when the last window closes for daemons: 
   `if window_manager.is_empty() && !is_daemon { *compositor = None; }` (`is_daemon` is threaded into `run_action`). Non-daemon apps keep the old behavior. But anyway, they still exit when the last window is closed.

**Small refactoring note**
I've also added a small refactoring by introducing the `run_action!` macro to reduce boilerplate.

**What I've tested**

Built xdg-desktop-portal with this change and checked the file chooser from Chrome and Brave on
an NVIDIA RTX 4090 (driver 580.159.03, Wayland), with different approaches:

- **20+ upload/download dialogs open, 0 crashes** (previously ~50% crashed -> the "needs 2–3 clicks" symptom).

**Small note**
It was a very deep rabbit hole. Finding the root cause for this issue was one of the most puzzling things I've encountered while fixing issues in the Pop OS ecosystem.
