### PR TITLE
add patch wgpu x11 for build crate in e2k cpu architecture

### DIFF
--- a/wgpu/src/window/x11.rs
+++ b/wgpu/src/window/x11.rs
@@ -146,17 +146,9 @@ pub fn get_x11_device_ids<W: Window>(window: &W) -> Option<(u16, u16)> {
                                     {
                                         let stat =
                                             stat(Path::new("/dev/dri").join(device)).ok()?;
-                                        let dev: u64 = {
-                                            #[cfg(not(target_arch = "e2k"))]
-                                            {
-                                                stat.st_rdev
-                                            }
-
-                                            #[cfg(target_arch = "e2k")]
-                                            {
-                                                stat.st_rdev as u64
-                                            }
-                                        };
+                                        // Hack (u64 as u64) for E2K CPU architecture
+                                        #[allow(clippy::unnecessary_cast)]
+                                        let dev = stat.st_rdev as u64;
                                         return super::ids_from_dev(dev);
                                     }
                                 }
@@ -177,17 +169,9 @@ pub fn get_x11_device_ids<W: Window>(window: &W) -> Option<(u16, u16)> {
         let dri3 = conn.dri3_open(root, x11rb::NONE).ok()?.reply().ok()?;
         let device_fd = dri3.device_fd;
         let stat = fstat(device_fd).ok()?;
-        let dev: u64 = {
-            #[cfg(not(target_arch = "e2k"))]
-            {
-                stat.st_rdev
-            }
-
-            #[cfg(target_arch = "e2k")]
-            {
-                stat.st_rdev as u64
-            }
-        };
+        // Hack (u64 as u64) for E2K CPU architecture
+        #[allow(clippy::unnecessary_cast)]
+        let dev = stat.st_rdev as u64;
         super::ids_from_dev(dev)
     }
 }

--- a/wgpu/src/window/x11.rs
+++ b/wgpu/src/window/x11.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use std::{
     fs,
     io::{BufRead, BufReader},
@@ -144,7 +146,17 @@ pub fn get_x11_device_ids<W: Window>(window: &W) -> Option<(u16, u16)> {
                                     {
                                         let stat =
                                             stat(Path::new("/dev/dri").join(device)).ok()?;
-                                        let dev = stat.st_rdev;
+                                        let dev: u64 = {
+                                            #[cfg(not(target_arch = "e2k"))]
+                                            {
+                                                stat.st_rdev
+                                            }
+
+                                            #[cfg(target_arch = "e2k")]
+                                            {
+                                                stat.st_rdev as u64
+                                            }
+                                        };
                                         return super::ids_from_dev(dev);
                                     }
                                 }
@@ -165,7 +177,17 @@ pub fn get_x11_device_ids<W: Window>(window: &W) -> Option<(u16, u16)> {
         let dri3 = conn.dri3_open(root, x11rb::NONE).ok()?.reply().ok()?;
         let device_fd = dri3.device_fd;
         let stat = fstat(device_fd).ok()?;
-        let dev = stat.st_rdev;
+        let dev: u64 = {
+            #[cfg(not(target_arch = "e2k"))]
+            {
+                stat.st_rdev
+            }
+
+            #[cfg(target_arch = "e2k")]
+            {
+                stat.st_rdev as u64
+            }
+        };
         super::ids_from_dev(dev)
     }
 }


### PR DESCRIPTION
Good afternoon! 

 When generating code for the "linux-raw-sys" crate using "bindgen" on the "E2K (Elbrus 2000)" processor architecture, one of the types for the "st_rdev" field does not match the type implemented for the "x86_64" architecture (u32 instead of u64). A small conditional compilation patch is required to fix the error.
 
 I intentionally left conditional compilation instead of a direct typecast for all cases, so that the fix would not be accidentally removed by a linter or developer who noticed the u64 to u64 cast.