### PR TITLE
feat: less "hand" cursors

### DIFF
--- a/widget/src/button.rs
+++ b/widget/src/button.rs
@@ -528,23 +528,6 @@ where
         );
     }
 
-    fn mouse_interaction(
-        &self,
-        _tree: &Tree,
-        layout: Layout<'_>,
-        cursor: mouse::Cursor,
-        _viewport: &Rectangle,
-        _renderer: &Renderer,
-    ) -> mouse::Interaction {
-        let is_mouse_over = cursor.is_over(layout.bounds());
-
-        if is_mouse_over && self.on_press.is_some() {
-            mouse::Interaction::Pointer
-        } else {
-            mouse::Interaction::default()
-        }
-    }
-
     fn overlay<'b>(
         &'b mut self,
         tree: &'b mut Tree,

--- a/widget/src/checkbox.rs
+++ b/widget/src/checkbox.rs
@@ -411,21 +411,6 @@ where
         }
     }
 
-    fn mouse_interaction(
-        &self,
-        _tree: &Tree,
-        layout: Layout<'_>,
-        cursor: mouse::Cursor,
-        _viewport: &Rectangle,
-        _renderer: &Renderer,
-    ) -> mouse::Interaction {
-        if cursor.is_over(layout.bounds()) && self.on_toggle.is_some() {
-            mouse::Interaction::Pointer
-        } else {
-            mouse::Interaction::default()
-        }
-    }
-
     fn draw(
         &self,
         tree: &Tree,

--- a/widget/src/overlay/menu.rs
+++ b/widget/src/overlay/menu.rs
@@ -497,23 +497,6 @@ where
         }
     }
 
-    fn mouse_interaction(
-        &self,
-        _tree: &Tree,
-        layout: Layout<'_>,
-        cursor: mouse::Cursor,
-        _viewport: &Rectangle,
-        _renderer: &Renderer,
-    ) -> mouse::Interaction {
-        let is_mouse_over = cursor.is_over(layout.bounds());
-
-        if is_mouse_over {
-            mouse::Interaction::Pointer
-        } else {
-            mouse::Interaction::default()
-        }
-    }
-
     fn draw(
         &self,
         _tree: &Tree,

--- a/widget/src/pick_list.rs
+++ b/widget/src/pick_list.rs
@@ -560,24 +560,6 @@ where
         }
     }
 
-    fn mouse_interaction(
-        &self,
-        _tree: &Tree,
-        layout: Layout<'_>,
-        cursor: mouse::Cursor,
-        _viewport: &Rectangle,
-        _renderer: &Renderer,
-    ) -> mouse::Interaction {
-        let bounds = layout.bounds();
-        let is_mouse_over = cursor.is_over(bounds);
-
-        if is_mouse_over {
-            mouse::Interaction::Pointer
-        } else {
-            mouse::Interaction::default()
-        }
-    }
-
     fn draw(
         &self,
         tree: &Tree,

--- a/widget/src/radio.rs
+++ b/widget/src/radio.rs
@@ -376,21 +376,6 @@ where
         }
     }
 
-    fn mouse_interaction(
-        &self,
-        _tree: &Tree,
-        layout: Layout<'_>,
-        cursor: mouse::Cursor,
-        _viewport: &Rectangle,
-        _renderer: &Renderer,
-    ) -> mouse::Interaction {
-        if cursor.is_over(layout.bounds()) {
-            mouse::Interaction::Pointer
-        } else {
-            mouse::Interaction::default()
-        }
-    }
-
     fn draw(
         &self,
         tree: &Tree,

--- a/widget/src/slider.rs
+++ b/widget/src/slider.rs
@@ -653,35 +653,6 @@ where
         );
     }
 
-    fn mouse_interaction(
-        &self,
-        tree: &Tree,
-        layout: Layout<'_>,
-        cursor: mouse::Cursor,
-        _viewport: &Rectangle,
-        _renderer: &Renderer,
-    ) -> mouse::Interaction {
-        let state = tree.state.downcast_ref::<State>();
-
-        if state.is_dragging {
-            // FIXME: Fall back to `Pointer` on Windows
-            // See https://github.com/rust-windowing/winit/issues/1043
-            if cfg!(target_os = "windows") {
-                mouse::Interaction::Pointer
-            } else {
-                mouse::Interaction::Grabbing
-            }
-        } else if cursor.is_over(layout.bounds()) {
-            if cfg!(target_os = "windows") {
-                mouse::Interaction::Pointer
-            } else {
-                mouse::Interaction::Grab
-            }
-        } else {
-            mouse::Interaction::default()
-        }
-    }
-
     #[cfg(feature = "a11y")]
     fn a11y_nodes(
         &self,

--- a/widget/src/toggler.rs
+++ b/widget/src/toggler.rs
@@ -440,12 +440,8 @@ where
         _viewport: &Rectangle,
         _renderer: &Renderer,
     ) -> mouse::Interaction {
-        if cursor.is_over(layout.bounds()) {
-            if self.on_toggle.is_some() {
-                mouse::Interaction::Pointer
-            } else {
-                mouse::Interaction::NotAllowed
-            }
+        if cursor.is_over(layout.bounds()) && self.on_toggle.is_none() {
+            mouse::Interaction::NotAllowed
         } else {
             mouse::Interaction::default()
         }

--- a/widget/src/vertical_slider.rs
+++ b/widget/src/vertical_slider.rs
@@ -516,34 +516,6 @@ where
         );
     }
 
-    fn mouse_interaction(
-        &self,
-        tree: &Tree,
-        layout: Layout<'_>,
-        cursor: mouse::Cursor,
-        _viewport: &Rectangle,
-        _renderer: &Renderer,
-    ) -> mouse::Interaction {
-        let state = tree.state.downcast_ref::<State>();
-
-        if state.is_dragging {
-            // FIXME: Fall back to `Pointer` on Windows
-            // See https://github.com/rust-windowing/winit/issues/1043
-            if cfg!(target_os = "windows") {
-                mouse::Interaction::Pointer
-            } else {
-                mouse::Interaction::Grabbing
-            }
-        } else if cursor.is_over(layout.bounds()) {
-            if cfg!(target_os = "windows") {
-                mouse::Interaction::Pointer
-            } else {
-                mouse::Interaction::Grab
-            }
-        } else {
-            mouse::Interaction::default()
-        }
-    }
 }
 
 impl<'a, T, Message, Theme, Renderer>


### PR DESCRIPTION
Hi! This PR addresses the way the cursor shape changes when hovering some widgets.

Currently, the way the cursor behaves in Iced is closer to a webpage than a desktop: when hovering most widgets, the cursor turns into a "hand", whereas GTK and KDE keep the default "arrow" cursor.
The affected widgets are the following:
- buttons
- checkboxes
- radio buttons
- sliders
- menus
- pick lists

This is inconsistent with other desktop GUI frameworks and introduces some flickering when hovering a list of buttons. It also kinda makes Iced/libcosmic apps feel more like webapps than "native" apps.

For instance, here is a video comparing file managers from KDE, GNOME and COSMIC:

[Kooha-2026-07-21-22-12-11.webm](https://github.com/user-attachments/assets/8bb7a236-5d13-4679-a0f9-aceaebef78a3)

Thanks!