### PR TITLE
wayland: keep the clipboard alive when its surface is destroyed

### DIFF
--- a/winit/src/platform_specific/wayland/sctk_event.rs
+++ b/winit/src/platform_specific/wayland/sctk_event.rs
@@ -719,12 +719,6 @@ impl SctkEvent {
                                 DndSurface(Arc::new(Box::new(w.raw.clone()))),
                                 Vec::new(),
                             );
-                            if clipboard
-                                .window_id()
-                                .is_some_and(|id| w.raw.id() == id)
-                            {
-                                *clipboard = Clipboard::unconnected();
-                            }
                         }
                         events.push((
                             Some(id.inner()),
@@ -935,12 +929,6 @@ impl SctkEvent {
                                         ))),
                                         Vec::new(),
                                     );
-                                    if clipboard
-                                        .window_id()
-                                        .is_some_and(|id| w.raw.id() == id)
-                                    {
-                                        *clipboard = Clipboard::unconnected();
-                                    }
                                 }
                                 _ = user_interfaces.remove(&id.inner());
 
@@ -1666,12 +1654,6 @@ impl SctkEvent {
                                 DndSurface(Arc::new(Box::new(w.raw.clone()))),
                                 Vec::new(),
                             );
-                            if clipboard
-                                .window_id()
-                                .is_some_and(|id| w.raw.id() == id)
-                            {
-                                *clipboard = Clipboard::unconnected();
-                            }
                         }
                         events.push((
                             Some(id_wrapper.inner()),


### PR DESCRIPTION
When a layer-shell surface, popup, or subsurface is destroyed, the wayland event loop resets the clipboard with `*clipboard = Clipboard::unconnected()`. That drops the `window_clipboard::Clipboard` and the smithay-clipboard worker serving whatever was just copied. So any app that copies to the clipboard and then closes the surface it copied from loses the offer immediately.

COSMIC's screenshot portal is the clearest case. It owns a single overlay surface, and copying to the clipboard destroys that overlay in the same batch as the copy, so the `image/png` offer dies a moment after it's set and nothing can paste the screenshot. See pop-os/xdg-desktop-portal-cosmic#295.

The reset isn't needed. `window_clipboard` only wants the wayland *display* handle, not the surface, and smithay-clipboard runs its own connection to serve the selection. The display outlives every surface, so a copied selection should survive the surface going away. The regular window-close path in `lib.rs` already does the right thing by rebinding to another window instead of dropping; only the layer/popup/subsurface destroy paths did the unconditional reset. This removes those three.

Before, copying a screenshot to the clipboard:

    $ wl-paste --list-types
    text/plain;charset=utf-8
    UTF8_STRING
    text/plain

After:

    $ wl-paste --list-types
    image/png
    text/plain
