### PR TITLE
fix: intersect nested clip bounds with parent layer

### DIFF
--- a/graphics/src/layer.rs
+++ b/graphics/src/layer.rs
@@ -83,12 +83,19 @@ impl<T: Layer> Stack<T> {
     /// Pushes a new clipping region in the [`Stack`]; creating a new layer in the
     /// process.
     pub fn push_clip(&mut self, bounds: Rectangle) {
+        let bounds = bounds * self.transformation();
+        let bounds = bounds
+            .intersection(&self.layers[self.current].bounds())
+            .unwrap_or(Rectangle {
+                width: 0.0,
+                height: 0.0,
+                ..bounds
+            });
+
         self.previous.push(self.current);
 
         self.current = self.active_count;
         self.active_count += 1;
-
-        let bounds = bounds * self.transformation();
 
         if self.current == self.layers.len() {
             self.layers.push(T::with_bounds(bounds));


### PR DESCRIPTION
**Problem**
`Stack`'s nested children don't respect parents' layer bounds, so content "escapes" the ancestor's clipping.

**Fix**
Intersect child bounds with parent layer on `push_clip`, so they can't escape parent bounds.