### PR TITLE
fix: improve raster image downscaling quality

### DIFF
--- a/graphics/src/image.rs
+++ b/graphics/src/image.rs
@@ -5,6 +5,8 @@ use crate::core::Bytes;
 use crate::core::Color;
 use crate::core::Radians;
 use crate::core::Rectangle;
+#[cfg(feature = "image")]
+use crate::core::Size;
 use crate::core::image;
 use crate::core::svg;
 
@@ -42,6 +44,81 @@ impl Image {
 /// An image buffer.
 #[cfg(feature = "image")]
 pub type Buffer = ::image::ImageBuffer<::image::Rgba<u8>, Bytes>;
+
+/// Chooses a stable, aspect-preserving prefilter size for a physical draw size.
+///
+/// Each level is a power-of-two reduction of the source and is never smaller
+/// than the requested target in either dimension. This keeps resize animation
+/// from producing a new cached raster for every physical pixel.
+#[cfg(feature = "image")]
+pub fn downsample_size(image: &Buffer, target: Size<u32>) -> Size<u32> {
+    let target_width = target.width.max(1);
+    let target_height = target.height.max(1);
+    let width_ratio = image.width() / target_width;
+    let height_ratio = image.height() / target_height;
+    let ratio = width_ratio.min(height_ratio);
+
+    if ratio < 2 {
+        return Size::new(image.width(), image.height());
+    }
+
+    let factor = 1 << (31 - ratio.leading_zeros());
+
+    Size::new(
+        image.width().div_ceil(factor),
+        image.height().div_ceil(factor),
+    )
+}
+
+/// Builds a premultiplied-alpha Lanczos level for a physical draw size.
+#[cfg(feature = "image")]
+pub fn downsample(image: &Buffer, target: Size<u32>) -> Option<Buffer> {
+    let size = downsample_size(image, target);
+
+    if size == Size::new(image.width(), image.height()) {
+        return None;
+    }
+
+    let mut premultiplied = image.clone().into_raw().to_vec();
+
+    for pixel in premultiplied.chunks_exact_mut(4) {
+        let alpha = u16::from(pixel[3]);
+
+        for channel in &mut pixel[..3] {
+            *channel = ((u16::from(*channel) * alpha + 127) / 255) as u8;
+        }
+    }
+
+    let premultiplied =
+        ::image::ImageBuffer::<::image::Rgba<u8>, Vec<u8>>::from_raw(
+            image.width(),
+            image.height(),
+            premultiplied,
+        )?;
+    let resized = ::image::imageops::resize(
+        &premultiplied,
+        size.width,
+        size.height,
+        ::image::imageops::FilterType::Lanczos3,
+    );
+    let mut pixels = resized.into_raw();
+
+    for pixel in pixels.chunks_exact_mut(4) {
+        let alpha = u32::from(pixel[3]);
+
+        if alpha == 0 {
+            pixel[..3].fill(0);
+            continue;
+        }
+
+        for channel in &mut pixel[..3] {
+            *channel = ((u32::from(*channel) * 255 + alpha / 2) / alpha)
+                .min(255) as u8;
+        }
+    }
+
+    ::image::ImageBuffer::from_raw(size.width, size.height, Bytes::from(pixels))
+}
 
 #[cfg(feature = "image")]
 /// Tries to load an image by its [`Handle`].
@@ -178,5 +255,64 @@ fn to_error(error: ::image::ImageError) -> image::Error {
             image::Error::Inaccessible(Arc::new(error))
         }
         error => image::Error::Invalid(Arc::new(error)),
+    }
+}
+
+#[cfg(all(test, feature = "image"))]
+mod tests {
+    use super::*;
+
+    fn solid(width: u32, height: u32) -> Buffer {
+        Buffer::from_raw(
+            width,
+            height,
+            Bytes::from(vec![255; width as usize * height as usize * 4]),
+        )
+        .expect("valid solid image dimensions")
+    }
+
+    #[test]
+    fn downsample_levels_are_stable_and_never_smaller_than_the_target() {
+        let image = solid(512, 384);
+
+        assert_eq!(
+            downsample_size(&image, Size::new(48, 36)),
+            Size::new(64, 48)
+        );
+        assert_eq!(
+            downsample_size(&image, Size::new(63, 40)),
+            Size::new(64, 48)
+        );
+        assert_eq!(
+            downsample_size(&image, Size::new(300, 200)),
+            Size::new(512, 384)
+        );
+    }
+
+    #[test]
+    fn premultiplied_downsample_avoids_transparent_color_bleed() {
+        let mut pixels = vec![0; 4 * 4 * 4];
+
+        for y in 0..4 {
+            for x in 0..2 {
+                let offset = (y * 4 + x) * 4;
+                pixels[offset..offset + 4].copy_from_slice(&[255, 0, 0, 255]);
+            }
+
+            for x in 2..4 {
+                let offset = (y * 4 + x) * 4;
+                pixels[offset..offset + 4].copy_from_slice(&[0, 0, 255, 0]);
+            }
+        }
+
+        let image = Buffer::from_raw(4, 4, Bytes::from(pixels))
+            .expect("valid test image dimensions");
+        let resized = downsample(&image, Size::new(1, 1))
+            .expect("the image should be downsampled");
+        let pixel = resized.get_pixel(0, 0).0;
+
+        assert!(pixel[0] > 200);
+        assert_eq!(pixel[1], 0);
+        assert_eq!(pixel[2], 0);
     }
 }

--- a/tiny_skia/src/raster.rs
+++ b/tiny_skia/src/raster.rs
@@ -6,6 +6,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::RefCell;
 use std::collections::hash_map;
 
+type SourceImage = graphics::image::Buffer;
+
 #[derive(Debug)]
 pub struct Pipeline {
     cache: RefCell<Cache>,
@@ -23,7 +25,7 @@ impl Pipeline {
         handle: &raster::Handle,
     ) -> Result<raster::Allocation, raster::Error> {
         let mut cache = self.cache.borrow_mut();
-        let image = cache.allocate(handle)?;
+        let image = cache.source(handle)?;
 
         #[allow(unsafe_code)]
         Ok(unsafe {
@@ -33,7 +35,7 @@ impl Pipeline {
 
     pub fn dimensions(&self, handle: &raster::Handle) -> Option<Size<u32>> {
         let mut cache = self.cache.borrow_mut();
-        let image = cache.allocate(handle).ok()?;
+        let image = cache.source(handle).ok()?;
 
         Some(Size::new(image.width(), image.height()))
     }
@@ -50,17 +52,24 @@ impl Pipeline {
         border_radius: [f32; 4],
     ) {
         let mut cache = self.cache.borrow_mut();
+        let target_size = match filter_method {
+            raster::FilterMethod::Linear => Size::new(
+                bounds.width.ceil().max(1.0) as u32,
+                bounds.height.ceil().max(1.0) as u32,
+            ),
+            raster::FilterMethod::Nearest => cache
+                .source(handle)
+                .ok()
+                .map(|image| Size::new(image.width(), image.height()))
+                .unwrap_or(Size::new(1, 1)),
+        };
 
-        let Ok(mut image) = cache.allocate(handle) else {
+        let Ok(mut image) = cache.allocate(handle, target_size) else {
             return;
         };
 
         let width_scale = bounds.width / image.width() as f32;
         let height_scale = bounds.height / image.height() as f32;
-        let quality = match filter_method {
-            raster::FilterMethod::Linear => tiny_skia::FilterQuality::Bilinear,
-            raster::FilterMethod::Nearest => tiny_skia::FilterQuality::Nearest,
-        };
         let mut scratch;
 
         // Round the borders if a border radius is defined
@@ -108,51 +117,55 @@ impl Pipeline {
 
 #[derive(Debug, Default)]
 struct Cache {
-    entries: FxHashMap<raster::Id, Option<Entry>>,
-    hits: FxHashSet<raster::Id>,
+    sources: FxHashMap<raster::Id, Result<SourceImage, raster::Error>>,
+    entries: FxHashMap<UploadKey, Option<Entry>>,
+    source_hits: FxHashSet<raster::Id>,
 }
 
 impl Cache {
+    pub fn source(
+        &mut self,
+        handle: &raster::Handle,
+    ) -> Result<&SourceImage, raster::Error> {
+        let id = handle.id();
+
+        if let hash_map::Entry::Vacant(entry) = self.sources.entry(id) {
+            let _ = entry.insert(graphics::image::load(handle));
+        }
+
+        let _ = self.source_hits.insert(id);
+        self.sources
+            .get(&id)
+            .expect("cached image source")
+            .as_ref()
+            .map_err(Clone::clone)
+    }
+
     pub fn allocate(
         &mut self,
         handle: &raster::Handle,
+        target_size: Size<u32>,
     ) -> Result<tiny_skia::PixmapRef<'_>, raster::Error> {
-        let id = handle.id();
+        let upload_size = {
+            let image = self.source(handle)?;
+            graphics::image::downsample_size(image, target_size)
+        };
+        let key = UploadKey::new(handle.id(), upload_size);
 
-        if let hash_map::Entry::Vacant(entry) = self.entries.entry(id) {
-            let image = match graphics::image::load(handle) {
-                Ok(image) => image,
-                Err(error) => {
-                    let _ = entry.insert(None);
+        if !self.entries.contains_key(&key) {
+            let image = self.source(handle)?;
+            let resized = graphics::image::downsample(image, upload_size);
 
-                    return Err(error);
-                }
+            let uploaded = if let Some(resized) = resized.as_ref() {
+                entry_from_image(resized)
+            } else {
+                entry_from_image(image)
             };
 
-            if image.width() == 0 || image.height() == 0 {
-                return Err(raster::Error::Empty);
-            }
-
-            let mut buffer =
-                vec![0u32; image.width() as usize * image.height() as usize];
-
-            for (i, pixel) in image.pixels().enumerate() {
-                let [r, g, b, a] = pixel.0;
-
-                buffer[i] = bytemuck::cast(
-                    tiny_skia::ColorU8::from_rgba(b, g, r, a).premultiply(),
-                );
-            }
-
-            let _ = entry.insert(Some(Entry {
-                width: image.width(),
-                height: image.height(),
-                pixels: buffer,
-            }));
+            let _ = self.entries.insert(key, uploaded);
         }
 
-        let _ = self.hits.insert(id);
-        let Some(ret) = self.entries.get(&id).unwrap().as_ref().map(|entry| {
+        let Some(ret) = self.entries.get(&key).unwrap().as_ref().map(|entry| {
             tiny_skia::PixmapRef::from_bytes(
                 bytemuck::cast_slice(&entry.pixels),
                 entry.width,
@@ -167,8 +180,10 @@ impl Cache {
     }
 
     fn trim(&mut self) {
-        self.entries.retain(|key, _| self.hits.contains(key));
-        self.hits.clear();
+        self.sources.retain(|key, _| self.source_hits.contains(key));
+        self.entries
+            .retain(|key, _| self.source_hits.contains(&key.image_id));
+        self.source_hits.clear();
     }
 }
 
@@ -177,6 +192,46 @@ struct Entry {
     width: u32,
     height: u32,
     pixels: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct UploadKey {
+    image_id: raster::Id,
+    width: u32,
+    height: u32,
+}
+
+impl UploadKey {
+    fn new(image_id: raster::Id, target_size: Size<u32>) -> Self {
+        Self {
+            image_id,
+            width: target_size.width.max(1),
+            height: target_size.height.max(1),
+        }
+    }
+}
+
+fn entry_from_image(image: &SourceImage) -> Option<Entry> {
+    if image.width() == 0 || image.height() == 0 {
+        return None;
+    }
+
+    let mut pixels =
+        vec![0u32; image.width() as usize * image.height() as usize];
+
+    for (i, pixel) in image.pixels().enumerate() {
+        let [r, g, b, a] = pixel.0;
+
+        pixels[i] = bytemuck::cast(
+            tiny_skia::ColorU8::from_rgba(b, g, r, a).premultiply(),
+        );
+    }
+
+    Some(Entry {
+        width: image.width(),
+        height: image.height(),
+        pixels,
+    })
 }
 
 // https://users.rust-lang.org/t/how-to-trim-image-to-circle-image-without-jaggy/70374/2

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -60,30 +60,45 @@ impl Cache {
     ) {
         use crate::image::raster::Memory;
 
+        self.receive();
+
+        if let Some(memory) = self.raster.cache.get_mut(handle) {
+            match memory {
+                Memory::Host(image) => {
+                    let size = Size::new(image.width(), image.height());
+
+                    if let Some(device) =
+                        self.raster.cache.get_entry(handle, size)
+                    {
+                        if let Some(allocation) = device
+                            .allocation
+                            .as_ref()
+                            .and_then(core::image::Allocation::upgrade)
+                        {
+                            callback(Ok(allocation));
+                            return;
+                        }
+
+                        #[allow(unsafe_code)]
+                        let allocation =
+                            unsafe { core::image::allocate(handle, size) };
+
+                        device.allocation = Some(allocation.downgrade());
+                        callback(Ok(allocation));
+                        return;
+                    }
+                }
+                Memory::Error(error) => {
+                    callback(Err(error.clone()));
+                    return;
+                }
+            }
+        }
+
         let callback = Box::new(callback);
 
         if let Some(callbacks) = self.raster.pending.get_mut(&handle.id()) {
             callbacks.push(callback);
-            return;
-        }
-
-        if let Some(Memory::Device {
-            allocation, entry, ..
-        }) = self.raster.cache.get_mut(handle)
-        {
-            if let Some(allocation) = allocation
-                .as_ref()
-                .and_then(core::image::Allocation::upgrade)
-            {
-                callback(Ok(allocation));
-                return;
-            }
-
-            #[allow(unsafe_code)]
-            let new = unsafe { core::image::allocate(handle, entry.size()) };
-            *allocation = Some(new.downgrade());
-            callback(Ok(new));
-
             return;
         }
 
@@ -102,34 +117,61 @@ impl Cache {
     ) -> Result<core::image::Allocation, core::image::Error> {
         use crate::image::raster::Memory;
 
+        self.receive();
+
         if !self.raster.cache.contains(handle) {
             self.raster.cache.insert(handle, Memory::load(handle));
         }
 
         match self.raster.cache.get_mut(handle).unwrap() {
             Memory::Host(image) => {
+                let size = Size::new(image.width(), image.height());
+
+                if let Some(device_entry) =
+                    self.raster.cache.get_entry(handle, size)
+                {
+                    if let Some(allocation) = device_entry
+                        .allocation
+                        .as_ref()
+                        .and_then(core::image::Allocation::upgrade)
+                    {
+                        return Ok(allocation);
+                    }
+
+                    #[allow(unsafe_code)]
+                    let allocation =
+                        unsafe { core::image::allocate(handle, size) };
+
+                    device_entry.allocation = Some(allocation.downgrade());
+
+                    return Ok(allocation);
+                }
+
                 let mut encoder = device.create_command_encoder(
                     &wgpu::CommandEncoderDescriptor {
                         label: Some("raster image upload"),
                     },
                 );
 
-                let entry = self.atlas.upload(
-                    device,
-                    &mut encoder,
-                    &mut self.raster.belt,
-                    image.width(),
-                    image.height(),
-                    image,
-                );
+                if self
+                    .raster
+                    .cache
+                    .upload(
+                        device,
+                        &mut encoder,
+                        &mut self.raster.belt,
+                        handle,
+                        Some(size),
+                        &mut self.atlas,
+                    )
+                    .is_none()
+                {
+                    return Err(core::image::Error::OutOfMemory);
+                }
 
                 self.raster.belt.finish();
                 let submission = queue.submit([encoder.finish()]);
                 self.raster.belt.recall();
-
-                let Some(entry) = entry else {
-                    return Err(core::image::Error::OutOfMemory);
-                };
 
                 let _ = device.poll(wgpu::PollType::Wait {
                     submission_index: Some(submission),
@@ -137,41 +179,15 @@ impl Cache {
                 });
 
                 #[allow(unsafe_code)]
-                let allocation = unsafe {
-                    core::image::allocate(
-                        handle,
-                        Size::new(image.width(), image.height()),
-                    )
-                };
+                let allocation = unsafe { core::image::allocate(handle, size) };
 
-                self.raster.cache.insert(
-                    handle,
-                    Memory::Device {
-                        entry,
-                        bind_group: None,
-                        allocation: Some(allocation.downgrade()),
-                    },
-                );
-
-                Ok(allocation)
-            }
-            Memory::Device {
-                entry, allocation, ..
-            } => {
-                if let Some(allocation) = allocation
-                    .as_ref()
-                    .and_then(core::image::Allocation::upgrade)
+                if let Some(device_entry) =
+                    self.raster.cache.get_entry(handle, size)
                 {
-                    return Ok(allocation);
+                    device_entry.allocation = Some(allocation.downgrade());
                 }
 
-                #[allow(unsafe_code)]
-                let new =
-                    unsafe { core::image::allocate(handle, entry.size()) };
-
-                *allocation = Some(new.downgrade());
-
-                Ok(new)
+                Ok(allocation)
             }
             Memory::Error(error) => Err(error.clone()),
         }
@@ -209,12 +225,11 @@ impl Cache {
         encoder: &mut wgpu::CommandEncoder,
         belt: &mut wgpu::util::StagingBelt,
         handle: &core::image::Handle,
+        target_size: Option<Size<u32>>,
     ) -> Option<(&atlas::Entry, &Arc<wgpu::BindGroup>)> {
-        use crate::image::raster::Memory;
-
         self.receive();
 
-        let memory = load_image(
+        let _ = load_image(
             &mut self.raster.cache,
             &mut self.raster.pending,
             #[cfg(not(target_arch = "wasm32"))]
@@ -223,50 +238,18 @@ impl Cache {
             None,
         )?;
 
-        if let Memory::Device {
-            entry, bind_group, ..
-        } = memory
-        {
-            return Some((
-                entry,
-                bind_group.as_ref().unwrap_or(self.atlas.bind_group()),
-            ));
-        }
-
-        let image = memory.host()?;
-
-        const MAX_SYNC_SIZE: usize = 2 * 1024 * 1024;
-
-        // TODO: Concurrent Wasm support
-        if image.len() < MAX_SYNC_SIZE || cfg!(target_arch = "wasm32") {
-            let entry = self.atlas.upload(
-                device,
-                encoder,
-                belt,
-                image.width(),
-                image.height(),
-                &image,
-            )?;
-
-            *memory = Memory::Device {
-                entry,
-                bind_group: None,
-                allocation: None,
-            };
-
-            if let Memory::Device { entry, .. } = memory {
-                return Some((entry, self.atlas.bind_group()));
-            }
-        }
-
-        if !self.raster.pending.contains_key(&handle.id()) {
-            let _ = self.raster.pending.insert(handle.id(), Vec::new());
-
-            #[cfg(not(target_arch = "wasm32"))]
-            self.worker.upload(handle, image);
-        }
-
-        None
+        self.raster
+            .cache
+            .upload(device, encoder, belt, handle, target_size, &mut self.atlas)
+            .map(|device_entry| {
+                (
+                    &device_entry.entry,
+                    device_entry
+                        .bind_group
+                        .as_ref()
+                        .unwrap_or(self.atlas.bind_group()),
+                )
+            })
     }
 
     #[cfg(feature = "svg")]
@@ -313,21 +296,22 @@ impl Cache {
     fn receive(&mut self) {
         #[cfg(not(target_arch = "wasm32"))]
         while let Ok(work) = self.worker.try_recv() {
-            use crate::image::raster::Memory;
+            use crate::image::raster::{Device, Memory};
 
             match work {
                 worker::Work::Upload {
                     handle,
+                    image,
                     entry,
                     bind_group,
                 } => {
                     let callbacks = self.raster.pending.remove(&handle.id());
+                    let size = Size::new(image.width(), image.height());
 
                     let allocation = if let Some(callbacks) = callbacks {
                         #[allow(unsafe_code)]
-                        let allocation = unsafe {
-                            core::image::allocate(&handle, entry.size())
-                        };
+                        let allocation =
+                            unsafe { core::image::allocate(&handle, size) };
 
                         let reference = allocation.downgrade();
 
@@ -340,9 +324,11 @@ impl Cache {
                         None
                     };
 
-                    self.raster.cache.insert(
+                    self.raster.cache.insert(&handle, Memory::Host(image));
+                    self.raster.cache.insert_entry(
                         &handle,
-                        Memory::Device {
+                        size,
+                        Device {
                             entry,
                             bind_group: Some(bind_group),
                             allocation,
@@ -477,15 +463,6 @@ mod worker {
             let _ = self.jobs.send(Job::Load(handle.clone()));
         }
 
-        pub fn upload(&self, handle: &image::Handle, image: raster::Image) {
-            let _ = self.jobs.send(Job::Upload {
-                handle: handle.clone(),
-                width: image.width(),
-                height: image.height(),
-                rgba: image.into_raw(),
-            });
-        }
-
         pub fn drop(&self, bind_group: Arc<wgpu::BindGroup>) {
             let _ = self.jobs.send(Job::Drop(bind_group));
         }
@@ -516,12 +493,6 @@ mod worker {
     #[derive(Debug)]
     enum Job {
         Load(image::Handle),
-        Upload {
-            handle: image::Handle,
-            rgba: Bytes,
-            width: u32,
-            height: u32,
-        },
         Drop(Arc<wgpu::BindGroup>),
         Quit,
     }
@@ -529,6 +500,7 @@ mod worker {
     pub enum Work {
         Upload {
             handle: image::Handle,
+            image: raster::Image,
             entry: atlas::Entry,
             bind_group: Arc<wgpu::BindGroup>,
         },
@@ -552,33 +524,26 @@ mod worker {
                 match job {
                     Job::Load(handle) => {
                         match crate::graphics::image::load(&handle) {
-                            Ok(image) => self.upload(
-                                handle,
-                                image.width(),
-                                image.height(),
-                                image.into_raw(),
-                                Shell::invalidate_layout,
-                            ),
+                            Ok(image) => {
+                                let width = image.width();
+                                let height = image.height();
+                                let rgba = image.clone().into_raw();
+
+                                self.upload(
+                                    handle,
+                                    image,
+                                    width,
+                                    height,
+                                    rgba,
+                                    Shell::invalidate_layout,
+                                );
+                            }
                             Err(error) => {
                                 let _ = self
                                     .output
                                     .send(Work::Error { handle, error });
                             }
                         }
-                    }
-                    Job::Upload {
-                        handle,
-                        rgba,
-                        width,
-                        height,
-                    } => {
-                        self.upload(
-                            handle,
-                            width,
-                            height,
-                            rgba,
-                            Shell::request_redraw,
-                        );
                     }
                     Job::Drop(bind_group) => {
                         drop(bind_group);
@@ -591,6 +556,7 @@ mod worker {
         fn upload(
             &mut self,
             handle: image::Handle,
+            image: raster::Image,
             width: u32,
             height: u32,
             rgba: Bytes,
@@ -632,6 +598,7 @@ mod worker {
             self.queue.on_submitted_work_done(move || {
                 let _ = output.send(Work::Upload {
                     handle,
+                    image,
                     entry,
                     bind_group,
                 });

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -266,8 +266,24 @@ impl State {
                     bounds,
                     clip_bounds,
                 } => {
+                    let target_size = match image.filter_method {
+                        crate::core::image::FilterMethod::Linear => {
+                            Some(Size::new(
+                                (bounds.width * scale).ceil().max(1.0) as u32,
+                                (bounds.height * scale).ceil().max(1.0) as u32,
+                            ))
+                        }
+                        crate::core::image::FilterMethod::Nearest => None,
+                    };
+
                     if let Some((atlas_entry, bind_group)) = cache
-                        .upload_raster(device, encoder, belt, &image.handle)
+                        .upload_raster(
+                            device,
+                            encoder,
+                            belt,
+                            &image.handle,
+                            target_size,
+                        )
                     {
                         match atlas.as_mut() {
                             None => {

--- a/wgpu/src/image/raster.rs
+++ b/wgpu/src/image/raster.rs
@@ -13,12 +13,6 @@ pub type Image = graphics::image::Buffer;
 pub enum Memory {
     /// Image data on host
     Host(Image),
-    /// Storage entry
-    Device {
-        entry: atlas::Entry,
-        bind_group: Option<Arc<wgpu::BindGroup>>,
-        allocation: Option<Weak<image::Memory>>,
-    },
     Error(image::Error),
 }
 
@@ -37,42 +31,116 @@ impl Memory {
 
                 Size::new(width, height)
             }
-            Memory::Device { entry, .. } => entry.size(),
             Memory::Error(_) => Size::new(1, 1),
-        }
-    }
-
-    pub fn host(&self) -> Option<Image> {
-        match self {
-            Memory::Host(image) => Some(image.clone()),
-            Memory::Device { .. } | Memory::Error(_) => None,
         }
     }
 }
 
 #[derive(Debug, Default)]
 pub struct Cache {
-    map: FxHashMap<image::Id, Memory>,
-    hits: FxHashSet<image::Id>,
+    images: FxHashMap<image::Id, Memory>,
+    entries: FxHashMap<UploadKey, Device>,
+    image_hits: FxHashSet<image::Id>,
+    entry_hits: FxHashSet<UploadKey>,
     should_trim: bool,
 }
 
 impl Cache {
     pub fn get_mut(&mut self, handle: &image::Handle) -> Option<&mut Memory> {
-        let _ = self.hits.insert(handle.id());
+        let _ = self.image_hits.insert(handle.id());
 
-        self.map.get_mut(&handle.id())
+        self.images.get_mut(&handle.id())
     }
 
     pub fn insert(&mut self, handle: &image::Handle, memory: Memory) {
-        let _ = self.map.insert(handle.id(), memory);
-        let _ = self.hits.insert(handle.id());
+        let _ = self.images.insert(handle.id(), memory);
+        let _ = self.image_hits.insert(handle.id());
 
         self.should_trim = true;
     }
 
     pub fn contains(&self, handle: &image::Handle) -> bool {
-        self.map.contains_key(&handle.id())
+        self.images.contains_key(&handle.id())
+    }
+
+    pub fn get_entry(
+        &mut self,
+        handle: &image::Handle,
+        target_size: Size<u32>,
+    ) -> Option<&mut Device> {
+        let key = UploadKey::new(handle.id(), target_size);
+        let _ = self.image_hits.insert(handle.id());
+        let _ = self.entry_hits.insert(key);
+
+        self.entries.get_mut(&key)
+    }
+
+    pub fn insert_entry(
+        &mut self,
+        handle: &image::Handle,
+        target_size: Size<u32>,
+        device: Device,
+    ) {
+        let key = UploadKey::new(handle.id(), target_size);
+        let _ = self.image_hits.insert(handle.id());
+        let _ = self.entry_hits.insert(key);
+        let _ = self.entries.insert(key, device);
+
+        self.should_trim = true;
+    }
+
+    pub fn upload(
+        &mut self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        belt: &mut wgpu::util::StagingBelt,
+        handle: &image::Handle,
+        target_size: Option<Size<u32>>,
+        atlas: &mut Atlas,
+    ) -> Option<&Device> {
+        let source = match self.get_mut(handle)? {
+            Memory::Host(image) => image,
+            Memory::Error(_) => return None,
+        };
+        let upload_size = target_size.map_or_else(
+            || Size::new(source.width(), source.height()),
+            |target_size| graphics::image::downsample_size(source, target_size),
+        );
+        let key = UploadKey::new(handle.id(), upload_size);
+        let _ = self.entry_hits.insert(key);
+
+        if self.entries.contains_key(&key) {
+            return self.entries.get(&key);
+        }
+
+        let source = match self.images.get(&handle.id())? {
+            Memory::Host(image) => image,
+            Memory::Error(_) => return None,
+        };
+        let resized = target_size.and_then(|target_size| {
+            graphics::image::downsample(source, target_size)
+        });
+        let pixels = resized.as_ref().unwrap_or(source);
+        let entry = atlas.upload(
+            device,
+            encoder,
+            belt,
+            pixels.width(),
+            pixels.height(),
+            pixels,
+        )?;
+
+        let _ = self.entries.insert(
+            key,
+            Device {
+                entry,
+                bind_group: None,
+                allocation: None,
+            },
+        );
+        self.should_trim = true;
+
+        self.entries.get(&key)
     }
 
     pub fn trim(
@@ -85,39 +153,61 @@ impl Cache {
             return;
         }
 
-        let hits = &self.hits;
+        let image_hits = &self.image_hits;
+        let entry_hits = &self.entry_hits;
 
-        self.map.retain(|id, memory| {
-            // Retain active allocations
-            if let Memory::Device { allocation, .. } = memory
-                && allocation
-                    .as_ref()
-                    .is_some_and(|allocation| allocation.strong_count() > 0)
+        self.images.retain(|id, _| image_hits.contains(id));
+
+        self.entries.retain(|key, device| {
+            if device
+                .allocation
+                .as_ref()
+                .is_some_and(|allocation| allocation.strong_count() > 0)
             {
                 return true;
             }
 
-            let retain = hits.contains(id);
+            let retain = entry_hits.contains(key);
 
             if !retain {
-                log::debug!("Dropping image allocation: {id:?}");
+                log::debug!("Dropping image allocation: {key:?}");
 
-                if let Memory::Device {
-                    entry, bind_group, ..
-                } = memory
-                {
-                    if let Some(bind_group) = bind_group.take() {
-                        on_drop(bind_group);
-                    } else {
-                        atlas.remove(entry);
-                    }
+                if let Some(bind_group) = device.bind_group.take() {
+                    on_drop(bind_group);
+                } else {
+                    atlas.remove(&device.entry);
                 }
             }
 
             retain
         });
 
-        self.hits.clear();
+        self.image_hits.clear();
+        self.entry_hits.clear();
         self.should_trim = false;
+    }
+}
+
+#[derive(Debug)]
+pub struct Device {
+    pub entry: atlas::Entry,
+    pub bind_group: Option<Arc<wgpu::BindGroup>>,
+    pub allocation: Option<Weak<image::Memory>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct UploadKey {
+    image_id: image::Id,
+    width: u32,
+    height: u32,
+}
+
+impl UploadKey {
+    fn new(image_id: image::Id, target_size: Size<u32>) -> Self {
+        Self {
+            image_id,
+            width: target_size.width.max(1),
+            height: target_size.height.max(1),
+        }
     }
 }


### PR DESCRIPTION
## Problem

  Raster images lose visual quality when they are rendered much smaller than their original
  size. This is especially noticeable with detailed images such as application icons, avatars,
  and thumbnails, which can look pixelated or have rough edges after being scaled down.

  Both the `wgpu` and `tiny-skia` renderers previously relied on their regular sampling filters
  to reduce the original image directly to the destination size. Bilinear filtering works well
  for small size changes, but it does not produce good results when a large image is drawn at a
  much smaller size.

  ## Motivation

  This issue affects several common components in COSMIC, including:

  - Application icons
  - Panel and dock icons
  - Status area icons
  - User avatars
  - File thumbnails

  Improving this behavior in iced fixes the underlying rendering problem instead of requiring
  each application or widget to resize its images manually.

  ## Implementation

  This change adds a shared image downsampling path used by both raster renderers.

  Before an image is uploaded or drawn:

  1. The renderer determines its physical destination size.
  2. It selects an aspect-preserving, power-of-two downsampling level that is never smaller
  than the destination.
  3. It creates that level using Lanczos3 filtering.
  4. It caches the result for future frames.

  Using stable power-of-two levels prevents a new image from being generated for every small
  size change. This is important during window resizing and icon animations.

  Images are premultiplied before filtering and unpremultiplied afterward. This prevents hidden
  RGB values in transparent pixels from bleeding into visible edges.

  The renderer caches the original image together with its generated size levels:

  - `wgpu` keeps separate GPU entries for each required level.
  - `tiny-skia` keeps reusable prefiltered pixmaps while the source image remains active.

  Images using `Nearest` filtering continue to use the original source, preserving the expected
  pixel-art behavior.

  ## Testing

  ### Automated testing

  The following checks were run successfully:

  - `cargo test -p iced_graphics --features image image::tests`
  - `cargo check -p iced_wgpu -p iced_tiny_skia --all-features`
  - Clippy checks for the affected crates
  - Formatting checks for the modified files
  - `git diff --check`

  The new unit tests verify that:

  - Downsampling levels remain stable across nearby destination sizes.
  - The selected level is never smaller than the destination.
  - Transparent pixels do not introduce color bleeding during downsampling.

  ### Manual testing

  The change was tested with both the `wgpu` and `tiny-skia` backends in downstream COSMIC
  components:

  - Application Library icons
  - COSMIC Files image thumbnails
  - User avatars in COSMIC Settings
  - Panel and dock icons
  - Status area icons

  The manual test included window resizing, scrolling through image grids, repeated navigation,
  menu interaction, hover animations, and icons with transparent edges.

  Both backends produced noticeably cleaner images. Cached downsampling levels also avoided
  recurring slowdowns during resizing and animation.
