### PR TITLE
improv: use `cosmic_text`'s persistent cached fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.2.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?rev=a7d2d7a#a7d2d7a6188425f699eaddf7a025617ce56068ae"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=32283d7#32283d76a8d0342da74c4cc022a533c52dcf378f"
 dependencies = [
  "bitflags 2.11.0",
  "cosmic-protocols",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "cosmic-protocols"
 version = "0.2.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?rev=a7d2d7a#a7d2d7a6188425f699eaddf7a025617ce56068ae"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=32283d7#32283d76a8d0342da74c4cc022a533c52dcf378f"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -1321,8 +1321,7 @@ dependencies = [
 [[package]]
 name = "cosmic-text"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be17b688510d934ce13f48a2beba700e11583e281e0fda99c22bb256a14eda73"
+source = "git+https://github.com/pop-os/cosmic-text.git?rev=4fe1195e6451d6aaa3dc383895d6fd366ea9fc7b#4fe1195e6451d6aaa3dc383895d6fd366ea9fc7b"
 dependencies = [
  "bitflags 2.11.0",
  "fontdb",
@@ -1446,7 +1445,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "cryoglyph"
 version = "0.1.0"
-source = "git+https://github.com/iced-rs/cryoglyph.git?rev=e429a025df36ab8145708acb309080ae3deec17a#e429a025df36ab8145708acb309080ae3deec17a"
+source = "git+https://github.com/pop-os/glyphon.git?rev=273130949ef4ffc652e3d5e5255219f1f079868e#273130949ef4ffc652e3d5e5255219f1f079868e"
 dependencies = [
  "cosmic-text",
  "etagere",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,8 +238,8 @@ async-std = "1.0"
 bitflags = "2.5"
 bytemuck = { version = "1.0", features = ["derive"] }
 bytes = "1.6"
-cosmic-text = "0.19"
-cryoglyph = { git = "https://github.com/iced-rs/cryoglyph.git", rev = "e429a025df36ab8145708acb309080ae3deec17a" }
+cosmic-text = { git = "https://github.com/pop-os/cosmic-text.git", rev = "4fe1195e6451d6aaa3dc383895d6fd366ea9fc7b" }
+cryoglyph = { git = "https://github.com/pop-os/glyphon.git", rev = "273130949ef4ffc652e3d5e5255219f1f079868e" }
 dark-light = "1.0"
 resvg = "0.45"
 web-sys = "0.3.69"

--- a/graphics/src/text.rs
+++ b/graphics/src/text.rs
@@ -133,7 +133,7 @@ pub fn font_system() -> &'static RwLock<FontSystem> {
 
     FONT_SYSTEM.get_or_init(|| {
         RwLock::new(FontSystem {
-            raw: cosmic_text::FontSystem::new_with_fonts([
+            raw: cosmic_text::FontSystem::new_with_fonts_and_cache([
                 cosmic_text::fontdb::Source::Binary(Arc::new(
                     include_bytes!("../fonts/Iced-Icons.ttf").as_slice(),
                 )),

--- a/wgpu/src/image/vector.rs
+++ b/wgpu/src/image/vector.rs
@@ -1,5 +1,6 @@
 use crate::core::svg;
 use crate::core::{Color, Size};
+use crate::graphics::text;
 use crate::image::atlas::{self, Atlas};
 
 use resvg::tiny_skia;
@@ -40,6 +41,7 @@ pub struct Cache {
     rasterized_hits: FxHashSet<(u64, u32, u32, ColorFilter)>,
     should_trim: bool,
     fontdb: Option<Arc<usvg::fontdb::Database>>,
+    fontdb_version: Option<text::Version>,
 }
 
 type ColorFilter = Option<[u8; 4]>;
@@ -51,12 +53,12 @@ impl Cache {
             return self.svgs.get(&handle.id()).unwrap();
         }
 
-        // TODO: Reuse `cosmic-text` font database
-        if self.fontdb.is_none() {
-            let mut fontdb = usvg::fontdb::Database::new();
-            fontdb.load_system_fonts();
+        let font_system = text::font_system().read().expect("Read font system");
+        let version = font_system.version();
 
-            self.fontdb = Some(Arc::new(fontdb));
+        if self.fontdb_version != Some(version) {
+            self.fontdb = Some(Arc::new(font_system.db().clone()));
+            self.fontdb_version = Some(version);
         }
 
         let options = usvg::Options {


### PR DESCRIPTION
This improves the app startup on systems with many fonts. We have to switch to Pop's fork of glyphon. But we're gonna pin cosmic-text to a specific commit so the previous issues when a breaking change was merged in cosmic-text doesn't happen anymore.

- [x] Depends on https://github.com/pop-os/cosmic-text/pull/510
- [x] Depends on https://github.com/pop-os/glyphon/pull/5
- [ ] Update cache if a new folder has been created since