### PR TITLE
wgpu: adapt resolution limits to adapter capabilities

### DIFF
--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -261,8 +261,11 @@ impl Compositor {
             .using_resolution(adapter.limits())];
 
         #[cfg(not(target_arch = "wasm32"))]
-        let limits =
-            [wgpu::Limits::default(), wgpu::Limits::downlevel_defaults()];
+        let limits = [
+            wgpu::Limits::default().using_resolution(adapter.limits()),
+            wgpu::Limits::downlevel_defaults()
+                .using_resolution(adapter.limits()),
+        ];
 
         let limits = limits.into_iter().map(|limits| wgpu::Limits {
             max_bind_groups: 2,


### PR DESCRIPTION
## Summary

Adapt the native `iced_wgpu` resolution-dependent limits to the capabilities reported by the selected `wgpu::Adapter`.

The current native path first requests `Limits::default()`. On Raspberry Pi 5, the V3DV adapter supports a 4096 maximum 2D texture dimension, while the default request is larger. The request fails and iced falls back to `downlevel_defaults()`, unnecessarily constraining the logical device to 2048.

At 2560x1440 this caused `Surface::configure` failures in COSMIC applications with `maximum extent for either dimension is 2048`.

## Fix

Apply `.using_resolution(adapter.limits())` to both native candidate limit sets. This preserves the existing default/downlevel fallback while adapting resolution-dependent limits to the actual adapter.

## Raspberry Pi 5 hardware A/B

- Stock `cosmic-app-library` @ 2560x1440: FAIL
- Patched `cosmic-app-library` @ 2560x1440: PASS
- Stock `cosmic-workspaces` @ 2560x1440: FAIL / wgpu panic / exit 101
- Patched `cosmic-workspaces` @ 2560x1440: PASS
- V3DV `maxImageDimension2D`: 4096
- OpenGL `GL_MAX_TEXTURE_SIZE`: 4096

## Validation

- `cargo fmt --package iced_wgpu -- --check`: PASS
- `cargo check --offline --package iced_wgpu`: PASS
- `git diff --check`: PASS
- Physical Raspberry Pi 5 A/B testing: PASS

The checked-in upstream `Cargo.lock` currently requires a one-line resolution refresh with the local Cargo toolchain; the same `--locked` failure was reproduced on an untouched upstream worktree. No lockfile changes are included here.

This PR intentionally contains one commit modifying only `wgpu/src/window/compositor.rs`.