### PR TITLE
feat: add overflow option to Pin widget to allow content beyond boundaries

### DIFF
--- a/widget/src/pin.rs
+++ b/widget/src/pin.rs
@@ -60,6 +60,7 @@ where
     width: Length,
     height: Length,
     position: Point,
+    overflow: bool,
 }
 
 impl<'a, Message, Theme, Renderer> Pin<'a, Message, Theme, Renderer>
@@ -75,6 +76,7 @@ where
             width: Length::Fill,
             height: Length::Fill,
             position: Point::ORIGIN,
+            overflow: false,
         }
     }
 
@@ -105,6 +107,12 @@ where
     /// Sets the Y coordinate of the [`Pin`].
     pub fn y(mut self, y: impl Into<Pixels>) -> Self {
         self.position.y = y.into().0;
+        self
+    }
+
+    /// Sets whether the [`Pin`] can overflow its boundaries.
+    pub fn overflow(mut self, overflow: bool) -> Self {
+        self.overflow = overflow;
         self
     }
 }
@@ -145,8 +153,12 @@ where
     ) -> layout::Node {
         let limits = limits.width(self.width).height(self.height);
 
-        let available =
-            limits.max() - Size::new(self.position.x, self.position.y);
+        let available = 
+            if self.overflow {
+                limits.max()
+            } else {
+                limits.max() - Size::new(self.position.x, self.position.y)
+            };
 
         let node = self
             .content


### PR DESCRIPTION
Adds an overflow `bool` field to the `Pin` widget with a corresponding `.overflow()` builder method.

By default, `Pin` subtracts its position from the available layout space, which causes content to be clipped or repositioned when near the boundaries of its container  The images below demonstrates it:

Here's what the node box and the text should look, consistently.
<img width="910" height="490" alt="image" src="https://github.com/user-attachments/assets/50803cd6-c10f-437e-8fbc-f05c6455dee5" />

Here's what it looks like with the current `Pin`.
<img width="910" height="490" alt="image" src="https://github.com/user-attachments/assets/2c213f79-0fa6-4957-825b-cd86054d5a9e" />
<img width="910" height="490" alt="image" src="https://github.com/user-attachments/assets/43cb70c9-aa3c-4c2d-bf47-d48863c476d6" />

With `.overflow(true)`, it skips this subtraction, giving the content the full available space regardless of position.
<img width="910" height="490" alt="image" src="https://github.com/user-attachments/assets/f18bee05-5440-4ea0-8f3b-0b0b17883653" />

This is useful for infinite canvas or free-form layout scenarios where pinned content should be able to move freely without being constrained by its screen position.

You can check out my repo's [canvas.rs](https://github.com/john-basilio/dreaming-wizard/blob/main/src/nav/canvas.rs) where `pin()` was used.