### PR TITLE
perf: do not redraw on mouse move events

### DIFF
--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -1391,7 +1391,6 @@ async fn run_instance<P>(
                             true
                         }
                     });
-                    let no_window_events = window_events.is_empty();
                     #[cfg(wayland_platform)]
                     window_events.push(core::Event::PlatformSpecific(
                         core::event::PlatformSpecific::Wayland(
@@ -1409,8 +1408,7 @@ async fn run_instance<P>(
                             &mut clipboard,
                             &mut messages,
                         );
-                    let mut needs_redraw =
-                        !no_window_events || !messages.is_empty();
+                    let mut needs_redraw = !messages.is_empty();
                     if let Some(requested_size) =
                         clipboard.requested_logical_size.lock().unwrap().take()
                     {
@@ -1466,7 +1464,16 @@ async fn run_instance<P>(
                             mouse_interaction,
                             ..
                         } => {
+                            let mouse_changed =
+                                window.mouse_interaction != mouse_interaction;
+
                             window.update_mouse(mouse_interaction);
+
+                            if mouse_changed {
+                                window.request_redraw(
+                                    core::window::RedrawRequest::NextFrame,
+                                );
+                            }
 
                             #[cfg(not(feature = "unconditional-rendering"))]
                             window.request_redraw(_redraw_request);

--- a/winit/src/platform_specific/wayland/handlers/seat/pointer.rs
+++ b/winit/src/platform_specific/wayland/handlers/seat/pointer.rs
@@ -1,8 +1,5 @@
-use crate::{
-    event_loop::state::FrameStatus,
-    platform_specific::wayland::{
-        event_loop::state::SctkState, sctk_event::SctkEvent,
-    },
+use crate::platform_specific::wayland::{
+    event_loop::state::SctkState, sctk_event::SctkEvent,
 };
 use cctk::sctk::{
     delegate_pointer,
@@ -48,14 +45,6 @@ impl PointerHandler for SctkState {
                 );
                 if self.windows.iter().any(|w| w.window.id() == id) {
                     continue;
-                }
-
-                let entry = self
-                    .frame_status
-                    .entry(e.surface.id())
-                    .or_insert(FrameStatus::RequestedRedraw);
-                if matches!(entry, FrameStatus::Received) {
-                    *entry = FrameStatus::Ready;
                 }
 
                 self.sctk_events.push(SctkEvent::PointerEvent {


### PR DESCRIPTION
Libcosmic apps redraw the whole window on mouse move.
Upstream iced has fixed this.

This PR removes that, and puts the onus on the widgets, if they need a redraw they should request it.


In this video you see cosmic-term currently redraws the whole window when the cursor is moving, but after this change it only redraws when something has changed. Foot redraws what actually has changed. Kitty is similar to cosmic-term and has to commit the whole window, but it only does it when something is actually changed.


https://github.com/user-attachments/assets/404aaa5d-274a-4c36-848b-20bdc68c1e0b


[05ffc07](https://github.com/pop-os/iced/pull/377/commits/05ffc077206cfed519201fb9f3ce75e45a3951c2) Fixes full screen redraw on desktop background (cosmic-files-applet).


https://github.com/user-attachments/assets/da49edac-dd20-4345-9778-2fb474e10b0a



